### PR TITLE
follow-on to #7 -- need open callAsFunction to be able to override that, even in open classes

### DIFF
--- a/Source/MLXNN/Activations.swift
+++ b/Source/MLXNN/Activations.swift
@@ -334,7 +334,7 @@ open class GLU: Module, UnaryLayer {
         super.init()
     }
 
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         glu(x, axis: axis)
     }
 }
@@ -354,7 +354,7 @@ open class GLU: Module, UnaryLayer {
 /// - <doc:activations>
 /// - ``sigmoid(_:)``
 open class Sigmoid: Module, UnaryLayer {
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         sigmoid(x)
     }
 }
@@ -375,7 +375,7 @@ open class Sigmoid: Module, UnaryLayer {
 /// - <doc:activations>
 /// - ``mish(_:)``
 open class Mish: Module, UnaryLayer {
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         mish(x)
     }
 }
@@ -392,7 +392,7 @@ open class Mish: Module, UnaryLayer {
 /// - <doc:activations>
 /// - ``relu(_:)``
 open class ReLU: Module, UnaryLayer {
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         relu(x)
     }
 }
@@ -409,7 +409,7 @@ open class ReLU: Module, UnaryLayer {
 /// - <doc:activations>
 /// - ``leakyRelu(_:negativeSlope:)``
 open class LeakyReLU: Module, UnaryLayer {
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         leakyRelu(x)
     }
 }
@@ -426,7 +426,7 @@ open class LeakyReLU: Module, UnaryLayer {
 /// - <doc:activations>
 /// - ``relu6(_:)``
 open class ReLU6: Module, UnaryLayer {
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         relu6(x)
     }
 }
@@ -442,7 +442,7 @@ open class ReLU6: Module, UnaryLayer {
 /// ### See Also
 /// - <doc:activations>
 open class SoftMax: Module, UnaryLayer {
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         softMax(x, axis: -1)
     }
 }
@@ -459,7 +459,7 @@ open class SoftMax: Module, UnaryLayer {
 /// - <doc:activations>
 /// - ``softPlus(_:)``
 open class SoftPlus: Module, UnaryLayer {
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         softPlus(x)
     }
 }
@@ -476,7 +476,7 @@ open class SoftPlus: Module, UnaryLayer {
 /// - <doc:activations>
 /// - ``softSign(_:)``
 open class SoftSign: Module, UnaryLayer {
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         softSign(x)
     }
 }
@@ -500,7 +500,7 @@ open class CELU: Module, UnaryLayer {
         super.init()
     }
 
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         celu(x, alpha: alpha)
     }
 }
@@ -517,7 +517,7 @@ open class CELU: Module, UnaryLayer {
 /// - <doc:activations>
 /// - ``silu(_:)``
 open class SiLU: Module, UnaryLayer {
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         silu(x)
     }
 }
@@ -534,7 +534,7 @@ open class SiLU: Module, UnaryLayer {
 /// - <doc:activations>
 /// - ``logSoftMax(_:axis:)``
 open class LogSoftMax: Module, UnaryLayer {
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         logSoftMax(x)
     }
 }
@@ -551,7 +551,7 @@ open class LogSoftMax: Module, UnaryLayer {
 /// - <doc:activations>
 /// - ``logSigmoid(_:)``
 open class LogSigmoid: Module, UnaryLayer {
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         logSigmoid(x)
     }
 }
@@ -576,7 +576,7 @@ open class PReLU: Module, UnaryLayer {
         super.init()
     }
 
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         prelu(x, alpha: weight)
     }
 }
@@ -612,7 +612,7 @@ open class GELU: Module, UnaryLayer {
         super.init()
     }
 
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         switch approximation {
         case .none:
             gelu(x)
@@ -626,7 +626,7 @@ open class GELU: Module, UnaryLayer {
 
 /// Applies the hyperbolic tangent function
 open class Tanh: Module, UnaryLayer {
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         tanh(x)
     }
 }
@@ -643,7 +643,7 @@ open class Tanh: Module, UnaryLayer {
 /// - <doc:activations>
 /// - ``hardSwish(_:)``
 open class HardSwish: Module, UnaryLayer {
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         hardSwish(x)
     }
 }
@@ -671,7 +671,7 @@ open class Step: Module, UnaryLayer {
         super.init()
     }
 
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         step(x, threshold: threshold)
     }
 }
