### PR TITLE
switch NN classes to be open -- support subclasses outside the module

### DIFF
--- a/Source/MLXNN/Activations.swift
+++ b/Source/MLXNN/Activations.swift
@@ -326,8 +326,8 @@ public func hardSwish(_ x: MLXArray) -> MLXArray {
 /// ### See Also
 /// - <doc:activations>
 /// - ``glu(_:axis:)``
-public class GLU: Module, UnaryLayer {
-    let axis: Int
+open class GLU: Module, UnaryLayer {
+    public let axis: Int
 
     public init(axis: Int = -1) {
         self.axis = axis
@@ -353,7 +353,7 @@ public class GLU: Module, UnaryLayer {
 /// ### See Also
 /// - <doc:activations>
 /// - ``sigmoid(_:)``
-public class Sigmoid: Module, UnaryLayer {
+open class Sigmoid: Module, UnaryLayer {
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
         sigmoid(x)
     }
@@ -374,7 +374,7 @@ public class Sigmoid: Module, UnaryLayer {
 /// ### See Also
 /// - <doc:activations>
 /// - ``mish(_:)``
-public class Mish: Module, UnaryLayer {
+open class Mish: Module, UnaryLayer {
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
         mish(x)
     }
@@ -391,7 +391,7 @@ public class Mish: Module, UnaryLayer {
 /// ### See Also
 /// - <doc:activations>
 /// - ``relu(_:)``
-public class ReLU: Module, UnaryLayer {
+open class ReLU: Module, UnaryLayer {
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
         relu(x)
     }
@@ -408,7 +408,7 @@ public class ReLU: Module, UnaryLayer {
 /// ### See Also
 /// - <doc:activations>
 /// - ``leakyRelu(_:negativeSlope:)``
-public class LeakyReLU: Module, UnaryLayer {
+open class LeakyReLU: Module, UnaryLayer {
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
         leakyRelu(x)
     }
@@ -425,7 +425,7 @@ public class LeakyReLU: Module, UnaryLayer {
 /// ### See Also
 /// - <doc:activations>
 /// - ``relu6(_:)``
-public class ReLU6: Module, UnaryLayer {
+open class ReLU6: Module, UnaryLayer {
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
         relu6(x)
     }
@@ -441,7 +441,7 @@ public class ReLU6: Module, UnaryLayer {
 ///
 /// ### See Also
 /// - <doc:activations>
-public class SoftMax: Module, UnaryLayer {
+open class SoftMax: Module, UnaryLayer {
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
         softMax(x, axis: -1)
     }
@@ -458,7 +458,7 @@ public class SoftMax: Module, UnaryLayer {
 /// ### See Also
 /// - <doc:activations>
 /// - ``softPlus(_:)``
-public class SoftPlus: Module, UnaryLayer {
+open class SoftPlus: Module, UnaryLayer {
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
         softPlus(x)
     }
@@ -475,7 +475,7 @@ public class SoftPlus: Module, UnaryLayer {
 /// ### See Also
 /// - <doc:activations>
 /// - ``softSign(_:)``
-public class SoftSign: Module, UnaryLayer {
+open class SoftSign: Module, UnaryLayer {
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
         softSign(x)
     }
@@ -492,8 +492,8 @@ public class SoftSign: Module, UnaryLayer {
 /// ### See Also
 /// - <doc:activations>
 /// - ``celu(_:alpha:)``
-public class CELU: Module, UnaryLayer {
-    let alpha: Float
+open class CELU: Module, UnaryLayer {
+    public let alpha: Float
 
     public init(alpha: Float = 1.0) {
         self.alpha = alpha
@@ -516,7 +516,7 @@ public class CELU: Module, UnaryLayer {
 /// ### See Also
 /// - <doc:activations>
 /// - ``silu(_:)``
-public class SiLU: Module, UnaryLayer {
+open class SiLU: Module, UnaryLayer {
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
         silu(x)
     }
@@ -533,7 +533,7 @@ public class SiLU: Module, UnaryLayer {
 /// ### See Also
 /// - <doc:activations>
 /// - ``logSoftMax(_:axis:)``
-public class LogSoftMax: Module, UnaryLayer {
+open class LogSoftMax: Module, UnaryLayer {
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
         logSoftMax(x)
     }
@@ -550,7 +550,7 @@ public class LogSoftMax: Module, UnaryLayer {
 /// ### See Also
 /// - <doc:activations>
 /// - ``logSigmoid(_:)``
-public class LogSigmoid: Module, UnaryLayer {
+open class LogSigmoid: Module, UnaryLayer {
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
         logSigmoid(x)
     }
@@ -567,9 +567,9 @@ public class LogSigmoid: Module, UnaryLayer {
 /// ### See Also
 /// - <doc:activations>
 /// - ``prelu(_:alpha:)``
-public class PReLU: Module, UnaryLayer {
+open class PReLU: Module, UnaryLayer {
 
-    let weight: MLXArray
+    public let weight: MLXArray
 
     public init(count: Int = 1, value: Float = 0.25) {
         self.weight = MLXArray.full([count], values: MLXArray(value))
@@ -594,7 +594,7 @@ public class PReLU: Module, UnaryLayer {
 /// - ``gelu(_:)``
 /// - ``geluApproximate(_:)``
 /// - ``geluFastApproximate(_:)``
-public class GELU: Module, UnaryLayer {
+open class GELU: Module, UnaryLayer {
 
     public enum Approximation {
         /// See ``gelu(_:)``
@@ -605,7 +605,7 @@ public class GELU: Module, UnaryLayer {
         case fast
     }
 
-    let approximation: Approximation
+    public let approximation: Approximation
 
     public init(approximation: Approximation = .none) {
         self.approximation = approximation
@@ -625,7 +625,7 @@ public class GELU: Module, UnaryLayer {
 }
 
 /// Applies the hyperbolic tangent function
-public class Tanh: Module, UnaryLayer {
+open class Tanh: Module, UnaryLayer {
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
         tanh(x)
     }
@@ -642,7 +642,7 @@ public class Tanh: Module, UnaryLayer {
 /// ### See Also
 /// - <doc:activations>
 /// - ``hardSwish(_:)``
-public class HardSwish: Module, UnaryLayer {
+open class HardSwish: Module, UnaryLayer {
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
         hardSwish(x)
     }
@@ -662,9 +662,9 @@ public class HardSwish: Module, UnaryLayer {
 /// ### See Also
 /// - <doc:activations>
 /// - ``step(_:threshold:)``
-public class Step: Module, UnaryLayer {
+open class Step: Module, UnaryLayer {
 
-    let threshold: Float
+    public let threshold: Float
 
     public init(threshold: Float = 0.0) {
         self.threshold = threshold
@@ -687,7 +687,7 @@ public class Step: Module, UnaryLayer {
 /// ### See Also
 /// - <doc:activations>
 /// - ``selu(_:)``
-public class SELU: Module, UnaryLayer {
+open class SELU: Module, UnaryLayer {
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
         selu(x)
     }

--- a/Source/MLXNN/Containers.swift
+++ b/Source/MLXNN/Containers.swift
@@ -37,9 +37,9 @@ import MLX
 ///   ],
 /// }
 /// ```
-public class Sequential: Module, UnaryLayer {
+open class Sequential: Module, UnaryLayer {
 
-    let layers: [UnaryLayer]
+    public let layers: [UnaryLayer]
 
     public init(layers: [UnaryLayer]) {
         self.layers = layers

--- a/Source/MLXNN/Convolution.swift
+++ b/Source/MLXNN/Convolution.swift
@@ -9,12 +9,12 @@ import MLXRandom
 /// ### See Also
 /// - ``Conv2d``
 /// - ``init(inputChannels:outputChannels:kernelSize:stride:padding:bias:)``
-public class Conv1d: Module, UnaryLayer {
+open class Conv1d: Module, UnaryLayer {
 
-    let weight: MLXArray
-    let bias: MLXArray?
-    let padding: Int
-    let stride: Int
+    public let weight: MLXArray
+    public let bias: MLXArray?
+    public let padding: Int
+    public let stride: Int
 
     /// Applies a 1-dimensional convolution over the multi-channel input sequence.
     ///
@@ -62,12 +62,12 @@ public class Conv1d: Module, UnaryLayer {
 /// ### See Also
 /// - ``Conv1d``
 /// - ``init(inputChannels:outputChannels:kernelSize:stride:padding:bias:)``
-public class Conv2d: Module, UnaryLayer {
+open class Conv2d: Module, UnaryLayer {
 
-    let weight: MLXArray
-    let bias: MLXArray?
-    let padding: (Int, Int)
-    let stride: (Int, Int)
+    public let weight: MLXArray
+    public let bias: MLXArray?
+    public let padding: (Int, Int)
+    public let stride: (Int, Int)
 
     /// Applies a 2-dimensional convolution over the multi-channel input image.
     ///

--- a/Source/MLXNN/Dropout.swift
+++ b/Source/MLXNN/Dropout.swift
@@ -13,9 +13,9 @@ import MLXRandom
 /// ### See Also
 /// - ``Dropout2d``
 /// - ``Dropout3d``
-public class Dropout: Module, UnaryLayer {
+open class Dropout: Module, UnaryLayer {
 
-    let p1: Float
+    public let p1: Float
 
     public init(p: Float = 0.5) {
         precondition((0 ..< 1).contains(p))
@@ -53,9 +53,9 @@ public class Dropout: Module, UnaryLayer {
 /// ### See Also
 /// - ``Dropout``
 /// - ``Dropout3d``
-public class Dropout2d: Module, UnaryLayer {
+open class Dropout2d: Module, UnaryLayer {
 
-    let p1: Float
+    public let p1: Float
 
     public init(p: Float = 0.5) {
         precondition((0 ..< 1).contains(p))
@@ -100,9 +100,9 @@ public class Dropout2d: Module, UnaryLayer {
 /// ### See Also
 /// - ``Dropout``
 /// - ``Dropout2d``
-public class Dropout3d: Module, UnaryLayer {
+open class Dropout3d: Module, UnaryLayer {
 
-    let p1: Float
+    public let p1: Float
 
     public init(p: Float = 0.5) {
         precondition((0 ..< 1).contains(p))

--- a/Source/MLXNN/Embedding.swift
+++ b/Source/MLXNN/Embedding.swift
@@ -7,9 +7,9 @@ import MLXRandom
 /// Implements a simple lookup table that maps each input integer to a high-dimensional vector.
 ///
 /// Typically used to embed discrete tokens for processing by neural networks.
-public class Embedding: Module, UnaryLayer {
+open class Embedding: Module, UnaryLayer {
 
-    let weight: MLXArray
+    public let weight: MLXArray
 
     /// Implements a simple lookup table that maps each input integer to a high-dimensional vector.
     ///

--- a/Source/MLXNN/Linear.swift
+++ b/Source/MLXNN/Linear.swift
@@ -68,10 +68,10 @@ public class Identity: Module, UnaryLayer {
 /// - <doc:custom-layers>
 /// - ``QuantizedLinear``
 /// - ``Bilinear``
-public class Linear: Module, UnaryLayer {
+open class Linear: Module, UnaryLayer {
 
-    let weight: MLXArray
-    let bias: MLXArray?
+    public let weight: MLXArray
+    public let bias: MLXArray?
 
     public var shape: (Int, Int) {
         (weight.dim(0), weight.dim(1))
@@ -139,10 +139,10 @@ public class Linear: Module, UnaryLayer {
 /// ### See Also
 /// - <doc:custom-layers>
 /// - ``Linear``
-public class Bilinear: Module {
+open class Bilinear: Module {
 
-    let weight: MLXArray
-    let bias: MLXArray?
+    public let weight: MLXArray
+    public let bias: MLXArray?
 
     public init(
         _ inputDimensions1: Int, _ inputDimensions2: Int, _ outputDimensions: Int, bias: Bool = true

--- a/Source/MLXNN/Normalization.swift
+++ b/Source/MLXNN/Normalization.swift
@@ -10,13 +10,13 @@ import MLX
 ///
 /// ### See also
 /// - <doc:normalization>
-public class InstanceNorm: Module, UnaryLayer {
+open class InstanceNorm: Module, UnaryLayer {
 
-    let dimensions: Int
-    let eps: Float
+    public let dimensions: Int
+    public let eps: Float
 
-    let weight: MLXArray?
-    let bias: MLXArray?
+    public let weight: MLXArray?
+    public let bias: MLXArray?
 
     /// Applies instance normalization [1] on the inputs.
     ///
@@ -68,13 +68,13 @@ public class InstanceNorm: Module, UnaryLayer {
 ///
 /// ### See also
 /// - <doc:normalization>
-public class LayerNorm: Module, UnaryLayer {
+open class LayerNorm: Module, UnaryLayer {
 
-    let dimensions: Int
-    let eps: Float
+    public let dimensions: Int
+    public let eps: Float
 
-    let weight: MLXArray?
-    let bias: MLXArray?
+    public let weight: MLXArray?
+    public let bias: MLXArray?
 
     /// Applies layer normalization [1] on the inputs.
     ///
@@ -129,10 +129,10 @@ public class LayerNorm: Module, UnaryLayer {
 ///
 /// ### See also
 /// - <doc:normalization>
-public class RMSNorm: Module, UnaryLayer {
+open class RMSNorm: Module, UnaryLayer {
 
-    let weight: MLXArray
-    let eps: Float
+    public let weight: MLXArray
+    public let eps: Float
 
     public init(dimensions: Int, eps: Float = 1e-5) {
         self.weight = MLXArray.ones([dimensions])
@@ -169,15 +169,15 @@ public class RMSNorm: Module, UnaryLayer {
 ///
 /// ### See also
 /// - <doc:normalization>
-public class GroupNorm: Module, UnaryLayer {
+open class GroupNorm: Module, UnaryLayer {
 
-    let groupCount: Int
-    let dimensions: Int
-    let eps: Float
-    let pytorchCompatible: Bool
+    public let groupCount: Int
+    public let dimensions: Int
+    public let eps: Float
+    public let pytorchCompatible: Bool
 
-    let weight: MLXArray?
-    let bias: MLXArray?
+    public let weight: MLXArray?
+    public let bias: MLXArray?
 
     /// Applies Group Normalization [1] on the inputs.
     ///
@@ -262,14 +262,14 @@ public class GroupNorm: Module, UnaryLayer {
 ///
 /// ### See also
 /// - <doc:normalization>
-public class BatchNorm: Module, UnaryLayer {
+open class BatchNorm: Module, UnaryLayer {
 
-    let featureCount: Int
-    let eps: Float
-    let momentum: Float
+    public let featureCount: Int
+    public let eps: Float
+    public let momentum: Float
 
-    let weight: MLXArray?
-    let bias: MLXArray?
+    public let weight: MLXArray?
+    public let bias: MLXArray?
 
     @ParameterInfo(key: "running_mean") var runningMean: MLXArray?
     @ParameterInfo(key: "running_var") var runningVar: MLXArray?

--- a/Source/MLXNN/PositionalEncoding.swift
+++ b/Source/MLXNN/PositionalEncoding.swift
@@ -124,11 +124,11 @@ final public class RoPE: Module, UnaryLayer {
 ///
 /// ### See Also
 /// - <doc:positional-encoding>
-public class SinusoidalPositionalEncoding: Module, UnaryLayer {
+open class SinusoidalPositionalEncoding: Module, UnaryLayer {
 
     let _sigmas: MLXArray
-    let scale: Float
-    let cosineFirst: Bool
+    public let scale: Float
+    public let cosineFirst: Bool
 
     /// Initialize the layer.
     /// - Parameters:

--- a/Source/MLXNN/Quantized.swift
+++ b/Source/MLXNN/Quantized.swift
@@ -22,13 +22,13 @@ import MLXRandom
 ///
 /// ### See Also
 /// - ``init(weight:bias:groupSize:bits:)``
-public class QuantizedLinear: Linear {
+open class QuantizedLinear: Linear {
 
-    let groupSize: Int
-    let bits: Int
+    public let groupSize: Int
+    public let bits: Int
 
-    let scales: MLXArray
-    let biases: MLXArray
+    public let scales: MLXArray
+    public let biases: MLXArray
 
     /// Applies an affine transformation to the input using a quantized weight matrix.
     ///

--- a/Source/MLXNN/Transformer.swift
+++ b/Source/MLXNN/Transformer.swift
@@ -8,14 +8,14 @@ import MLX
 /// ### See Also
 /// - <doc:transformers>
 /// - ``init(dimensions:numHeads:queryInputDimensions:keyInputDimensions:valueInputDimensions:valueDimensions:valueOutputDimensions:bias:)``
-public class MultiHeadAttention: Module {
+open class MultiHeadAttention: Module {
 
-    let numHeads: Int
+    public let numHeads: Int
 
-    @ModuleInfo(key: "query_proj") var queryProjection: Linear
-    @ModuleInfo(key: "key_proj") var keyProjection: Linear
-    @ModuleInfo(key: "value_proj") var valueProjection: Linear
-    @ModuleInfo(key: "out_proj") var outProjection: Linear
+    @ModuleInfo(key: "query_proj") public var queryProjection: Linear
+    @ModuleInfo(key: "key_proj") public var keyProjection: Linear
+    @ModuleInfo(key: "value_proj") public var valueProjection: Linear
+    @ModuleInfo(key: "out_proj") public var outProjection: Linear
 
     /// Implements the scaled dot product attention with multiple heads.
     ///
@@ -324,7 +324,7 @@ class TransformerDecoder: Module {
 /// ### See Also
 /// - <doc:transformers>
 /// - <https://arxiv.org/abs/1706.03762>
-public class Transformer: Module {
+open class Transformer: Module {
 
     let encoder: TransformerEncoder
     let decoder: TransformerDecoder

--- a/Tests/MLXTests/TransformTests.swift
+++ b/Tests/MLXTests/TransformTests.swift
@@ -242,7 +242,7 @@ class TransformTests: XCTestCase {
 
     func testCompilePerformance() {
         // this is the code from compilation.md
-        
+
         // disabling until we pick up the fix for https://github.com/ml-explore/mlx/issues/31
         return
 


### PR DESCRIPTION
Largish change but very mechanical:

- convert `public class` to `open class` -- this allows classes outside the module to subclass
    - e.g. `class LayerNorm(nn.LayerNorm)` from `phi`
- expose the ivars as public in case subclasses want to use them (they are `let` so this is safe)