### PR TITLE
integrate MLXArray functions and free functions up to mlx v0.3.0

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -88,7 +88,7 @@ target_link_libraries(MLXFFT PRIVATE MLX)
 dependencies: [.product(name: "MLX", package: "mlx-swift"),
                .product(name: "MLXRandom", package: "mlx-swift"),
                .product(name: "MLXNN", package: "mlx-swift"),
-               .product(name: "MLXOptimziers", package: "mlx-swift"),
+               .product(name: "MLXOptimizers", package: "mlx-swift"),
                .product(name: "MLXFFT", package: "mlx-swift")]
 ```
 
@@ -98,7 +98,7 @@ dependencies: [.product(name: "MLX", package: "mlx-swift"),
 dependencies: [.product(name: "MLX", package: "mlx-swift"),
                .product(name: "MLXRandom", package: "mlx-swift"),
                .product(name: "MLXNN", package: "mlx-swift"),
-               .product(name: "MLXOptimziers", package: "mlx-swift"),
+               .product(name: "MLXOptimizers", package: "mlx-swift"),
                .product(name: "MLXFFT", package: "mlx-swift")]
 ```
 

--- a/Package.swift
+++ b/Package.swift
@@ -120,7 +120,7 @@ let package = Package(
         ),
         .target(
             name: "MLXNN",
-            dependencies: ["MLX", "MLXRandom"]
+            dependencies: ["MLX", "MLXRandom", "Cmlx"]
         ),
         .target(
             name: "MLXOptimizers",

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ and add the libraries as dependencies:
 dependencies: [.product(name: "MLX", package: "mlx-swift"),
                .product(name: "MLXRandom", package: "mlx-swift"),
                .product(name: "MLXNN", package: "mlx-swift"),
-               .product(name: "MLXOptimziers", package: "mlx-swift"),
+               .product(name: "MLXOptimizers", package: "mlx-swift"),
                .product(name: "MLXFFT", package: "mlx-swift")]
 ```
 
@@ -92,5 +92,7 @@ Ronan Collobert.
 
 ## Versions
 
-The software generally matches the API and implementation of MLX as of tag 
+The ``MLX`` array functions should match MLX as of tag 
+[v0.3.0](https://github.com/ml-explore/mlx/releases/tag/v0.3.0).  The `MLXNN`
+package should match MLX (`mlx.nn`) as of tag
 [v0.0.10](https://github.com/ml-explore/mlx/releases/tag/v0.0.10).

--- a/Source/Cmlx/include/mlx.h
+++ b/Source/Cmlx/include/mlx.h
@@ -1,3 +1,4 @@
 #include "mlx/c/mlx.h"
 #include "mlx/c/transforms_impl.h"
 #include "mlx/c/linalg.h"
+#include "mlx/c/fast.h"

--- a/Source/MLX/Documentation.docc/Articles/converting-python.md
+++ b/Source/MLX/Documentation.docc/Articles/converting-python.md
@@ -218,8 +218,8 @@ This is a mapping of `mx` free functions to their ``MLX`` counterparts.
 `reshape` | ``MLX/reshaped(_:_:stream:)-5x3y0``
 `round` | ``MLX/round(_:decimals:stream:)``
 `rsqrt` | ``MLX/rsqrt(_:stream:)``
-`save` | ``MLX/save(array:url:stream:)`` and ``MLX/save(arrays:url:stream:)``
-`save_safetensors` | ``MLX/save(arrays:url:stream:)``
+`save` | ``MLX/save(array:url:stream:)`` and ``MLX/save(arrays:metadata:url:stream:)``
+`save_safetensors` | ``MLX/save(arrays:metadata:url:stream:)``
 `savez` | not supported
 `savez_compressed` | not supported
 `sigmoid` | ``MLX/sigmoid(_:stream:)``

--- a/Source/MLX/Documentation.docc/MLX.md
+++ b/Source/MLX/Documentation.docc/MLX.md
@@ -1,6 +1,6 @@
 #  ``MLX``
 
-MLX Swift is a Swift API for [MLX](https://ml-explore.github.io/mlx/build/html/index.html).
+MLX Swift is a Swift API for MLX.
 
 MLX is an array framework for machine learning research on Apple
 silicon. MLX Swift expands MLX to the Swift language, making research and

--- a/Source/MLX/Documentation.docc/Organization/arithmetic.md
+++ b/Source/MLX/Documentation.docc/Organization/arithmetic.md
@@ -73,9 +73,6 @@ Note: the `-` and `/` operators are not able to be linked here.
 - ``MLXArray/+(_:_:)-1rv98``
 - ``MLXArray/+(_:_:)-2vili``
 - ``MLXArray/+(_:_:)-1jn5i``
-- ``MLXArray/-(_:_:)-7frdo``
-- ``MLXArray/-(_:_:)-9mf3``
-- ``MLXArray/-(_:_:)-971j0``
 - ``MLXArray/-(_:)``
 - ``MLXArray/*(_:_:)-1z2ck``
 - ``MLXArray/*(_:_:)-sw3w``
@@ -127,6 +124,7 @@ Note: the `-` and `/` operators are not able to be linked here.
 - ``acos(_:stream:)``
 - ``acosh(_:stream:)``
 - ``add(_:_:stream:)``
+- ``addmm(_:_:_:alpha:beta:stream:)``
 - ``asin(_:stream:)``
 - ``asinh(_:stream:)``
 - ``atan(_:stream:)``

--- a/Source/MLX/Documentation.docc/Organization/logical.md
+++ b/Source/MLX/Documentation.docc/Organization/logical.md
@@ -53,6 +53,7 @@ if (a < b).all().item() {
 - ``equal(_:_:stream:)``
 - ``greater(_:_:stream:)``
 - ``greaterEqual(_:_:stream:)``
+- ``isClose(_:_:rtol:atol:equalNaN:stream:)``
 - ``less(_:_:stream:)``
 - ``lessEqual(_:_:stream:)``
 - ``logicalNot(_:stream:)``

--- a/Source/MLX/Documentation.docc/free-functions.md
+++ b/Source/MLX/Documentation.docc/free-functions.md
@@ -210,3 +210,8 @@ operations as methods for convenience.
 - ``stopGradient(_:stream:)``
 - ``jvp(_:primals:tangents:)``
 - ``vjp(_:primals:cotangents:)``
+
+### Other
+
+- ``diag(_:k:stream:)``
+- ``diagonal(_:offset:axis1:axis2:stream:)``

--- a/Source/MLX/Documentation.docc/install.md
+++ b/Source/MLX/Documentation.docc/install.md
@@ -25,7 +25,7 @@ and add the libraries (as needed) as dependencies:
 dependencies: [.product(name: "MLX", package: "mlx-swift"),
                .product(name: "MLXRandom", package: "mlx-swift"),
                .product(name: "MLXNN", package: "mlx-swift"),
-               .product(name: "MLXOptimziers", package: "mlx-swift"),
+               .product(name: "MLXOptimizers", package: "mlx-swift"),
                .product(name: "MLXFFT", package: "mlx-swift")]
 ```
 

--- a/Source/MLX/MLXArray+Ops.swift
+++ b/Source/MLX/MLXArray+Ops.swift
@@ -91,7 +91,6 @@ extension MLXArray {
     ///
     /// ### See Also
     /// - <doc:arithmetic>
-    /// - ``MLXArray/-(_:_:)-7frdo``
     public static func - <T: ScalarOrArray>(lhs: MLXArray, rhs: T) -> MLXArray {
         let s = StreamOrDevice.default
         let rhs = rhs.asMLXArray(dtype: lhs.dtype)
@@ -102,7 +101,6 @@ extension MLXArray {
     ///
     /// ### See Also
     /// - <doc:arithmetic>
-    /// - ``MLXArray/-(_:_:)-7frdo``
     public static func - <T: ScalarOrArray>(lhs: T, rhs: MLXArray) -> MLXArray {
         let s = StreamOrDevice.default
         let lhs = lhs.asMLXArray(dtype: rhs.dtype)
@@ -1305,6 +1303,46 @@ extension MLXArray {
         return MLXArray(mlx_cumsum(flat, 0, reverse, inclusive, stream.ctx))
     }
 
+    /// Extract a diagonal or construct a diagonal matrix.
+    ///
+    /// If self is 1-D then a diagonal matrix is constructed with self on the
+    /// `k`-th diagonal. If self is 2-D then the `k`-th diagonal is
+    /// returned.
+    ///
+    /// - Parameters:
+    ///   - k: the diagonal to extract or construct
+    ///   - stream: stream or device to evaluate on
+    ///
+    /// ### See Also
+    /// - ``diagonal(offset:axis1:axis2:stream:)``
+    public func diag(k: Int = 0, stream: StreamOrDevice = .default) -> MLXArray {
+        MLXArray(mlx_diag(ctx, k.int32, stream.ctx))
+    }
+
+    /// Return specified diagonals.
+    ///
+    /// If self is 2-D, then a 1-D array containing the diagonal at the given
+    /// `offset` is returned.
+    ///
+    /// If self has more than two dimensions, then `axis1` and `axis2`
+    /// determine the 2D subarrays from which diagonals are extracted. The new
+    /// shape is the original shape with `axis1` and `axis2` removed and a
+    /// new dimension inserted at the end corresponding to the diagonal.
+    ///
+    /// - Parameters:
+    ///   - offset: offset of the diagonal.  Can be positive or negative
+    ///   - axis1: first axis of the 2-D sub-array from which the diagonals should be taken
+    ///   - axis2: second axis of the 2-D sub-array from which the diagonals should be taken
+    ///   - stream: stream or device to evaluate on
+    ///
+    /// ### See Also
+    /// - ``diag(k:stream:)``
+    public func diagonal(
+        offset: Int = 0, axis1: Int = 0, axis2: Int = 1, stream: StreamOrDevice = .default
+    ) -> MLXArray {
+        MLXArray(mlx_diagonal(ctx, offset.int32, axis1.int32, axis2.int32, stream.ctx))
+    }
+
     /// Element-wise exponential.
     ///
     /// ### See Also
@@ -1347,6 +1385,11 @@ extension MLXArray {
     }
 
     /// Flatten an array.
+    ///
+    /// The axes flattened will be between `start` and `end`,
+    /// inclusive. Negative axes are supported. After converting negative axis to
+    /// positive, axes outside the valid range will be clamped to a valid value,
+    /// `start` to `0` and `end` to `ndim - 1`.
     ///
     /// For example:
     ///

--- a/Source/MLX/Ops+Array.swift
+++ b/Source/MLX/Ops+Array.swift
@@ -91,6 +91,9 @@ public func all(_ array: MLXArray, keepDims: Bool = false, stream: StreamOrDevic
 
 /// Approximate comparison of two arrays.
 ///
+/// Infinite values are considered equal if they have the same sign, NaN values are not equal unless
+/// `equalNAN` is `true`.
+///
 /// The arrays are considered equal if:
 ///
 /// ```swift
@@ -120,6 +123,7 @@ public func all(_ array: MLXArray, keepDims: Bool = false, stream: StreamOrDevic
 ///
 /// ### See Also
 /// - <doc:logical>
+/// - ``isClose(_:_:rtol:atol:equalNaN:stream:)``
 /// - ``arrayEqual(_:_:equalNAN:stream:)``
 /// - ``MLXArray/arrayEqual(_:equalNAN:stream:)``
 public func allClose<T: ScalarOrArray>(
@@ -318,6 +322,7 @@ public func argMin(_ array: MLXArray, keepDims: Bool = false, stream: StreamOrDe
 /// ### See Also
 /// - <doc:logical>
 /// - ``allClose(_:_:rtol:atol:equalNaN:stream:)``
+/// - ``isClose(_:_:rtol:atol:equalNaN:stream:)``
 /// - ``MLXArray/.==(_:_:)-56m0a``
 /// - ``MLXArray/arrayEqual(_:equalNAN:stream:)``
 public func arrayEqual<T: ScalarOrArray>(
@@ -504,6 +509,49 @@ public func cumsum(
     return MLXArray(mlx_cumsum(flat, 0, reverse, inclusive, stream.ctx))
 }
 
+/// Extract a diagonal or construct a diagonal matrix.
+///
+/// If `array` is 1-D then a diagonal matrix is constructed with `array` on the
+/// `k`-th diagonal. If `array` is 2-D then the `k`-th diagonal is
+/// returned.
+///
+/// - Parameters:
+///   - array: input array
+///   - k: the diagonal to extract or construct
+///   - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - ``diagonal(_:offset:axis1:axis2:stream:)``
+public func diag(_ array: MLXArray, k: Int = 0, stream: StreamOrDevice = .default) -> MLXArray {
+    MLXArray(mlx_diag(array.ctx, k.int32, stream.ctx))
+}
+
+/// Return specified diagonals.
+///
+/// If `array` is 2-D, then a 1-D array containing the diagonal at the given
+/// `offset` is returned.
+///
+/// If `array` has more than two dimensions, then `axis1` and `axis2`
+/// determine the 2D subarrays from which diagonals are extracted. The new
+/// shape is the original shape with `axis1` and `axis2` removed and a
+/// new dimension inserted at the end corresponding to the diagonal.
+///
+/// - Parameters:
+///   - array: input array
+///   - offset: offset of the diagonal.  Can be positive or negative
+///   - axis1: first axis of the 2-D sub-array from which the diagonals should be taken
+///   - axis2: second axis of the 2-D sub-array from which the diagonals should be taken
+///   - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - ``diag(_:k:stream:)``
+public func diagonal(
+    _ array: MLXArray, offset: Int = 0, axis1: Int = 0, axis2: Int = 1,
+    stream: StreamOrDevice = .default
+) -> MLXArray {
+    MLXArray(mlx_diagonal(array.ctx, offset.int32, axis1.int32, axis2.int32, stream.ctx))
+}
+
 /// Element-wise exponential.
 ///
 /// ### See Also
@@ -514,6 +562,11 @@ public func exp(_ array: MLXArray, stream: StreamOrDevice = .default) -> MLXArra
 }
 
 /// Flatten an array.
+///
+/// The axes flattened will be between `start` and `end`,
+/// inclusive. Negative axes are supported. After converting negative axis to
+/// positive, axes outside the valid range will be clamped to a valid value,
+/// `start` to `0` and `end` to `ndim - 1`.
 ///
 /// For example:
 ///
@@ -731,6 +784,7 @@ public func logSumExp(_ array: MLXArray, keepDims: Bool = false, stream: StreamO
 /// ### See Also
 /// - <doc:arithmetic>
 /// - ``multiply(_:_:stream:)``
+/// - ``addmm(_:_:_:alpha:beta:stream:)``
 /// - ``MLXArray/matmul(_:stream:)``
 public func matmul(_ a: MLXArray, _ b: MLXArray, stream: StreamOrDevice = .default) -> MLXArray {
     MLXArray(mlx_matmul(a.ctx, b.ctx, stream.ctx))

--- a/Source/MLX/Ops.swift
+++ b/Source/MLX/Ops.swift
@@ -35,6 +35,37 @@ public func add<A: ScalarOrArray, B: ScalarOrArray>(
     return MLXArray(mlx_add(a.ctx, b.ctx, stream.ctx))
 }
 
+/// Matrix multiplication with addition and optional scaling.
+///
+/// Perform the (possibly batched) matrix multiplication of two arrays and add to the result
+/// with optional scaling factors.
+///
+/// Equivalent to:
+///
+/// ```swift
+/// alpha * matmul(a, b) + beta * c
+/// ```
+///
+/// > Note the ordering of the parameters
+///
+/// - Parameters:
+///   - c: input array or scalar
+///   - a: input array or scalar
+///   - b: input array or scalar
+///   - alpha: optional scaling for the matrix product of `a` and `b`
+///   - beta: optional scaling factor for `c`
+///   - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - ``matmul(_:_:stream:)``
+public func addmm<A: ScalarOrArray, B: ScalarOrArray, C: ScalarOrArray>(
+    _ c: C, _ a: A, _ b: B, alpha: Float = 1.0, beta: Float = 1.0, stream: StreamOrDevice = .default
+) -> MLXArray {
+    let (a, b) = toArrays(a, b)
+    let (_, c) = toArrays(a, c)
+    return MLXArray(mlx_addmm(c.ctx, a.ctx, b.ctx, alpha, beta, stream.ctx))
+}
+
 /// Element-wise inverse cosine.
 ///
 /// - Parameters:
@@ -705,6 +736,37 @@ public func greaterEqual<A: ScalarOrArray, B: ScalarOrArray>(
 ) -> MLXArray {
     let (a, b) = toArrays(a, b)
     return MLXArray(mlx_greater_equal(a.ctx, b.ctx, stream.ctx))
+}
+
+/// Returns a boolean array where two arrays are element-wise equal within a tolerance.
+///
+/// Infinite values are considered equal if they have the same sign, NaN values are not equal unless
+/// `equalNAN` is `true`.
+///
+/// Two values are considered close if:
+///
+/// ```swift
+/// abs(a - b) <= (atol + rtol * abs(b))
+/// ```
+///
+/// Unlike ``arrayEqual(_:_:equalNAN:stream:)`` this function supports <doc:broadcasting>.
+///
+/// - Parameters:
+///   - a: input array
+///   - b: input array
+///   - rtol: relative tolerance (see discussion)
+///   - atol: absolute tolerance (see discussion)
+///   - equalNaN: if `true` treat NaN values as equal to each other
+///   - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - ``allClose(_:_:rtol:atol:equalNaN:stream:)``
+/// - ``arrayEqual(_:_:equalNAN:stream:)``
+public func isClose(
+    _ a: MLXArray, _ b: MLXArray, rtol: Double = 1e-5, atol: Double = 1e-8, equalNaN: Bool = false,
+    stream: StreamOrDevice = .default
+) -> MLXArray {
+    MLXArray(mlx_isclose(a.ctx, b.ctx, rtol, atol, equalNaN, stream.ctx))
 }
 
 /// Element-wise less than.

--- a/Source/MLXNN/Linear.swift
+++ b/Source/MLXNN/Linear.swift
@@ -107,9 +107,11 @@ open class Linear: Module, UnaryLayer {
     }
 
     open func callAsFunction(_ x: MLXArray) -> MLXArray {
-        var result = x.matmul(weight.T)
+        let result: MLXArray
         if let bias {
-            result = result + bias
+            result = addmm(bias, x, weight.T)
+        } else {
+            result = matmul(x, weight.T)
         }
         return result
     }


### PR DESCRIPTION
- this brings the MLXArray methods and free functions up to parity with mlx v0.3.0
	- addmm
	- diag
	- diagonal
	- isclose

- adopts fast.rope in RoPE
- adopts admm in Linear
- update documentation and fix any docs warnings

For comparison: https://github.com/ml-explore/mlx/compare/v0.0.10...v0.3.0