### PR TITLE
Updates in support of stable-diffusion

### DIFF
--- a/Source/MLX/Documentation.docc/Articles/converting-python.md
+++ b/Source/MLX/Documentation.docc/Articles/converting-python.md
@@ -69,7 +69,7 @@ Note: some of the symbols are not linkable.
 `ndim` | ``MLXArray/ndim``
 `itemsize` | ``MLXArray/itemSize``
 `nbytes` | ``MLXArray/nbytes``
-`shape` | ``MLXArray/shape``
+`shape` | ``MLXArray/shape`` or ``MLXArray/shape2`` ... ``MLXArray/shape4`` (destructuring)
 `dtype` | ``MLXArray/dtype``
 `item` | ``MLXArray/item(_:)``
 `tolist` | ``MLXArray/asArray(_:)``
@@ -122,7 +122,7 @@ Note: some of the symbols are not linkable.
 `round` | ``MLXArray/round(decimals:stream:)``
 `rsqrt` | ``MLXArray/rsqrt(stream:)``
 `sin` | ``MLXArray/sin(stream:)``
-`split` | ``MLXArray/split(parts:axis:stream:)``
+`split` | ``MLXArray/split(parts:axis:stream:)`` or ``MLXArray/split(axis:stream:)`` (destructuring)
 `sqrt` | ``MLXArray/sqrt(stream:)``
 `square` | ``MLXArray/square(stream:)``
 `squeeze` | ``MLXArray/squeezed(axes:stream:)``

--- a/Source/MLX/Documentation.docc/Organization/conversion.md
+++ b/Source/MLX/Documentation.docc/Organization/conversion.md
@@ -11,6 +11,7 @@ MLX has several functions to support converting between ``DType``:
 - ``MLXArray/asType(_:stream:)-4eqoc``
 - ``MLXArray/asType(_:stream:)-6d44y``
 - ``MLXArray/asArray(_:)``
+- ``MLXArray/asData(noCopy:)``
 - ``MLXArray/asImaginary(stream:)``
 - ``MLXArray/imaginaryPart(stream:)``
 - ``MLXArray/realPart(stream:)``

--- a/Source/MLX/Documentation.docc/Organization/shapes.md
+++ b/Source/MLX/Documentation.docc/Organization/shapes.md
@@ -13,6 +13,9 @@ will moves rows and columns as they modify the shape.
 ### Reading Shapes
 
 - ``MLXArray/shape``
+- ``MLXArray/shape2``
+- ``MLXArray/shape3``
+- ``MLXArray/shape4``
 - ``MLXArray/dim(_:)``
 
 ### MLXArray Shape Methods (Same Size)
@@ -46,6 +49,7 @@ These methods manipulate the shape and contents of the array:
 - ``MLXArray/movedAxis(source:destination:stream:)``
 - ``MLXArray/split(parts:axis:stream:)``
 - ``MLXArray/split(indices:axis:stream:)``
+- ``MLXArray/split(axis:stream:)``
 - ``MLXArray/swappedAxes(_:_:stream:)``
 - ``MLXArray/transposed(stream:)``
 - ``MLXArray/transposed(axis:stream:)``
@@ -64,6 +68,7 @@ These methods manipulate the shape and contents of the array:
 - ``padded(_:widths:value:stream:)``
 - ``split(_:indices:axis:stream:)``
 - ``split(_:parts:axis:stream:)``
+- ``split(_:axis:stream:)``
 - ``stacked(_:axis:stream:)``
 - ``swappedAxes(_:_:_:stream:)``
 - ``tiled(_:repetitions:stream:)-72ntc``

--- a/Source/MLX/Documentation.docc/free-functions.md
+++ b/Source/MLX/Documentation.docc/free-functions.md
@@ -171,6 +171,7 @@ operations as methods for convenience.
 - ``reshaped(_:_:stream:)-96lgr``
 - ``split(_:indices:axis:stream:)``
 - ``split(_:parts:axis:stream:)``
+- ``split(_:axis:stream:)``
 - ``squeezed(_:stream:)``
 - ``squeezed(_:axis:stream:)``
 - ``squeezed(_:axes:stream:)``

