### PR TITLE
add spi.yml for swift package index

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [MLX, MLXRandom, MLXNN, MLXOptimizers, MLXFFT, MLXLinalg]

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -118,7 +118,9 @@ import MLXFFT
 for x in MLX MLXRandom MLXNN MLXOptimizers MLXFFT; do
 ```
 
-13. Run `pre-commit`
+13. Add to `.spi.yml` for swift package index
+
+14. Run `pre-commit`
 
 ```
 pre-commit run --all-files

--- a/Source/MLX/Documentation.docc/MLX.md
+++ b/Source/MLX/Documentation.docc/MLX.md
@@ -36,12 +36,12 @@ are the CPU and GPU.
 
 ## Other MLX Packages
 
-- [MLX](https://ml-explore.github.io/mlx-swift/MLX/documentation/mlx/)
-- [MLXRandom](https://ml-explore.github.io/mlx-swift/MLXRandom/documentation/mlxrandom/)
-- [MLXNN](https://ml-explore.github.io/mlx-swift/MLXNN/documentation/mlxnn/)
-- [MLXOptimizers](https://ml-explore.github.io/mlx-swift/MLXOptimizers/documentation/mlxoptimizers/)
-- [MLXFFT](https://ml-explore.github.io/mlx-swift/MLXFFT/documentation/mlxfft/)
-- [MLXLinalg](https://ml-explore.github.io/mlx-swift/MLXLinalg/documentation/mlxlinalg/)
+- [MLX](../../../MLX/documentation/mlx/)
+- [MLXRandom](../../../MLXRandom/documentation/mlxrandom/)
+- [MLXNN](../../../MLXNN/documentation/mlxnn/)
+- [MLXOptimizers](../../../MLXOptimizers/documentation/mlxoptimizers/)
+- [MLXFFT](../../../MLXFFT/documentation/mlxfft/)
+- [MLXLinalg](../../../MLXLinalg/documentation/mlxlinalg/)
 
 - [Python `mlx`](https://ml-explore.github.io/mlx/build/html/index.html)
 

--- a/Source/MLXFFT/Documentation.docc/MLXFFT.md
+++ b/Source/MLXFFT/Documentation.docc/MLXFFT.md
@@ -4,12 +4,12 @@ Fast Fourier Transform Functions
 
 ## Other MLX Packages
 
-- [MLX](https://ml-explore.github.io/mlx-swift/MLX/documentation/mlx/)
-- [MLXRandom](https://ml-explore.github.io/mlx-swift/MLXRandom/documentation/mlxrandom/)
-- [MLXNN](https://ml-explore.github.io/mlx-swift/MLXNN/documentation/mlxnn/)
-- [MLXOptimizers](https://ml-explore.github.io/mlx-swift/MLXOptimizers/documentation/mlxoptimizers/)
-- [MLXFFT](https://ml-explore.github.io/mlx-swift/MLXFFT/documentation/mlxfft/)
-- [MLXLinalg](https://ml-explore.github.io/mlx-swift/MLXLinalg/documentation/mlxlinalg/)
+- [MLX](../../../MLX/documentation/mlx/)
+- [MLXRandom](../../../MLXRandom/documentation/mlxrandom/)
+- [MLXNN](../../../MLXNN/documentation/mlxnn/)
+- [MLXOptimizers](../../../MLXOptimizers/documentation/mlxoptimizers/)
+- [MLXFFT](../../../MLXFFT/documentation/mlxfft/)
+- [MLXLinalg](../../../MLXLinalg/documentation/mlxlinalg/)
 
 - [Python `mlx`](https://ml-explore.github.io/mlx/build/html/index.html)
 

--- a/Source/MLXLinalg/Documentation.docc/MLXLinalg.md
+++ b/Source/MLXLinalg/Documentation.docc/MLXLinalg.md
@@ -4,11 +4,11 @@ Linear Algebra Functions
 
 ## Other MLX Packages
 
-- [MLX](https://ml-explore.github.io/mlx-swift/MLX/documentation/mlx/)
-- [MLXRandom](https://ml-explore.github.io/mlx-swift/MLXRandom/documentation/mlxrandom/)
-- [MLXNN](https://ml-explore.github.io/mlx-swift/MLXNN/documentation/mlxnn/)
-- [MLXOptimizers](https://ml-explore.github.io/mlx-swift/MLXOptimizers/documentation/mlxoptimizers/)
-- [MLXFFT](https://ml-explore.github.io/mlx-swift/MLXFFT/documentation/mlxfft/)
-- [MLXLinalg](https://ml-explore.github.io/mlx-swift/MLXLinalg/documentation/mlxlinalg/)
+- [MLX](../../../MLX/documentation/mlx/)
+- [MLXRandom](../../../MLXRandom/documentation/mlxrandom/)
+- [MLXNN](../../../MLXNN/documentation/mlxnn/)
+- [MLXOptimizers](../../../MLXOptimizers/documentation/mlxoptimizers/)
+- [MLXFFT](../../../MLXFFT/documentation/mlxfft/)
+- [MLXLinalg](../../../MLXLinalg/documentation/mlxlinalg/)
 
 - [Python `mlx`](https://ml-explore.github.io/mlx/build/html/index.html)

--- a/Source/MLXNN/Documentation.docc/MLXNN.md
+++ b/Source/MLXNN/Documentation.docc/MLXNN.md
@@ -43,12 +43,12 @@ See <doc:training>
 
 ## Other MLX Packages
 
-- [MLX](https://ml-explore.github.io/mlx-swift/MLX/documentation/mlx/)
-- [MLXRandom](https://ml-explore.github.io/mlx-swift/MLXRandom/documentation/mlxrandom/)
-- [MLXNN](https://ml-explore.github.io/mlx-swift/MLXNN/documentation/mlxnn/)
-- [MLXOptimizers](https://ml-explore.github.io/mlx-swift/MLXOptimizers/documentation/mlxoptimizers/)
-- [MLXFFT](https://ml-explore.github.io/mlx-swift/MLXFFT/documentation/mlxfft/)
-- [MLXLinalg](https://ml-explore.github.io/mlx-swift/MLXLinalg/documentation/mlxlinalg/)
+- [MLX](../../../MLX/documentation/mlx/)
+- [MLXRandom](../../../MLXRandom/documentation/mlxrandom/)
+- [MLXNN](../../../MLXNN/documentation/mlxnn/)
+- [MLXOptimizers](../../../MLXOptimizers/documentation/mlxoptimizers/)
+- [MLXFFT](../../../MLXFFT/documentation/mlxfft/)
+- [MLXLinalg](../../../MLXLinalg/documentation/mlxlinalg/)
 
 - [Python `mlx`](https://ml-explore.github.io/mlx/build/html/index.html)
 

--- a/Source/MLXOptimizers/Documentation.docc/MLXOptimizers.md
+++ b/Source/MLXOptimizers/Documentation.docc/MLXOptimizers.md
@@ -31,12 +31,12 @@ for _ in 0 ..< epochs {
 
 ## Other MLX Packages
 
-- [MLX](https://ml-explore.github.io/mlx-swift/MLX/documentation/mlx/)
-- [MLXRandom](https://ml-explore.github.io/mlx-swift/MLXRandom/documentation/mlxrandom/)
-- [MLXNN](https://ml-explore.github.io/mlx-swift/MLXNN/documentation/mlxnn/)
-- [MLXOptimizers](https://ml-explore.github.io/mlx-swift/MLXOptimizers/documentation/mlxoptimizers/)
-- [MLXFFT](https://ml-explore.github.io/mlx-swift/MLXFFT/documentation/mlxfft/)
-- [MLXLinalg](https://ml-explore.github.io/mlx-swift/MLXLinalg/documentation/mlxlinalg/)
+- [MLX](../../../MLX/documentation/mlx/)
+- [MLXRandom](../../../MLXRandom/documentation/mlxrandom/)
+- [MLXNN](../../../MLXNN/documentation/mlxnn/)
+- [MLXOptimizers](../../../MLXOptimizers/documentation/mlxoptimizers/)
+- [MLXFFT](../../../MLXFFT/documentation/mlxfft/)
+- [MLXLinalg](../../../MLXLinalg/documentation/mlxlinalg/)
 
 - [Python `mlx`](https://ml-explore.github.io/mlx/build/html/index.html)
 

--- a/Source/MLXRandom/Documentation.docc/MLXRandom.md
+++ b/Source/MLXRandom/Documentation.docc/MLXRandom.md
@@ -27,12 +27,12 @@ splittable version of Threefry, which is a counter-based PRNG.
 
 ## Other MLX Packages
 
-- [MLX](https://ml-explore.github.io/mlx-swift/MLX/documentation/mlx/)
-- [MLXRandom](https://ml-explore.github.io/mlx-swift/MLXRandom/documentation/mlxrandom/)
-- [MLXNN](https://ml-explore.github.io/mlx-swift/MLXNN/documentation/mlxnn/)
-- [MLXOptimizers](https://ml-explore.github.io/mlx-swift/MLXOptimizers/documentation/mlxoptimizers/)
-- [MLXFFT](https://ml-explore.github.io/mlx-swift/MLXFFT/documentation/mlxfft/)
-- [MLXLinalg](https://ml-explore.github.io/mlx-swift/MLXLinalg/documentation/mlxlinalg/)
+- [MLX](../../../MLX/documentation/mlx/)
+- [MLXRandom](../../../MLXRandom/documentation/mlxrandom/)
+- [MLXNN](../../../MLXNN/documentation/mlxnn/)
+- [MLXOptimizers](../../../MLXOptimizers/documentation/mlxoptimizers/)
+- [MLXFFT](../../../MLXFFT/documentation/mlxfft/)
+- [MLXLinalg](../../../MLXLinalg/documentation/mlxlinalg/)
 
 - [Python `mlx`](https://ml-explore.github.io/mlx/build/html/index.html)
 


### PR DESCRIPTION
- also replace some absolute links with relative links to fit better into non gh pages sites (for cross package linking)

This should partially address https://github.com/ml-explore/mlx-swift/issues/14