### PR TITLE
lora updates part 2

### DIFF
--- a/Source/MLXNN/Linear.swift
+++ b/Source/MLXNN/Linear.swift
@@ -102,17 +102,21 @@ open class Linear: Module, UnaryLayer {
     ///   - inputDimensions: number of input dimensions
     ///   - outputDimensions: number of output dimensions
     ///   - bias: if `true` this layer will apply a bias
-    convenience init(inputDimensions: Int, outputDimensions: Int, bias: Bool = true) {
+    public convenience init(inputDimensions: Int, outputDimensions: Int, bias: Bool = true) {
         self.init(inputDimensions, outputDimensions, bias: bias)
     }
 
-    internal init(weight: MLXArray, bias: MLXArray? = nil) {
+    /// Initializer meant for subclasses to provide weight and bias arrays directly.
+    ///
+    /// This is used e.g. by ``QuantizedLinear`` to provide quantized weights and biases
+    /// rather than have ``Linear`` compute them.
+    public init(weight: MLXArray, bias: MLXArray? = nil) {
         self.weight = weight
         self.bias = bias
     }
 
     /// Describe the `inputDimensions` and `outputDimensions`.
-    public override func describeExtra(_ indent: Int) -> String {
+    open override func describeExtra(_ indent: Int) -> String {
         "(inputDimensions=\(weight.dim(1)), outputDimensions=\(weight.dim(0)), bias=\(bias == nil ? "false" : "true"))"
     }
 

--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -162,7 +162,7 @@ open class Module {
     ///
     /// ### See Also
     /// - ``description(indent:)``
-    public func describeExtra(_ indent: Int) -> String {
+    open func describeExtra(_ indent: Int) -> String {
         let other = filterMap(filter: Self.filterOther, map: Self.mapOther())
         let kv = other.sorted { lhs, rhs in lhs.key < rhs.key }
 
@@ -760,7 +760,7 @@ open class Module {
     /// ### See Also
     /// - ``freeze(recursive:keys:)``
     /// - ``unfreeze(recursive:keys:strict:)``
-    public func freeze(recursive: Bool = true, keys: [String]? = nil, strict: Bool = false) throws {
+    open func freeze(recursive: Bool = true, keys: [String]? = nil, strict: Bool = false) throws {
         let visitor = freezeVisitor(keys: keys, strict: strict) {
             $0.noGrad.formUnion($1)
         }
@@ -797,8 +797,7 @@ open class Module {
     /// ### See Also
     /// - ``Module/freeze(recursive:keys:)``
     /// - ``Module/unfreeze(recursive:keys:strict:)``
-    public func unfreeze(recursive: Bool = true, keys: [String]? = nil, strict: Bool = false) throws
-    {
+    open func unfreeze(recursive: Bool = true, keys: [String]? = nil, strict: Bool = false) throws {
         let visitor = freezeVisitor(keys: keys, strict: strict) {
             $0.noGrad.subtract($1)
         }

--- a/Source/MLXNN/Quantized.swift
+++ b/Source/MLXNN/Quantized.swift
@@ -52,6 +52,7 @@ open class QuantizedLinear: Linear {
         self.init(weight: weight, bias: bias, groupSize: groupSize, bits: bits)
     }
 
+    /// Initialize a ``QuantizedLinear`` with non-quantized weights and bias.
     public init(weight: MLXArray, bias: MLXArray?, groupSize: Int = 64, bits: Int = 4) {
         self.groupSize = groupSize
         self.bits = bits
@@ -65,6 +66,21 @@ open class QuantizedLinear: Linear {
         super.init(weight: quantizedWeight, bias: bias)
 
         self.freeze()
+    }
+
+    /// Initializer meant for subclasses to provide arrays directly.
+    ///
+    /// ### See Also
+    /// - ``Linear/init(weight:bias:)``
+    public init(
+        weight: MLXArray, bias: MLXArray? = nil, scales: MLXArray, biases: MLXArray, groupSize: Int,
+        bits: Int
+    ) {
+        self.groupSize = groupSize
+        self.bits = bits
+        self.scales = scales
+        self.biases = biases
+        super.init(weight: weight, bias: bias)
     }
 
     public override func unfreeze(


### PR DESCRIPTION
Some more updates to handle the new way subclassing Linear we are doing for LoRA in https://github.com/ml-explore/mlx-swift-examples/pull/46

- the new LoRALinear and QLoraLinear implementations are subclasses of Linear
- these need the same access to their superclass initializer that QuantizedLinear had
- freeze/unfreeze need to be open for subclasses