### PR TITLE
fix #71 -- loading npy file always gives zeros

### DIFF
--- a/Tests/MLXTests/SaveTests.swift
+++ b/Tests/MLXTests/SaveTests.swift
@@ -46,4 +46,21 @@ final class SaveTests: XCTestCase {
         assertEqual(try XCTUnwrap(loadedArrays["foo"]), try XCTUnwrap(arrays["foo"]))
         assertEqual(try XCTUnwrap(loadedArrays["bar"]), try XCTUnwrap(arrays["bar"]))
     }
+    
+    public func testSaveArray() throws {
+        // single array npy file
+        let path = temporaryPath.appending(
+            path: "array.npy",
+            directoryHint: .notDirectory
+        )
+        
+        let array = MLX.ones([2, 4])
+
+        try MLX.save(array: array, url: path)
+
+        let loaded = try MLX.loadArray(url: path)
+        
+        assertEqual(array, loaded)
+    }
+
 }

--- a/Tests/MLXTests/SaveTests.swift
+++ b/Tests/MLXTests/SaveTests.swift
@@ -46,20 +46,20 @@ final class SaveTests: XCTestCase {
         assertEqual(try XCTUnwrap(loadedArrays["foo"]), try XCTUnwrap(arrays["foo"]))
         assertEqual(try XCTUnwrap(loadedArrays["bar"]), try XCTUnwrap(arrays["bar"]))
     }
-    
+
     public func testSaveArray() throws {
         // single array npy file
         let path = temporaryPath.appending(
             path: "array.npy",
             directoryHint: .notDirectory
         )
-        
+
         let array = MLX.ones([2, 4])
 
         try MLX.save(array: array, url: path)
 
         let loaded = try MLX.loadArray(url: path)
-        
+
         assertEqual(array, loaded)
     }
 


### PR DESCRIPTION
- we can't use the FILE * variant of the call as the operation is lazy
- the file is being closed before the read of the data is done