@@ -688,7 +688,7 @@ open class Step: Module, UnaryLayer {
 /// - <doc:activations>
 /// - ``selu(_:)``
 open class SELU: Module, UnaryLayer {
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         selu(x)
     }
 }

--- a/Source/MLXNN/Containers.swift
+++ b/Source/MLXNN/Containers.swift
@@ -85,7 +85,7 @@ open class Sequential: Module, UnaryLayer {
         self.layers = layers()
     }
 
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         var x = x
         for layer in layers {
             x = layer(x)

--- a/Source/MLXNN/Convolution.swift
+++ b/Source/MLXNN/Convolution.swift
@@ -48,7 +48,7 @@ open class Conv1d: Module, UnaryLayer {
         self.stride = stride
     }
 
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         var y = conv1d(x, weight, stride: stride, padding: padding)
         if let bias {
             y = y + bias
@@ -103,7 +103,7 @@ open class Conv2d: Module, UnaryLayer {
         self.stride = stride.values
     }
 
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         var y = conv2d(x, weight, stride: .init(stride), padding: .init(padding))
         if let bias {
             y = y + bias

--- a/Source/MLXNN/Dropout.swift
+++ b/Source/MLXNN/Dropout.swift
@@ -22,7 +22,7 @@ open class Dropout: Module, UnaryLayer {
         self.p1 = 1 - p
     }
 
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         if p1 == 1 || !self.training {
             return x
         }
@@ -62,7 +62,7 @@ open class Dropout2d: Module, UnaryLayer {
         self.p1 = 1 - p
     }
 
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         let ndim = x.ndim
         precondition(ndim == 3 || ndim == 4)
 
@@ -109,7 +109,7 @@ open class Dropout3d: Module, UnaryLayer {
         self.p1 = 1 - p
     }
 
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         let ndim = x.ndim
         precondition(ndim == 3 || ndim == 4)
 

--- a/Source/MLXNN/Embedding.swift
+++ b/Source/MLXNN/Embedding.swift
@@ -28,7 +28,7 @@ open class Embedding: Module, UnaryLayer {
         weight.shape.description
     }
 
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         weight[x]
     }
 }

--- a/Source/MLXNN/Linear.swift
+++ b/Source/MLXNN/Linear.swift
@@ -106,7 +106,7 @@ open class Linear: Module, UnaryLayer {
         "(inputDimensions=\(weight.dim(1)), outputDimensions=\(weight.dim(0)), bias=\(bias == nil ? "false" : "true"))"
     }
 
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         var result = x.matmul(weight.T)
         if let bias {
             result = result + bias
@@ -163,7 +163,7 @@ open class Bilinear: Module {
         "(inputDimensions1=\(weight.dim(2)), inputDimensions2=\(weight.dim(1)), outputDimensions=\(weight.dim(0)), bias=\(bias == nil ? "false" : "true"))"
     }
 
-    public func callAsFunction(_ x1: MLXArray, _ x2: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x1: MLXArray, _ x2: MLXArray) -> MLXArray {
         // normalize shapes
         let out = weight.dim(0)
         let in1 = weight.dim(2)

--- a/Source/MLXNN/Normalization.swift
+++ b/Source/MLXNN/Normalization.swift
@@ -42,7 +42,7 @@ open class InstanceNorm: Module, UnaryLayer {
         }
     }
 
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         let reductionAxes = Array(1 ..< x.ndim - 1)
 
         // compute stats
@@ -100,7 +100,7 @@ open class LayerNorm: Module, UnaryLayer {
         }
     }
 
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         let means = mean(x, axis: -1, keepDims: true)
         let variance = variance(x, axis: -1, keepDims: true)
         let x = (x - means) * rsqrt(variance + eps)
@@ -145,7 +145,7 @@ open class RMSNorm: Module, UnaryLayer {
         "(dimensions=\(weight.dim(0)), eps=\(self.eps))"
     }
 
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         // S is 1/sqrt(N) where N is the size of the features of x and is used
         // to compute a numerically more stable RMS of x by multiplying with S
         // first and summing.
@@ -250,7 +250,7 @@ open class GroupNorm: Module, UnaryLayer {
         return x
     }
 
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         pytorchCompatible ? pytorchGroupNorm(x) : groupNorm(x)
     }
 }
@@ -341,7 +341,7 @@ open class BatchNorm: Module, UnaryLayer {
         return (mean, variance)
     }
 