--- a/Source/MLX/Documentation.docc/troubleshooting.md
+++ b/Source/MLX/Documentation.docc/troubleshooting.md
@@ -38,6 +38,13 @@ to the build directory.
 Note: applications will link the `MLX` and `Cmlx` libraries which will automatically
 provide access to the metal libraries as a resource of your application.
 
+[mlx-swift-examples](https://github.com/ml-explore/mlx-swift-examples) contains a wrapper script, `mlx-run`
+that can be used to run the example command line tools:
+
+```
+./mlx-run llm-tool --help
+```
+
 ## Building
 
 Specific build issues you may encounter.

--- a/Source/MLX/MLXArray+Ops.swift
+++ b/Source/MLX/MLXArray+Ops.swift
@@ -2049,12 +2049,38 @@ extension MLXArray {
     ///
     /// ### See Also
     /// - <doc:shapes>
+    /// - ``split(axis:stream:)``
     /// - ``split(indices:axis:stream:)``
     /// - ``split(_:parts:axis:stream:)``
     public func split(parts: Int, axis: Int = 0, stream: StreamOrDevice = .default) -> [MLXArray] {
         let vec = mlx_split_equal_parts(ctx, parts.int32, axis.int32, stream.ctx)!
         defer { mlx_free(vec) }
         return mlx_vector_array_values(vec)
+    }
+
+    /// Split an array into 2 pieces along an axis and returns a tuple -- convenient for destructuring.
+    ///
+    /// Splits the array into 2 pieces along a given axis and returns an tuple of `MLXArray`:
+    ///
+    /// ```swift
+    /// let array = MLXArray(0 ..< 12, (4, 3))
+    ///
+    /// let (a, b) = array.split()
+    /// ```
+    ///
+    /// - Parameters:
+    ///     - axis: axis to split along
+    ///
+    /// ### See Also
+    /// - <doc:shapes>
+    /// - ``split(parts:axis:stream:)``
+    /// - ``split(indices:axis:stream:)``
+    /// - ``split(_:parts:axis:stream:)``
+    public func split(axis: Int = 0, stream: StreamOrDevice = .default) -> (MLXArray, MLXArray) {
+        let vec = mlx_split_equal_parts(ctx, 2, axis.int32, stream.ctx)!
+        defer { mlx_free(vec) }
+        let pieces = mlx_vector_array_values(vec)
+        return (pieces[0], pieces[1])
     }
 
     /// Split an array along a given axis.

--- a/Source/MLX/Ops+Array.swift
+++ b/Source/MLX/Ops+Array.swift
@@ -1262,7 +1262,7 @@ public func sin(_ array: MLXArray, stream: StreamOrDevice = .default) -> MLXArra
 /// ```swift
 /// let array = MLXArray(0 ..< 12, (4, 3))
 ///
-/// let halves = array.split(2)
+/// let halves = split(array, 2)
 /// print(halves)
 ///
 /// [array([[0, 1, 2],
@@ -1278,6 +1278,7 @@ public func sin(_ array: MLXArray, stream: StreamOrDevice = .default) -> MLXArra
 ///
 /// ### See Also
 /// - <doc:shapes>
+/// - ``split(_:parts:axis:stream:)``
 /// - ``split(_:indices:axis:stream:)``
 /// - ``MLXArray/split(parts:axis:stream:)``
 public func split(_ array: MLXArray, parts: Int, axis: Int = 0, stream: StreamOrDevice = .default)
@@ -1286,6 +1287,35 @@ public func split(_ array: MLXArray, parts: Int, axis: Int = 0, stream: StreamOr
     let vec = mlx_split_equal_parts(array.ctx, parts.int32, axis.int32, stream.ctx)!
     defer { mlx_free(vec) }
     return mlx_vector_array_values(vec)
+}
+
+/// Split an array into 2 equal size pieces along a given axis.
+///
+/// Splits the array into 2 pieces along a given axis and returns an tuple of `MLXArray`:
+///
+/// ```swift
+/// let array = MLXArray(0 ..< 12, (4, 3))
+///
+/// let (a, b) = split(array)
+/// ```
+///
+/// - Parameters:
+///     - array: input array
+///     - parts: array is split into that many sections of equal size. It is a fatal error if this is not possible
+///     - axis: axis to split along
+///
+/// ### See Also
+/// - <doc:shapes>
+/// - ``split(_:parts:axis:stream:)``
+/// - ``split(_:indices:axis:stream:)``
+/// - ``MLXArray/split(parts:axis:stream:)``
+public func split(_ array: MLXArray, axis: Int = 0, stream: StreamOrDevice = .default)
+    -> (MLXArray, MLXArray)
+{
+    let vec = mlx_split_equal_parts(array.ctx, 2, axis.int32, stream.ctx)!
+    defer { mlx_free(vec) }
+    let pieces = mlx_vector_array_values(vec)
+    return (pieces[0], pieces[1])
 }
 
 /// Split an array along a given axis.

--- a/Source/MLX/ParameterTypes.swift
+++ b/Source/MLX/ParameterTypes.swift
@@ -35,6 +35,10 @@ public struct IntOrPair: ExpressibleByIntegerLiteral, ExpressibleByArrayLiteral 
     public init(_ values: (Int, Int)) {
         self.values = values
     }
+
+    public init(_ value: Int) {
+        self.values = (value, value)
+    }
 }
 
 /// Parameter for convolutions allowing single integers or arrays.
@@ -58,6 +62,14 @@ public enum IntOrArray: ExpressibleByIntegerLiteral, ExpressibleByArrayLiteral {
 
     public init(arrayLiteral elements: Int...) {
         self = .array(elements)
+    }
+
+    public init(_ values: [Int]) {
+        self = .array(values)
+    }
+
+    public init(_ value: Int) {
+        self = .int(value)
     }
 
     public var asArray: [Int] {
@@ -110,6 +122,14 @@ public enum FloatOrArray: ExpressibleByFloatLiteral, ExpressibleByArrayLiteral {
 
     public init(arrayLiteral elements: Float...) {
         self = .array(elements)
+    }
+
+    public init(_ values: [Float]) {
+        self = .array(values)
+    }
+
+    public init(_ value: Float) {
+        self = .float(value)
     }
 
     public var asArray: [Float] {

--- a/Source/MLXNN/Activations.swift
+++ b/Source/MLXNN/Activations.swift
@@ -233,8 +233,8 @@ public func geluFastApproximate(_ x: MLXArray) -> MLXArray {
 /// - <doc:activations>
 /// - ``GLU``
 public func glu(_ x: MLXArray, axis: Int = -1) -> MLXArray {
-    let pieces = split(x, parts: 2, axis: axis)
-    return pieces[0] * sigmoid(pieces[1])
+    let (a, b) = x.split(axis: axis)
+    return a * sigmoid(b)
 }
 
 /// Applies the Step Activation Function.

--- a/Source/MLXNN/Linear.swift
+++ b/Source/MLXNN/Linear.swift
@@ -74,7 +74,7 @@ open class Linear: Module, UnaryLayer {
     public let bias: MLXArray?
 
     public var shape: (Int, Int) {
-        (weight.dim(0), weight.dim(1))
+        weight.shape2
     }
 
     /// Applies an affine transformation to the input.
@@ -177,9 +177,7 @@ open class Bilinear: Module {
 
     open func callAsFunction(_ x1: MLXArray, _ x2: MLXArray) -> MLXArray {
         // normalize shapes
-        let out = weight.dim(0)
-        let in1 = weight.dim(2)
-        let in2 = weight.dim(1)
+        let (out, in2, in1) = weight.shape3
         let xShape = x1.shape.dropLast()
         let x1 = x1.reshaped(-1, in1)
         let x2 = x2.reshaped(-1, 1, in2)

--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -1127,7 +1127,7 @@ public enum ModuleValue {
     /// ```
     case other(Any)
 
-    /// Recursive build of ``ModuleItem`` from a value.
+    /// Recursive build of ``ModuleValue`` from a value.
     private static func build(value: Any?) -> ModuleItem {
         guard let value else {
             return .none
@@ -1140,6 +1140,23 @@ public enum ModuleValue {
             return .value(.module(v))
         case let v as [Any]:
             return .array(v.map { build(value: $0) })
+
+        // handle tuples like arrays.  sadly we can't use parameter packs here
+        // so we have to enumerate the allowed tuples (up to 5 for now)
+        case let v as (Any, Any):
+            return .array([build(value: v.0), build(value: v.1)])
+        case let v as (Any, Any, Any):
+            return .array([build(value: v.0), build(value: v.1), build(value: v.2)])
+        case let v as (Any, Any, Any, Any):
+            return .array([
+                build(value: v.0), build(value: v.1), build(value: v.2), build(value: v.3),
+            ])
+        case let v as (Any, Any, Any, Any, Any):
+            return .array([
+                build(value: v.0), build(value: v.1), build(value: v.2), build(value: v.3),
+                build(value: v.4),
+            ])
+
         case let v as [String: Any]:
             return .dictionary(
                 Dictionary(uniqueKeysWithValues: v.map { ($0.key, build(value: $0.value)) }))
@@ -1160,7 +1177,7 @@ public enum ModuleValue {
         // has a label of `_items`
         if let (nl, nv) = unwrapProperty(value) {
             label = nl ?? label?.dropFirst().description
-            value = nv!
+            value = nv ?? (Optional<MLXArray>.none as Any)
         }
         if let (nl, nv) = unwrapModule(value) {
             label = nl ?? label?.dropFirst().description
@@ -1198,7 +1215,13 @@ public enum ModuleValue {
 
     public var wrappedValue: T {
         get {
-            value!
+            // note: this gives a warning but it does in fact do something
+            // in the case where this is e.g. ParameterInfo<MLXArray?>
+            if let value = value as? T {
+                return value
+            } else {
+                return value!
+            }
         }
         set {
             if value != nil {
@@ -1301,7 +1324,13 @@ private protocol TypeErasedSetterProvider {
 
     public var wrappedValue: T {
         get {
-            module!
+            // note: this gives a warning but it does in fact do something
+            // in the case where this is e.g. ModuleInfo<Linear?>
+            if let module = module as? T {
+                return module
+            } else {
+                return module!
+            }
         }
         set {
             module = newValue

--- a/Source/MLXNN/Normalization.swift
+++ b/Source/MLXNN/Normalization.swift
@@ -232,7 +232,12 @@ open class GroupNorm: Module, UnaryLayer {
     }
 
     open func callAsFunction(_ x: MLXArray) -> MLXArray {
-        pytorchCompatible ? pytorchGroupNorm(x) : groupNorm(x)
+        let x = pytorchCompatible ? pytorchGroupNorm(x) : groupNorm(x)
+        if let weight, let bias {
+            return weight * x + bias
+        } else {
+            return x
+        }
     }
 }
 

--- a/Source/MLXNN/Transformer.swift
+++ b/Source/MLXNN/Transformer.swift
@@ -76,14 +76,14 @@ open class MultiHeadAttention: Module {
     ) -> MLXArray {
         var queries = queryProjection(queries)
         var keys = keyProjection(keys)
-        let values = valueProjection(values)
+        var values = valueProjection(values)
 
         let (B, L) = (queries.dim(0), queries.dim(1))
         let S = keys.dim(1)
 
         queries = queries.reshaped(B, L, numHeads, -1).transposed(0, 2, 1, 3)
         keys = keys.reshaped(B, S, numHeads, -1).transposed(0, 2, 3, 1)
-        queries = queries.reshaped(B, S, numHeads, -1).transposed(0, 2, 1, 3)
+        values = values.reshaped(B, S, numHeads, -1).transposed(0, 2, 1, 3)
 
         // Dimensions are [batch x num heads x sequence x hidden dim]
         let scale = sqrt(1 / Float(queries.dim(-1)))


### PR DESCRIPTION
- make a variant of split that returns a tuple for the parts: 2 case (common)
- and destructuring shape properties (convenience)
- add asData to get access to bytes
- handle properties that hold modules/parameters in tuples
- handle optional parameter and module properties with ModuleInfo/PropertyInfo
- bugfix: GroupNorm was ignoring weight, bias
- bugfix: MultiHeadAttention was not reshaping correctly