### PR TITLE
changes based on recent feedback

### DIFF
--- a/Source/MLX/Documentation.docc/Articles/converting-python.md
+++ b/Source/MLX/Documentation.docc/Articles/converting-python.md
@@ -214,7 +214,7 @@ This is a mapping of `mx` free functions to their ``MLX`` counterparts.
 `quantized_matmul` | ``MLX/quantizedMatmul(_:_:scales:biases:transpose:groupSize:bits:stream:)``
 `reciprocal` | ``MLX/reciprocal(_:stream:)``
 `remainder` | ``MLX/remainder(_:_:stream:)``
-`repeat` | ``MLX/repeat(_:count:axis:stream:)``
+`repeat` | ``MLX/repeated(_:count:axis:stream:)``
 `reshape` | ``MLX/reshaped(_:_:stream:)-5x3y0``
 `round` | ``MLX/round(_:decimals:stream:)``
 `rsqrt` | ``MLX/rsqrt(_:stream:)``

--- a/Source/MLX/Documentation.docc/Organization/arithmetic.md
+++ b/Source/MLX/Documentation.docc/Organization/arithmetic.md
@@ -184,4 +184,4 @@ Note: the `-` and `/` operators are not able to be linked here.
 - ``inner(_:_:stream:)``
 - ``outer(_:_:stream:)``
 - ``tensordot(_:_:axes:stream:)-3qkgq``
-- ``tensordot(_:_:axes:stream:)-6gt4h``
+- ``tensordot(_:_:axes:stream:)-8yqyi``

--- a/Source/MLX/Documentation.docc/Organization/initialization.md
+++ b/Source/MLX/Documentation.docc/Organization/initialization.md
@@ -244,6 +244,8 @@ there are specific initializers to request it:
 - ``MLXArray/identity(_:type:stream:)``
 - ``MLXArray/linspace(_:_:count:stream:)-92x6l``
 - ``MLXArray/linspace(_:_:count:stream:)-7m7eg``
+- ``MLXArray/repeated(_:count:axis:stream:)``
+- ``MLXArray/repeated(_:count:stream:)``
 - ``MLXArray/repeat(_:count:axis:stream:)``
 - ``MLXArray/repeat(_:count:stream:)``
 - ``MLXArray/tri(_:m:k:type:stream:)``
@@ -260,6 +262,8 @@ there are specific initializers to request it:
 - ``MLX/identity(_:type:stream:)``
 - ``MLX/linspace(_:_:count:stream:)-7vj0o``
 - ``MLX/linspace(_:_:count:stream:)-6w959``
+- ``MLXArray/repeated(_:count:axis:stream:)``
+- ``MLXArray/repeated(_:count:stream:)``
 - ``MLX/repeat(_:count:axis:stream:)``
 - ``MLX/repeat(_:count:stream:)``
 - ``MLX/tri(_:m:k:type:stream:)``

--- a/Source/MLX/Documentation.docc/free-functions.md
+++ b/Source/MLX/Documentation.docc/free-functions.md
@@ -107,6 +107,8 @@ operations as methods for convenience.
 - ``MLX/identity(_:type:stream:)``
 - ``MLX/linspace(_:_:count:stream:)-7vj0o``
 - ``MLX/linspace(_:_:count:stream:)-6w959``
+- ``MLX/repeated(_:count:axis:stream:)``
+- ``MLX/repeated(_:count:stream:)``
 - ``MLX/repeat(_:count:axis:stream:)``
 - ``MLX/repeat(_:count:stream:)``
 - ``MLX/tri(_:m:k:type:stream:)``

