### PR TITLE
move documentation to swift package index

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -61,10 +61,12 @@ target_link_libraries(MLXFFT PRIVATE MLX)
 ```
 ## Other MLX Packages
 
-- [MLX](https://ml-explore.github.io/mlx-swift/MLX/documentation/mlx/)
-- [MLXRandom](https://ml-explore.github.io/mlx-swift/MLXRandom/documentation/mlxrandom/)
-- [MLXNN](https://ml-explore.github.io/mlx-swift/MLXNN/documentation/mlxnn/)
-- [MLXOptimizers](https://ml-explore.github.io/mlx-swift/MLXOptimizers/documentation/mlxoptimizers/)
+- [MLX](../mlx)
+- [MLXRandom](../mlxrandom)
+- [MLXNN](../mlxnn)
+- [MLXOptimizers](../mlxoptimizers)
+- [MLXFFT](../mlxfft)
+- [MLXLinalg](../mlxlinalg)
 
 - [Python `mlx`](https://ml-explore.github.io/mlx/build/html/index.html)
 ```
@@ -75,14 +77,10 @@ target_link_libraries(MLXFFT PRIVATE MLX)
 ## Other MLX Packages
 
 ...
-- [MLXFFT](https://ml-explore.github.io/mlx-swift/MLXFFT/documentation/mlxfft/)
+- [MLXFFT](../mlxfft/)
 ```
 
 8. Update README.md
-
-```
-[**Installation**](#installation) | [**MLX**](https://ml-explore.github.io/mlx-swift/MLX/documentation/mlx/) | ... | [**MLXFFT**](https://ml-explore.github.io/mlx-swift/MLXFFT/documentation/mlxfft/) | [**Examples**](#examples) 
-```
 
 ```
 dependencies: [.product(name: "MLX", package: "mlx-swift"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MLX Swift
 
-[**Installation**](#installation) | [**Documentation**](https://ml-explore.github.io/mlx-swift/MLX/documentation/mlx/) | [**Examples**](https://ml-explore.github.io/mlx-swift/MLX/documentation/mlx/examples)
+[**Installation**](#installation) | [**Documentation**](https://swiftpackageindex.com/ml-explore/mlx-swift/main/documentation/mlx) | [**Examples**](https://swiftpackageindex.com/ml-explore/mlx-swift/main/documentation/mlx/examples)
 
 MLX Swift is a Swift API for [MLX](https://ml-explore.github.io/mlx/build/html/index.html).
 
@@ -11,7 +11,7 @@ not for production deployment of models in apps.
 
 ## Examples
 
-MLX Swift has a [few examples](https://ml-explore.github.io/mlx-swift/MLX/documentation/mlx/examples), including:
+MLX Swift has a [few examples](https://swiftpackageindex.com/ml-explore/mlx-swift/main/documentation/mlx/examples), including:
 
 - Large-scale text generation with Mistral 7B
 - Training a simple multt-layer perceoptron on MNSIT
@@ -20,7 +20,7 @@ MLX Swift has a [few examples](https://ml-explore.github.io/mlx-swift/MLX/docume
 
 The ``MLX`` Swift package can be built and run from Xcode or SwiftPM. A CMake install is also provided. 
 
-More details are in the [documentation](https://ml-explore.github.io/mlx-swift/MLX/documentation/mlx/install).
+More details are in the [documentation](https://swiftpackageindex.com/ml-explore/mlx-swift/main/documentation/mlx/install).
 
 ### Xcode
 
@@ -76,7 +76,7 @@ ninja
 
 Check out the [contribution guidelines](CONTRIBUTING.md) for more information
 on contributing to MLX. See the
-[docs](https://ml-explore.github.io/mlx-swift/MLX/documentation/mlx/install) for more
+[docs](https://swiftpackageindex.com/ml-explore/mlx-swift/main/documentation/mlx/install) for more
 information on building from source, and running tests.
 
 We are grateful for all of [our

--- a/Source/MLX/Documentation.docc/MLX.md
+++ b/Source/MLX/Documentation.docc/MLX.md
@@ -36,12 +36,12 @@ are the CPU and GPU.
 
 ## Other MLX Packages
 
-- [MLX](../../../MLX/documentation/mlx/)
-- [MLXRandom](../../../MLXRandom/documentation/mlxrandom/)
-- [MLXNN](../../../MLXNN/documentation/mlxnn/)
-- [MLXOptimizers](../../../MLXOptimizers/documentation/mlxoptimizers/)
-- [MLXFFT](../../../MLXFFT/documentation/mlxfft/)
-- [MLXLinalg](../../../MLXLinalg/documentation/mlxlinalg/)
+- [MLX](../mlx)
+- [MLXRandom](../mlxrandom)
+- [MLXNN](../mlxnn)
+- [MLXOptimizers](../mlxoptimizers)
+- [MLXFFT](../mlxfft)
+- [MLXLinalg](../mlxlinalg)
 
 - [Python `mlx`](https://ml-explore.github.io/mlx/build/html/index.html)
 

--- a/Source/MLXFFT/Documentation.docc/MLXFFT.md
+++ b/Source/MLXFFT/Documentation.docc/MLXFFT.md
@@ -4,12 +4,12 @@ Fast Fourier Transform Functions
 
 ## Other MLX Packages
 
-- [MLX](../../../MLX/documentation/mlx/)
-- [MLXRandom](../../../MLXRandom/documentation/mlxrandom/)
-- [MLXNN](../../../MLXNN/documentation/mlxnn/)
-- [MLXOptimizers](../../../MLXOptimizers/documentation/mlxoptimizers/)
-- [MLXFFT](../../../MLXFFT/documentation/mlxfft/)
-- [MLXLinalg](../../../MLXLinalg/documentation/mlxlinalg/)
+- [MLX](../mlx)
+- [MLXRandom](../mlxrandom)
+- [MLXNN](../mlxnn)
+- [MLXOptimizers](../mlxoptimizers)
+- [MLXFFT](../mlxfft)
+- [MLXLinalg](../mlxlinalg)
 
 - [Python `mlx`](https://ml-explore.github.io/mlx/build/html/index.html)
 

--- a/Source/MLXLinalg/Documentation.docc/MLXLinalg.md
+++ b/Source/MLXLinalg/Documentation.docc/MLXLinalg.md
@@ -4,11 +4,11 @@ Linear Algebra Functions
 
 ## Other MLX Packages
 
-- [MLX](../../../MLX/documentation/mlx/)
-- [MLXRandom](../../../MLXRandom/documentation/mlxrandom/)
-- [MLXNN](../../../MLXNN/documentation/mlxnn/)
-- [MLXOptimizers](../../../MLXOptimizers/documentation/mlxoptimizers/)
-- [MLXFFT](../../../MLXFFT/documentation/mlxfft/)
-- [MLXLinalg](../../../MLXLinalg/documentation/mlxlinalg/)
+- [MLX](../mlx)
+- [MLXRandom](../mlxrandom)
+- [MLXNN](../mlxnn)
+- [MLXOptimizers](../mlxoptimizers)
+- [MLXFFT](../mlxfft)
+- [MLXLinalg](../mlxlinalg)
 
 - [Python `mlx`](https://ml-explore.github.io/mlx/build/html/index.html)

--- a/Source/MLXNN/Documentation.docc/MLXNN.md
+++ b/Source/MLXNN/Documentation.docc/MLXNN.md
@@ -43,12 +43,12 @@ See <doc:training>
 
 ## Other MLX Packages
 
-- [MLX](../../../MLX/documentation/mlx/)
-- [MLXRandom](../../../MLXRandom/documentation/mlxrandom/)
-- [MLXNN](../../../MLXNN/documentation/mlxnn/)
-- [MLXOptimizers](../../../MLXOptimizers/documentation/mlxoptimizers/)
-- [MLXFFT](../../../MLXFFT/documentation/mlxfft/)
-- [MLXLinalg](../../../MLXLinalg/documentation/mlxlinalg/)
+- [MLX](../mlx)
+- [MLXRandom](../mlxrandom)
+- [MLXNN](../mlxnn)
+- [MLXOptimizers](../mlxoptimizers)
+- [MLXFFT](../mlxfft)
+- [MLXLinalg](../mlxlinalg)
 
 - [Python `mlx`](https://ml-explore.github.io/mlx/build/html/index.html)
 

--- a/Source/MLXOptimizers/Documentation.docc/MLXOptimizers.md
+++ b/Source/MLXOptimizers/Documentation.docc/MLXOptimizers.md
@@ -31,12 +31,12 @@ for _ in 0 ..< epochs {
 
 ## Other MLX Packages
 
-- [MLX](../../../MLX/documentation/mlx/)
-- [MLXRandom](../../../MLXRandom/documentation/mlxrandom/)
-- [MLXNN](../../../MLXNN/documentation/mlxnn/)
-- [MLXOptimizers](../../../MLXOptimizers/documentation/mlxoptimizers/)
-- [MLXFFT](../../../MLXFFT/documentation/mlxfft/)
-- [MLXLinalg](../../../MLXLinalg/documentation/mlxlinalg/)
+- [MLX](../mlx)
+- [MLXRandom](../mlxrandom)
+- [MLXNN](../mlxnn)
+- [MLXOptimizers](../mlxoptimizers)
+- [MLXFFT](../mlxfft)
+- [MLXLinalg](../mlxlinalg)
 
 - [Python `mlx`](https://ml-explore.github.io/mlx/build/html/index.html)
 

--- a/Source/MLXRandom/Documentation.docc/MLXRandom.md
+++ b/Source/MLXRandom/Documentation.docc/MLXRandom.md
@@ -27,12 +27,12 @@ splittable version of Threefry, which is a counter-based PRNG.
 
 ## Other MLX Packages
 
-- [MLX](../../../MLX/documentation/mlx/)
-- [MLXRandom](../../../MLXRandom/documentation/mlxrandom/)
-- [MLXNN](../../../MLXNN/documentation/mlxnn/)
-- [MLXOptimizers](../../../MLXOptimizers/documentation/mlxoptimizers/)
-- [MLXFFT](../../../MLXFFT/documentation/mlxfft/)
-- [MLXLinalg](../../../MLXLinalg/documentation/mlxlinalg/)
+- [MLX](../mlx)
+- [MLXRandom](../mlxrandom)
+- [MLXNN](../mlxnn)
+- [MLXOptimizers](../mlxoptimizers)
+- [MLXFFT](../mlxfft)
+- [MLXLinalg](../mlxlinalg)
 
 - [Python `mlx`](https://ml-explore.github.io/mlx/build/html/index.html)
 


### PR DESCRIPTION
- documentation is at https://swiftpackageindex.com/ml-explore/mlx-swift/main/documentation/mlxrandom
- this is built daily
- fix the links between packages for their directory layout
