### PR TITLE
fix support for bfloat16, complex64

### DIFF
--- a/Source/MLX/Documentation.docc/Organization/initialization.md
+++ b/Source/MLX/Documentation.docc/Organization/initialization.md
@@ -202,6 +202,7 @@ let c = r + i.asImaginary()
 - ``MLXArray/init(_:)-10m``
 - ``MLXArray/init(_:)-96nyv``
 - ``MLXArray/init(_:dtype:)``
+- ``MLXArray/init(bfloat16:)``
 
 ### MLXArray Int Overrides
 

--- a/Source/MLX/MLXArray+Init.swift
+++ b/Source/MLX/MLXArray+Init.swift
@@ -103,6 +103,23 @@ extension MLXArray {
             })
     }
 
+    /// Initalizer allowing creation of scalar (0-dimension) `MLXArray` with a ``DType/bfloat16``
+    /// from a ``Float32``.
+    ///
+    /// ```swift
+    /// let a = MLXArray(bfloat16: 35)
+    /// ```
+    ///
+    /// ### See Also
+    /// - <doc:initialization>
+    public convenience init(bfloat16 value: Float32) {
+        let stream = StreamOrDevice.default
+        let v_mlx = mlx_array_from_float(Float32(value))!
+        defer { mlx_free(v_mlx) }
+        let v_bfloat = mlx_astype(v_mlx, DType.bfloat16.cmlxDtype, stream.ctx)!
+        self.init(v_bfloat)
+    }
+
     /// Initalizer allowing creation of scalar (0-dimension) `MLXArray` from a `HasDType` value
     /// with a conversion to a given ``DType``.
     ///
@@ -160,8 +177,10 @@ extension MLXArray {
                 #endif
                 case .float32:
                     self.init(Float32(v))
-                case .bfloat16, .complex64:
-                    fatalError("dtype \(dtype) not supported")
+                case .bfloat16:
+                    self.init(bfloat16: Float32(v))
+                case .complex64:
+                    self.init(real: Float32(v), imaginary: 0)
                 }
 
             } else if let v = value as? (any BinaryInteger) {
@@ -194,8 +213,10 @@ extension MLXArray {
                 #endif
                 case .float32:
                     self.init(Float32(v))
-                case .bfloat16, .complex64:
-                    fatalError("dtype \(dtype) not supported")
+                case .bfloat16:
+                    self.init(bfloat16: Float32(v))
+                case .complex64:
+                    self.init(real: Float32(v), imaginary: 0)
                 }
 
             } else {

--- a/Tests/MLXTests/MLXArray+OpsTests.swift
+++ b/Tests/MLXTests/MLXArray+OpsTests.swift
@@ -1,6 +1,7 @@
 // Copyright © 2024 Apple Inc.
 
 import Foundation
+import Numerics
 import XCTest
 
 @testable import MLX
@@ -133,6 +134,41 @@ class MLXArrayOpsTests: XCTestCase {
 
         XCTAssertEqual((x * 15.5).dtype, .float16)
         XCTAssertEqual((15.5 * x).dtype, .float16)
+    }
+
+    public func testBFloat16() {
+        let x = MLXArray([1, 5, 9]).asType(.bfloat16)
+        let y = x * x
+        XCTAssertEqual(y.dtype, .bfloat16)
+
+        // this will convert the 3 to bfloat16 via init<T: HasDType>(_ value: T, dtype: DType)
+        let z = (y + 3).sum()
+        XCTAssertEqual(z.dtype, .bfloat16)
+
+        // read out the value as a usable type
+        let r1 = z.item(Float32.self)
+        XCTAssertEqual(r1, 116)
+
+        let r2 = z.asArray(Float.self)
+        XCTAssertEqual(r2, [116])
+    }
+
+    public func testComplexPromote() {
+        let x = MLXArray(Complex(3, 4))
+        let y = x * x
+        XCTAssertEqual(y.dtype, .complex64)
+
+        // this will convert the 3 to (3, 0i) via init<T: HasDType>(_ value: T, dtype: DType)
+        let z = y + 3
+        XCTAssertEqual(z.dtype, .complex64)
+
+        // read out as complex
+        let r1 = z.item(Complex.self)
+        XCTAssertEqual(r1, Complex(-4, 24))
+
+        // read out the value as a usable type
+        let r2 = z.asArray(Complex.self)
+        XCTAssertEqual(r2, [Complex(-4, 24)])
     }
 
 }


### PR DESCRIPTION
- allow array + 3 where array is either bfloat16 or complex64
- allow read out with item() and asArray()

I ran into this when trying different LLM models