-    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open func callAsFunction(_ x: MLXArray) -> MLXArray {
         precondition((2 ... 4).contains(x.ndim))
 
         // Calculate the mean and variance used to normalize the input x. If we

--- a/Source/MLXNN/Quantized.swift
+++ b/Source/MLXNN/Quantized.swift
@@ -74,7 +74,7 @@ open class QuantizedLinear: Linear {
         self.freeze(recursive: false)
     }
 
-    public override func callAsFunction(_ x: MLXArray) -> MLXArray {
+    open override func callAsFunction(_ x: MLXArray) -> MLXArray {
         var x = quantizedMatmul(
             x,
             weight,

--- a/Source/MLXNN/Transformer.swift
+++ b/Source/MLXNN/Transformer.swift
@@ -71,7 +71,7 @@ open class MultiHeadAttention: Module {
             valueDimensions, valueOutputDimensions, bias: bias)
     }
 
-    public func callAsFunction(
+    open func callAsFunction(
         _ queries: MLXArray, keys: MLXArray, values: MLXArray, mask: MLXArray? = nil
     ) -> MLXArray {
         var queries = queryProjection(queries)
@@ -358,7 +358,7 @@ open class Transformer: Module {
             normFirst: normFirst)
     }
 
-    public func callAsFunction(
+    open func callAsFunction(
         source: MLXArray, target: MLXArray, sourceMask: MLXArray, targetMask: MLXArray,
         memoryMask: MLXArray
     ) -> MLXArray {

--- a/Source/MLXOptimizers/Optimizers.swift
+++ b/Source/MLXOptimizers/Optimizers.swift
@@ -24,7 +24,7 @@ public protocol Optimizer: Updatable, Evaluatable {
 ///
 /// ### See Also
 /// - <doc:MLXOptimizers>
-public class OptimizerBase<State: Updatable>: Optimizer {
+open class OptimizerBase<State: Updatable>: Optimizer {
 
     /// Stores a `State` value in a structure that matches the model parameters
     var stateStorage = NestedDictionary<String, State>()
@@ -39,11 +39,11 @@ public class OptimizerBase<State: Updatable>: Optimizer {
     ///     MLXArray.zeros(like: gradient)
     /// }
     /// ```
-    func newState(parameter: MLXArray) -> State {
+    open func newState(parameter: MLXArray) -> State {
         fatalError("newState() not implemented \(type(of: self))")
     }
 
-    public func innerState() -> [MLXArray] {
+    open func innerState() -> [MLXArray] {
         stateStorage
             .flattenedValues()
             .flatMap { $0.innerState() }
@@ -69,7 +69,9 @@ public class OptimizerBase<State: Updatable>: Optimizer {
         return p
     }
 
-    func applySingle(gradient: MLXArray, parameter: MLXArray, state: State) -> (MLXArray, State) {
+    open func applySingle(gradient: MLXArray, parameter: MLXArray, state: State) -> (
+        MLXArray, State
+    ) {
         fatalError("applySingle() not implemented \(type(of: self))")
     }
 }
@@ -78,8 +80,8 @@ public class OptimizerBase<State: Updatable>: Optimizer {
 ///
 /// ### See Also
 /// - <doc:MLXOptimizers>
-public class OptimizerBaseArrayState: OptimizerBase<MLXArray> {
-    override func newState(parameter: MLXArray) -> MLXArray {
+open class OptimizerBaseArrayState: OptimizerBase<MLXArray> {
+    override open func newState(parameter: MLXArray) -> MLXArray {
         MLXArray.zeros(like: parameter)
     }
 }
@@ -109,7 +111,7 @@ public struct TupleState: Updatable {
 ///
 /// ### See Also
 /// - <doc:MLXOptimizers>
-public class SGD: OptimizerBaseArrayState {
+open class SGD: OptimizerBaseArrayState {
 
     var learningRate: Float
     var momentum: Float = 0
@@ -138,11 +140,11 @@ public class SGD: OptimizerBaseArrayState {
         self.nesterov = nesterov
     }
 
-    override func newState(parameter: MLXArray) -> MLXArray {
+    override open func newState(parameter: MLXArray) -> MLXArray {
         MLXArray.zeros(like: parameter)
     }
 
-    override func applySingle(gradient: MLXArray, parameter: MLXArray, state: MLXArray) -> (
+    override open func applySingle(gradient: MLXArray, parameter: MLXArray, state: MLXArray) -> (
         MLXArray, MLXArray
     ) {
         var gradient = gradient
@@ -180,7 +182,7 @@ public class SGD: OptimizerBaseArrayState {
 ///
 /// ### See Also
 /// - <doc:MLXOptimizers>
-public class RMSprop: OptimizerBaseArrayState {
+open class RMSprop: OptimizerBaseArrayState {
 
     var learningRate: Float
     var alpha: Float = 0.99
@@ -200,7 +202,7 @@ public class RMSprop: OptimizerBaseArrayState {
         self.eps = eps
     }
 
-    override func applySingle(gradient: MLXArray, parameter: MLXArray, state: MLXArray) -> (
+    override open func applySingle(gradient: MLXArray, parameter: MLXArray, state: MLXArray) -> (
         MLXArray, MLXArray
     ) {
         let v = alpha * state + (1 - alpha) * square(gradient)
@@ -216,7 +218,7 @@ public class RMSprop: OptimizerBaseArrayState {
 ///
 /// ### See Also
 /// - <doc:MLXOptimizers>
-public class AdaGrad: OptimizerBaseArrayState {
+open class AdaGrad: OptimizerBaseArrayState {
 
     var learningRate: Float
     var eps: Float = 1e-8
@@ -232,7 +234,7 @@ public class AdaGrad: OptimizerBaseArrayState {
         self.eps = eps
     }
 
-    override func applySingle(gradient: MLXArray, parameter: MLXArray, state: MLXArray) -> (
+    override open func applySingle(gradient: MLXArray, parameter: MLXArray, state: MLXArray) -> (
         MLXArray, MLXArray
     ) {
         let v = state + square(gradient)
@@ -248,7 +250,7 @@ public class AdaGrad: OptimizerBaseArrayState {
 ///
 /// ### See Also
 /// - <doc:MLXOptimizers>
-public class AdaDelta: OptimizerBase<TupleState> {
+open class AdaDelta: OptimizerBase<TupleState> {
 
     var learningRate: Float
     var rho: Float = 0.99
@@ -268,11 +270,11 @@ public class AdaDelta: OptimizerBase<TupleState> {
         self.eps = eps
     }
 
-    override func newState(parameter: MLXArray) -> TupleState {
+    override open func newState(parameter: MLXArray) -> TupleState {
         TupleState(zeros: parameter)
     }
 
-    override func applySingle(gradient: MLXArray, parameter: MLXArray, state: TupleState) -> (
+    override open func applySingle(gradient: MLXArray, parameter: MLXArray, state: TupleState) -> (
         MLXArray, TupleState
     ) {
         var (v, u) = state.values
@@ -294,7 +296,7 @@ public class AdaDelta: OptimizerBase<TupleState> {
 ///
 /// ### See Also
 /// - <doc:MLXOptimizers>
-public class Adam: OptimizerBase<TupleState> {
+open class Adam: OptimizerBase<TupleState> {
 
     var learningRate: Float
     var betas: (Float, Float) = (0.9, 0.999)
@@ -311,11 +313,11 @@ public class Adam: OptimizerBase<TupleState> {
         self.eps = eps
     }
 
-    override func newState(parameter: MLXArray) -> TupleState {
+    override open func newState(parameter: MLXArray) -> TupleState {
         TupleState(zeros: parameter)
     }
 
-    override func applySingle(gradient: MLXArray, parameter: MLXArray, state: TupleState) -> (
+    override open func applySingle(gradient: MLXArray, parameter: MLXArray, state: TupleState) -> (
         MLXArray, TupleState
     ) {
         let (b1, b2) = betas
@@ -339,7 +341,7 @@ public class Adam: OptimizerBase<TupleState> {
 ///
 /// ### See Also
 /// - <doc:MLXOptimizers>
-public class AdamW: Adam {
+open class AdamW: Adam {
 
     var weightDecay: Float = 0.01
 
@@ -357,7 +359,7 @@ public class AdamW: Adam {
         super.init(learningRate: learningRate, betas: betas, eps: eps)
     }
 
-    override func applySingle(gradient: MLXArray, parameter: MLXArray, state: TupleState) -> (
+    override open func applySingle(gradient: MLXArray, parameter: MLXArray, state: TupleState) -> (
         MLXArray, TupleState
     ) {
         return super.applySingle(
@@ -375,7 +377,7 @@ public class AdamW: Adam {
 ///
 /// ### See Also
 /// - <doc:MLXOptimizers>
-public class Adamax: OptimizerBase<TupleState> {
+open class Adamax: OptimizerBase<TupleState> {
 
     var learningRate: Float
     var betas: (Float, Float) = (0.9, 0.999)
@@ -392,11 +394,11 @@ public class Adamax: OptimizerBase<TupleState> {
         self.eps = eps
     }
 
-    override func newState(parameter: MLXArray) -> TupleState {
+    override open func newState(parameter: MLXArray) -> TupleState {
         TupleState(zeros: parameter)
     }
 
-    override func applySingle(gradient: MLXArray, parameter: MLXArray, state: TupleState) -> (
+    override open func applySingle(gradient: MLXArray, parameter: MLXArray, state: TupleState) -> (
         MLXArray, TupleState
     ) {
         let (b1, b2) = betas
@@ -423,7 +425,7 @@ public class Adamax: OptimizerBase<TupleState> {
 ///
 /// ### See Also
 /// - <doc:MLXOptimizers>
-public class Lion: OptimizerBaseArrayState {
+open class Lion: OptimizerBaseArrayState {
 
     var learningRate: Float
     var betas: (Float, Float) = (0.9, 0.999)
@@ -441,7 +443,7 @@ public class Lion: OptimizerBaseArrayState {
         self.weightDecay = weightDecay
     }
 
-    override func applySingle(gradient: MLXArray, parameter: MLXArray, state: MLXArray) -> (
+    override open func applySingle(gradient: MLXArray, parameter: MLXArray, state: MLXArray) -> (
         MLXArray, MLXArray
     ) {
         let (b1, b2) = betas
@@ -466,7 +468,7 @@ public class Lion: OptimizerBaseArrayState {
 ///
 /// ### See Also
 /// - <doc:MLXOptimizers>
-public class Adafactor: OptimizerBase<Adafactor.State> {
+open class Adafactor: OptimizerBase<Adafactor.State> {
 
     var learningRate: Float? = nil
     var eps: (Float, Float) = (1e-30, 1e-3)
@@ -520,7 +522,7 @@ public class Adafactor: OptimizerBase<Adafactor.State> {
         self.warmupInit = warmupInit
     }
 
-    override func newState(parameter: MLXArray) -> State {
+    override open func newState(parameter: MLXArray) -> State {
         var s = State()
         if parameter.ndim >= 2 {
             let shape = parameter.shape
@@ -567,7 +569,7 @@ public class Adafactor: OptimizerBase<Adafactor.State> {
         return matmul(rFactor.expandedDimensions(axis: -1), cFactor.expandedDimensions(axis: 0))
     }
 
-    override func applySingle(gradient: MLXArray, parameter: MLXArray, state: State) -> (
+    override open func applySingle(gradient: MLXArray, parameter: MLXArray, state: State) -> (
         MLXArray, State
     ) {
         var state = state

--- a/Tests/MLXTests/SubclassTests.swift
+++ b/Tests/MLXTests/SubclassTests.swift
@@ -1,0 +1,39 @@
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+import MLX
+import MLXNN
+import MLXOptimizers
+import XCTest
+
+// not tests that run -- these are tests to make sure we can
+// compile subclasses outside the package they are defined in
+
+public class AdjustedRMSNorm: MLXNN.RMSNorm {
+    public override func callAsFunction(_ x: MLXArray) -> MLXArray {
+        super.callAsFunction(x) + 1
+    }
+}
+
+public class TrivialOptimizer: MLXOptimizers.OptimizerBase<MLXArray> {
+
+    public override func newState(parameter: MLXArray) -> MLXArray {
+        ones(like: parameter)
+    }
+
+    public override func applySingle(gradient: MLXArray, parameter: MLXArray, state: MLXArray) -> (
+        MLXArray, MLXArray
+    ) {
+        (gradient, state)
+    }
+}
+
+public class AdjustedSGD: MLXOptimizers.SGD {
+
+    public override func applySingle(gradient: MLXArray, parameter: MLXArray, state: MLXArray) -> (
+        MLXArray, MLXArray
+    ) {
+        super.applySingle(gradient: gradient + 1, parameter: parameter, state: state)
+    }
+
+}


### PR DESCRIPTION
I just discovered that:

```
open class X {
    public func y() {
    }
}
```

you cannot override `y()` in subclasses -- that needs to be marked as open too.

Per #16 we need the same treatment in MLXOptimizers.  Added compile-only test to make sure these can be subclassed outside the package (which wasn't obvious _inside_ the package!)