--- a/Source/MLX/Factory.swift
+++ b/Source/MLX/Factory.swift
@@ -186,7 +186,7 @@ extension MLXArray {
     /// ### See Also
     /// - <doc:initialization>
     /// - ``full(_:values:stream:)``
-    /// - ``repeat(_:count:axis:stream:)``
+    /// - ``repeated(_:count:axis:stream:)``
     static public func full<T: HasDType>(
         _ shape: [Int], values: MLXArray, type: T.Type, stream: StreamOrDevice = .default
     ) -> MLXArray {
@@ -213,7 +213,7 @@ extension MLXArray {
     /// ### See Also
     /// - <doc:initialization>
     /// - ``full(_:values:type:stream:)``
-    /// - ``repeat(_:count:axis:stream:)``
+    /// - ``repeated(_:count:axis:stream:)``
     static public func full(_ shape: [Int], values: MLXArray, stream: StreamOrDevice = .default)
         -> MLXArray
     {
@@ -296,11 +296,41 @@ extension MLXArray {
 
     /// Repeat an array along a specified axis.
     ///
+    /// > Deprected in favor of the more consistently named ``repeated(_:count:axis:stream:)``
+    ///
+    /// ### See Also
+    /// - <doc:initialization>
+    /// - ``repeated(_:count:stream:)``
+    /// - ``full(_:values:stream:)``
+    @available(*, deprecated, renamed: "repeated(_:count:axis:stream:)")
+    static public func `repeat`(
+        _ array: MLXArray, count: Int, axis: Int, stream: StreamOrDevice = .default
+    ) -> MLXArray {
+        MLXArray(mlx_repeat(array.ctx, count.int32, axis.int32, stream.ctx))
+    }
+
+    /// Repeat a flattened array along axis 0.
+    ///
+    /// > Deprected in favor of the more consistently named ``repeated(_:count:stream:)``
+    ///
+    /// ### See Also
+    /// - <doc:initialization>
+    /// - ``repeated(_:count:axis:stream:)``
+    /// - ``full(_:values:stream:)``
+    @available(*, deprecated, renamed: "repeated(_:count:stream:)")
+    static public func `repeat`(_ array: MLXArray, count: Int, stream: StreamOrDevice = .default)
+        -> MLXArray
+    {
+        MLXArray(mlx_repeat_all(array.ctx, count.int32, stream.ctx))
+    }
+
+    /// Repeat an array along a specified axis.
+    ///
     /// Example:
     ///
     /// ```swift
     /// // repeat a [2, 2] array 4 times along axis 1
-    /// let r = MLXArray.repeat(MLXArray(0 ..< 4, [2, 2]), count: 4, axis: 1)
+    /// let r = MLXArray.repeated(MLXArray(0 ..< 4, [2, 2]), count: 4, axis: 1)
     /// ```
     ///
     /// - Parameters:
@@ -311,9 +341,9 @@ extension MLXArray {
     ///
     /// ### See Also
     /// - <doc:initialization>
-    /// - ``repeat(_:count:stream:)``
+    /// - ``repeated(_:count:stream:)``
     /// - ``full(_:values:stream:)``
-    static public func `repeat`(
+    static public func repeated(
         _ array: MLXArray, count: Int, axis: Int, stream: StreamOrDevice = .default
     ) -> MLXArray {
         MLXArray(mlx_repeat(array.ctx, count.int32, axis.int32, stream.ctx))
@@ -325,7 +355,7 @@ extension MLXArray {
     ///
     /// ```swift
     /// // repeat a 4 element array 4 times along axis 0
-    /// let r = MLXArray.repeat(MLXArray(0 ..< 4, [2, 2]), count: 4)
+    /// let r = MLXArray.repeated(MLXArray(0 ..< 4, [2, 2]), count: 4)
     /// ```
     ///
     /// - Parameters:
@@ -335,9 +365,9 @@ extension MLXArray {
     ///
     /// ### See Also
     /// - <doc:initialization>
-    /// - ``repeat(_:count:axis:stream:)``
+    /// - ``repeated(_:count:axis:stream:)``
     /// - ``full(_:values:stream:)``
-    static public func `repeat`(_ array: MLXArray, count: Int, stream: StreamOrDevice = .default)
+    static public func repeated(_ array: MLXArray, count: Int, stream: StreamOrDevice = .default)
         -> MLXArray
     {
         MLXArray(mlx_repeat_all(array.ctx, count.int32, stream.ctx))
@@ -505,7 +535,7 @@ public func eye<T: HasDType>(
 /// ### See Also
 /// - <doc:initialization>
 /// - ``full(_:values:stream:)``
-/// - ``repeat(_:count:axis:stream:)``
+/// - ``repeated(_:count:axis:stream:)``
 public func full<T: HasDType>(
     _ shape: [Int], values: MLXArray, type: T.Type, stream: StreamOrDevice = .default
 ) -> MLXArray {
@@ -532,7 +562,7 @@ public func full<T: HasDType>(
 /// ### See Also
 /// - <doc:initialization>
 /// - ``full(_:values:type:stream:)``
-/// - ``repeat(_:count:axis:stream:)``
+/// - ``repeated(_:count:axis:stream:)``
 public func full(_ shape: [Int], values: MLXArray, stream: StreamOrDevice = .default) -> MLXArray {
     MLXArray(mlx_full(shape.asInt32, shape.count, values.ctx, values.dtype.cmlxDtype, stream.ctx))
 }
@@ -610,11 +640,39 @@ public func linspace<T: HasDType>(
 
 /// Repeat an array along a specified axis.
 ///
+/// > Deprected in favor of the more consistently named ``repeated(_:count:axis:stream:)``
+///
+/// ### See Also
+/// - <doc:initialization>
+/// - ``repeated(_:count:stream:)``
+/// - ``full(_:values:stream:)``
+@available(*, deprecated, renamed: "repeated(_:count:axis:stream:)")
+public func `repeat`(_ array: MLXArray, count: Int, axis: Int, stream: StreamOrDevice = .default)
+    -> MLXArray
+{
+    MLXArray(mlx_repeat(array.ctx, count.int32, axis.int32, stream.ctx))
+}
+
+/// Repeat a flattened array along axis 0.
+///
+/// > Deprected in favor of the more consistently named ``repeated(_:count:stream:)``
+///
+/// ### See Also
+/// - <doc:initialization>
+/// - ``repeated(_:count:axis:stream:)``
+/// - ``full(_:values:stream:)``
+@available(*, deprecated, renamed: "repeated(_:count:stream:)")
+public func `repeat`(_ array: MLXArray, count: Int, stream: StreamOrDevice = .default) -> MLXArray {
+    MLXArray(mlx_repeat_all(array.ctx, count.int32, stream.ctx))
+}
+
+/// Repeat an array along a specified axis.
+///
 /// Example:
 ///
 /// ```swift
 /// // repeat a [2, 2] array 4 times along axis 1
-/// let r = MLXArray.repeat(MLXArray(0 ..< 4, [2, 2]), count: 4, axis: 1)
+/// let r = MLXArray.repeated(MLXArray(0 ..< 4, [2, 2]), count: 4, axis: 1)
 /// ```
 ///
 /// - Parameters:
@@ -625,9 +683,9 @@ public func linspace<T: HasDType>(
 ///
 /// ### See Also
 /// - <doc:initialization>
-/// - ``repeat(_:count:stream:)``
+/// - ``repeated(_:count:stream:)``
 /// - ``full(_:values:stream:)``
-public func `repeat`(_ array: MLXArray, count: Int, axis: Int, stream: StreamOrDevice = .default)
+public func repeated(_ array: MLXArray, count: Int, axis: Int, stream: StreamOrDevice = .default)
     -> MLXArray
 {
     MLXArray(mlx_repeat(array.ctx, count.int32, axis.int32, stream.ctx))
@@ -639,7 +697,7 @@ public func `repeat`(_ array: MLXArray, count: Int, axis: Int, stream: StreamOrD
 ///
 /// ```swift
 /// // repeat a 4 element array 4 times along axis 0
-/// let r = MLXArray.repeat(MLXArray(0 ..< 4, [2, 2]), count: 4)
+/// let r = MLXArray.repeated(MLXArray(0 ..< 4, [2, 2]), count: 4)
 /// ```
 ///
 /// - Parameters:
@@ -649,9 +707,9 @@ public func `repeat`(_ array: MLXArray, count: Int, axis: Int, stream: StreamOrD
 ///
 /// ### See Also
 /// - <doc:initialization>
-/// - ``repeat(_:count:axis:stream:)``
+/// - ``repeated(_:count:axis:stream:)``
 /// - ``full(_:values:stream:)``
-public func `repeat`(_ array: MLXArray, count: Int, stream: StreamOrDevice = .default) -> MLXArray {
+public func repeated(_ array: MLXArray, count: Int, stream: StreamOrDevice = .default) -> MLXArray {
     MLXArray(mlx_repeat_all(array.ctx, count.int32, stream.ctx))
 }
 

--- a/Source/MLX/Ops.swift
+++ b/Source/MLX/Ops.swift
@@ -27,7 +27,7 @@ func broadcast(arrays: [MLXArray], stream: StreamOrDevice = .default) -> [MLXArr
 /// let b = MLXArray([4, 5, 6])
 ///
 /// // equivalent to a + b + 7
-/// let r = sum(sum(a, b), 7)
+/// let r = add(add(a, b), 7)
 /// ```
 ///
 /// - Parameters:

--- a/Source/MLX/Ops.swift
+++ b/Source/MLX/Ops.swift
@@ -20,6 +20,16 @@ func broadcast(arrays: [MLXArray], stream: StreamOrDevice = .default) -> [MLXArr
 ///
 /// Add two arrays with <doc:broadcasting>.
 ///
+/// For example:
+///
+/// ```swift
+/// let a = MLXArray(0 ..< 12, [4, 3])
+/// let b = MLXArray([4, 5, 6])
+///
+/// // equivalent to a + b + 7
+/// let r = sum(sum(a, b), 7)
+/// ```
+///
 /// - Parameters:
 ///     - a: the left hand side array
 ///     - b: the right hand side array

--- a/Source/MLXNN/Linear.swift
+++ b/Source/MLXNN/Linear.swift
@@ -96,6 +96,16 @@ open class Linear: Module, UnaryLayer {
         super.init()
     }
 
+    /// Convenience initializer giving parameter names.
+    ///
+    /// - Parameters:
+    ///   - inputDimensions: number of input dimensions
+    ///   - outputDimensions: number of output dimensions
+    ///   - bias: if `true` this layer will apply a bias
+    convenience init(inputDimensions: Int, outputDimensions: Int, bias: Bool = true) {
+        self.init(inputDimensions, outputDimensions, bias: bias)
+    }
+
     internal init(weight: MLXArray, bias: MLXArray? = nil) {
         self.weight = weight
         self.bias = bias


### PR DESCRIPTION
- rename repeat -> repeated (swift consistency), deprecate repeat()
- add variant of Linear initializer with parameter names