### PR TITLE
Use write mode when calling `save(arrays`

### DIFF
--- a/Source/MLX/Ops.swift
+++ b/Source/MLX/Ops.swift
@@ -1576,7 +1576,7 @@ public func save(
 
     switch url.pathExtension {
     case "safetensors":
-        if let fp = fopen(path, "r") {
+        if let fp = fopen(path, "w") {
             defer { fclose(fp) }
 
             mlx_save_safetensors_file(fp, mlx_arrays, mlx_metadata)


### PR DESCRIPTION
I noticed that the fopen call in `save(arrays` was using read mode, because of which the saving was failing. I changed it to "w" to match the other save methods. I did verify this fixes saving.

Given this is a system call, I wasn't sure how to unit test this. If there are any recommendations, let me know, will be happy to add tests.