### PR TITLE
fix for cross-package links in SPI

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -61,12 +61,12 @@ target_link_libraries(MLXFFT PRIVATE MLX)
 ```
 ## Other MLX Packages
 
-- [MLX](../mlx)
-- [MLXRandom](../mlxrandom)
-- [MLXNN](../mlxnn)
-- [MLXOptimizers](../mlxoptimizers)
-- [MLXFFT](../mlxfft)
-- [MLXLinalg](../mlxlinalg)
+- [MLX](mlx)
+- [MLXRandom](mlxrandom)
+- [MLXNN](mlxnn)
+- [MLXOptimizers](mlxoptimizers)
+- [MLXFFT](mlxfft)
+- [MLXLinalg](mlxlinalg)
 
 - [Python `mlx`](https://ml-explore.github.io/mlx/build/html/index.html)
 ```

--- a/Source/MLX/Documentation.docc/MLX.md
+++ b/Source/MLX/Documentation.docc/MLX.md
@@ -36,12 +36,12 @@ are the CPU and GPU.
 
 ## Other MLX Packages
 
-- [MLX](../mlx)
-- [MLXRandom](../mlxrandom)
-- [MLXNN](../mlxnn)
-- [MLXOptimizers](../mlxoptimizers)
-- [MLXFFT](../mlxfft)
-- [MLXLinalg](../mlxlinalg)
+- [MLX](mlx)
+- [MLXRandom](mlxrandom)
+- [MLXNN](mlxnn)
+- [MLXOptimizers](mlxoptimizers)
+- [MLXFFT](mlxfft)
+- [MLXLinalg](mlxlinalg)
 
 - [Python `mlx`](https://ml-explore.github.io/mlx/build/html/index.html)
 

--- a/Source/MLXFFT/Documentation.docc/MLXFFT.md
+++ b/Source/MLXFFT/Documentation.docc/MLXFFT.md
@@ -4,12 +4,12 @@ Fast Fourier Transform Functions
 
 ## Other MLX Packages
 
-- [MLX](../mlx)
-- [MLXRandom](../mlxrandom)
-- [MLXNN](../mlxnn)
-- [MLXOptimizers](../mlxoptimizers)
-- [MLXFFT](../mlxfft)
-- [MLXLinalg](../mlxlinalg)
+- [MLX](mlx)
+- [MLXRandom](mlxrandom)
+- [MLXNN](mlxnn)
+- [MLXOptimizers](mlxoptimizers)
+- [MLXFFT](mlxfft)
+- [MLXLinalg](mlxlinalg)
 
 - [Python `mlx`](https://ml-explore.github.io/mlx/build/html/index.html)
 

--- a/Source/MLXLinalg/Documentation.docc/MLXLinalg.md
+++ b/Source/MLXLinalg/Documentation.docc/MLXLinalg.md
@@ -4,11 +4,11 @@ Linear Algebra Functions
 
 ## Other MLX Packages
 
-- [MLX](../mlx)
-- [MLXRandom](../mlxrandom)
-- [MLXNN](../mlxnn)
-- [MLXOptimizers](../mlxoptimizers)
-- [MLXFFT](../mlxfft)
-- [MLXLinalg](../mlxlinalg)
+- [MLX](mlx)
+- [MLXRandom](mlxrandom)
+- [MLXNN](mlxnn)
+- [MLXOptimizers](mlxoptimizers)
+- [MLXFFT](mlxfft)
+- [MLXLinalg](mlxlinalg)
 
 - [Python `mlx`](https://ml-explore.github.io/mlx/build/html/index.html)

--- a/Source/MLXNN/Documentation.docc/MLXNN.md
+++ b/Source/MLXNN/Documentation.docc/MLXNN.md
@@ -43,12 +43,12 @@ See <doc:training>
 
 ## Other MLX Packages
 
-- [MLX](../mlx)
-- [MLXRandom](../mlxrandom)
-- [MLXNN](../mlxnn)
-- [MLXOptimizers](../mlxoptimizers)
-- [MLXFFT](../mlxfft)
-- [MLXLinalg](../mlxlinalg)
+- [MLX](mlx)
+- [MLXRandom](mlxrandom)
+- [MLXNN](mlxnn)
+- [MLXOptimizers](mlxoptimizers)
+- [MLXFFT](mlxfft)
+- [MLXLinalg](mlxlinalg)
 
 - [Python `mlx`](https://ml-explore.github.io/mlx/build/html/index.html)
 

--- a/Source/MLXOptimizers/Documentation.docc/MLXOptimizers.md
+++ b/Source/MLXOptimizers/Documentation.docc/MLXOptimizers.md
@@ -31,12 +31,12 @@ for _ in 0 ..< epochs {
 
 ## Other MLX Packages
 
-- [MLX](../mlx)
-- [MLXRandom](../mlxrandom)
-- [MLXNN](../mlxnn)
-- [MLXOptimizers](../mlxoptimizers)
-- [MLXFFT](../mlxfft)
-- [MLXLinalg](../mlxlinalg)
+- [MLX](mlx)
+- [MLXRandom](mlxrandom)
+- [MLXNN](mlxnn)
+- [MLXOptimizers](mlxoptimizers)
+- [MLXFFT](mlxfft)
+- [MLXLinalg](mlxlinalg)
 
 - [Python `mlx`](https://ml-explore.github.io/mlx/build/html/index.html)
 

--- a/Source/MLXRandom/Documentation.docc/MLXRandom.md
+++ b/Source/MLXRandom/Documentation.docc/MLXRandom.md
@@ -27,12 +27,12 @@ splittable version of Threefry, which is a counter-based PRNG.
 
 ## Other MLX Packages
 
-- [MLX](../mlx)
-- [MLXRandom](../mlxrandom)
-- [MLXNN](../mlxnn)
-- [MLXOptimizers](../mlxoptimizers)
-- [MLXFFT](../mlxfft)
-- [MLXLinalg](../mlxlinalg)
+- [MLX](mlx)
+- [MLXRandom](mlxrandom)
+- [MLXNN](mlxnn)
+- [MLXOptimizers](mlxoptimizers)
+- [MLXFFT](mlxfft)
+- [MLXLinalg](mlxlinalg)
 
 - [Python `mlx`](https://ml-explore.github.io/mlx/build/html/index.html)
 


### PR DESCRIPTION
- the links need to go from https://swiftpackageindex.com/ml-explore/mlx-swift/main/documentation/mlxrandom
- to https://swiftpackageindex.com/ml-explore/mlx-swift/main/documentation/mlx
- the last path component is basically a filename so we need something like this:

- [MLX](mlx)
- [MLXRandom](mlxrandom)

Note: this won't work if you hit https://swiftpackageindex.com/ml-explore/mlx-swift/main/documentation/mlx/ (trailing slash).  If we run in to problems with this we can try an absolute domain relative path next.