### PR TITLE
apply swiftformat -- now checked in circleci

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     ],
     dependencies: [
         // for Complex type
-        .package(url: "https://github.com/apple/swift-numerics", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-numerics", from: "1.0.0")
     ],
     targets: [
         // plugin to help build the metal shaders


### PR DESCRIPTION
Followup to https://github.com/ml-explore/mlx-swift/pull/21 -- apply swift-format.  Wasn't caught in previous PR as the change to Package.swift was on main in the main repo, not in the fork.