### PR TITLE
macOS target 13.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     name: "mlx-swift",
 
     platforms: [
-        .macOS(.v13),
+        .macOS("13.3"),
         .iOS(.v16),
     ],
 


### PR DESCRIPTION
Package uses functions introduced in macOS 13.3, that is reported while building the package. This PR bump the macOS platrorm to macOS 13.3

> /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk/System/Library/Frameworks/vecLib.framework/Headers/cblas_new.h:891:6: note: 'cblas_sgemm' has been marked as being introduced in macOS 13.3 here, but the deployment target is macOS 13.0.0