### PR TITLE
reconcile changes between mlx 0.8.1 and 0.12.1

### DIFF
--- a/Source/MLX/DType.swift
+++ b/Source/MLX/DType.swift
@@ -90,6 +90,21 @@ public enum DType: Hashable {
         default: false
         }
     }
+
+    public var isInteger: Bool {
+        switch self {
+        case .uint8, .uint16, .uint32, .uint64: true
+        case .int8, .int16, .int32, .int64: true
+        default: false
+        }
+    }
+
+    public var isSignedInteger: Bool {
+        switch self {
+        case .int8, .int16, .int32, .int64: true
+        default: false
+        }
+    }
 }
 
 /// Protocol for types that can provide a ``DType``

--- a/Source/MLX/Documentation.docc/Articles/lazy-evaluation.md
+++ b/Source/MLX/Documentation.docc/Articles/lazy-evaluation.md
@@ -17,7 +17,7 @@ describe below.
 
 ### Transforming Compute Graphs
 
-Lazy evaluation let's us record a compute graph without actually doing any
+Lazy evaluation lets us record a compute graph without actually doing any
 computations. This is useful for function transformations like `grad` and
 `vmap` and graph optimizations like `simplify`.
 

--- a/Source/MLX/Documentation.docc/Organization/arithmetic.md
+++ b/Source/MLX/Documentation.docc/Organization/arithmetic.md
@@ -138,6 +138,7 @@ Note: the `-` and `/` operators are not able to be linked here.
 - ``erf(_:stream:)``
 - ``erfInverse(_:stream:)``
 - ``exp(_:stream:)``
+- ``expm1(_:stream:)``
 - ``floor(_:stream:)``
 - ``floorDivide(_:_:stream:)``
 - ``isNaN(_:stream:)``

--- a/Source/MLX/Documentation.docc/Organization/reduction.md
+++ b/Source/MLX/Documentation.docc/Organization/reduction.md
@@ -81,6 +81,9 @@ See also <doc:logical> and <doc:cumulative>
 - ``min(_:keepDims:stream:)``
 - ``min(_:axis:keepDims:stream:)``
 - ``min(_:axes:keepDims:stream:)``
+- ``std(_:axes:keepDims:ddof:stream:)``
+- ``std(_:axis:keepDims:ddof:stream:)``
+- ``std(_:keepDims:ddof:stream:)``
 - ``sum(_:keepDims:stream:)``
 - ``sum(_:axis:keepDims:stream:)``
 - ``sum(_:axes:keepDims:stream:)``

--- a/Source/MLX/Documentation.docc/free-functions.md
+++ b/Source/MLX/Documentation.docc/free-functions.md
@@ -26,6 +26,7 @@ operations as methods for convenience.
 - ``erf(_:stream:)``
 - ``erfInverse(_:stream:)``
 - ``exp(_:stream:)``
+- ``expm1(_:stream:)``
 - ``floor(_:stream:)``
 - ``floorDivide(_:_:stream:)``
 - ``log(_:stream:)``

--- a/Source/MLX/Ops+Array.swift
+++ b/Source/MLX/Ops+Array.swift
@@ -557,6 +557,7 @@ public func diagonal(
 /// ### See Also
 /// - <doc:arithmetic>
 /// - ``MLXArray/exp(stream:)``
+/// - ``expm1(_:stream:)``
 public func exp(_ array: MLXArray, stream: StreamOrDevice = .default) -> MLXArray {
     MLXArray(mlx_exp(array.ctx, stream.ctx))
 }

--- a/Source/MLX/Ops.swift
+++ b/Source/MLX/Ops.swift
@@ -804,6 +804,21 @@ public func expandedDimensions(_ array: MLXArray, axis: Int, stream: StreamOrDev
     MLXArray(mlx_expand_dims(array.ctx, [axis.int32], 1, stream.ctx))
 }
 
+/// Element-wise exponential minus 1.
+///
+/// Computes `exp(x) - 1` with greater precision for small `x`.
+///
+/// - Parameters:
+///   - array: input array
+///     - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - <doc:arithmetic>
+/// - ``exp(_:stream:)``
+public func expm1(_ array: MLXArray, stream: StreamOrDevice = .default) -> MLXArray {
+    MLXArray(mlx_expm1(array.ctx, stream.ctx))
+}
+
 /// Element-wise greater than.
 ///
 /// Greater than on two arrays with <doc:broadcasting>.
@@ -1222,6 +1237,39 @@ public func logicalOr<A: ScalarOrArray, B: ScalarOrArray>(
 ) -> MLXArray {
     let (a, b) = toArrays(a, b)
     return MLXArray(mlx_logical_or(a.ctx, b.ctx, stream.ctx))
+}
+
+/// Indexing mode for ``meshGrid(_:sparse:indexing:stream:)``.
+public enum MeshGridIndexing: String {
+    /// cartesian indexing
+    case xy
+
+    /// matrix indexing
+    case ij
+}
+
+/// Generate multidimensional coordinate grids from 1-D coordinate arrays
+///
+/// - Parameters:
+///   - arrays: input arrays
+///   - sparse: if `true` a parse grid is returned in which each output array has a single
+///     non-zero element, otherwise a dense grid is returned.
+///   - indexing: indexing mode
+///   - stream: stream or device to evaluate on
+public func meshGrid(
+    _ arrays: [MLXArray], sparse: Bool = false, indexing: MeshGridIndexing = .xy,
+    stream: StreamOrDevice = .default
+) -> [MLXArray] {
+    let mlxArrays = new_mlx_vector_array(arrays)
+    defer { mlx_free(mlxArrays) }
+
+    let indexingString = mlx_string_new(indexing.rawValue.cString(using: .utf8))!
+    defer { mlx_free(indexingString) }
+
+    let result = mlx_meshgrid(mlxArrays, sparse, indexingString, stream.ctx)!
+    defer { mlx_free(result) }
+
+    return mlx_vector_array_values(result)
 }
 
 /// Element-wise maximum.
@@ -1728,6 +1776,64 @@ public func sorted(_ array: MLXArray, axis: Int, stream: StreamOrDevice = .defau
 /// - ``argSort(_:axis:stream:)``
 public func sorted(_ array: MLXArray, stream: StreamOrDevice = .default) -> MLXArray {
     MLXArray(mlx_sort_all(array.ctx, stream.ctx))
+}
+
+/// Compute the standard deviation(s) over the given axes.
+///
+/// - Parameters:
+///   - array: input array
+///   - axes: axes to reduce over
+///   - keepDims: if `true`keep reduced axis as singleton dimension
+///   - ddof: the divisor to compute the varian is `N - ddof`
+///   - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - <doc:reduction>
+/// - ``std(_:axis:keepDims:ddof:stream:)``
+/// - ``std(_:keepDims:ddof:stream:)``
+public func std(
+    _ array: MLXArray, axes: [Int], keepDims: Bool = false, ddof: Int = 0,
+    stream: StreamOrDevice = .default
+) -> MLXArray {
+    MLXArray(mlx_std(array.ctx, axes.asInt32, axes.count, keepDims, ddof.int32, stream.ctx))
+}
+
+/// Compute the standard deviation over the given axis.
+///
+/// - Parameters:
+///   - array: input array
+///   - axis: axis to reduce over
+///   - keepDims: if `true`keep reduced axis as singleton dimension
+///   - ddof: the divisor to compute the varian is `N - ddof`
+///   - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - <doc:reduction>
+/// - ``std(_:axes:keepDims:ddof:stream:)``
+/// - ``std(_:keepDims:ddof:stream:)``
+public func std(
+    _ array: MLXArray, axis: Int, keepDims: Bool = false, ddof: Int = 0,
+    stream: StreamOrDevice = .default
+) -> MLXArray {
+    MLXArray(mlx_std(array.ctx, [axis.int32], 1, keepDims, ddof.int32, stream.ctx))
+}
+
+/// Compute the standard deviations over all axes.
+///
+/// - Parameters:
+///   - array: input array
+///   - keepDims: if `true`keep reduced axis as singleton dimension
+///   - ddof: the divisor to compute the varian is `N - ddof`
+///   - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - <doc:reduction>
+/// - ``std(_:axes:keepDims:ddof:stream:)``
+/// - ``std(_:axis:keepDims:ddof:stream:)``
+public func std(
+    _ array: MLXArray, keepDims: Bool = false, ddof: Int = 0, stream: StreamOrDevice = .default
+) -> MLXArray {
+    MLXArray(mlx_std_all(array.ctx, keepDims, ddof.int32, stream.ctx))
 }
 
 /// Stacks the arrays along a new axis.

--- a/Source/MLX/Transforms+Compile.swift
+++ b/Source/MLX/Transforms+Compile.swift
@@ -159,7 +159,7 @@ public func compile(
     }
 }
 
-/// Overload of ``compile(inputs:outputs:shapeless:_:)-7korq`` that takes a two ``MLXArray`` and
+/// Overload of ``compile(inputs:outputs:shapeless:_:)-7korq`` that takes two ``MLXArray`` and
 /// produces a single ``MLXArray``.
 ///
 /// ### See Also
@@ -177,6 +177,27 @@ public func compile(
 
     return { a, b in
         compileState.call([a, b])[0]
+    }
+}
+
+/// Overload of ``compile(inputs:outputs:shapeless:_:)-7korq`` that takes three ``MLXArray`` and
+/// produces a single ``MLXArray``.
+///
+/// ### See Also
+/// - <doc:compilation>
+/// - ``compile(inputs:outputs:shapeless:_:)-7korq``
+public func compile(
+    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    _ f: @escaping (MLXArray, MLXArray, MLXArray) -> MLXArray
+)
+    -> (MLXArray, MLXArray, MLXArray) -> MLXArray
+{
+    let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
+        [f($0[0], $0[1], $0[2])]
+    }
+
+    return { a, b, c in
+        compileState.call([a, b, c])[0]
     }
 }
 

--- a/Source/MLXNN/Activations.swift
+++ b/Source/MLXNN/Activations.swift
@@ -195,7 +195,7 @@ public func gelu(_ x: MLXArray) -> MLXArray {
 /// This is:
 ///
 /// ```swift
-/// x * MLX.sigmoid(1.60033 * x * (1 + 0.0433603 * x.square()))
+/// 0.5 * x * (1 + tanh(sqrt(2 / Float.pi) * (x + 0.044715 * x**3)))
 /// ```
 ///
 /// ### See Also
@@ -747,7 +747,7 @@ private let compiledGelu: (MLXArray) -> MLXArray = {
 
 private let compiledGeluApproximate: (MLXArray) -> MLXArray = {
     compile(shapeless: true) { x in
-        x * sigmoid(1.60033 * x * (1 + 0.0433603 * x.square()))
+        0.5 * x * (1 + tanh(sqrt(2 / Float.pi) * (x + 0.044715 * x ** 3)))
     }
 }()
 

--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -392,7 +392,7 @@ open class Module {
     ///
     /// This passes `verify: .none`.  Note that there may still be `fatalErrors()` if
     /// for example an `MLXArray` is set on a `Module`.
-    public func update(parameters: ModuleParameters) {
+    public func update(parameters: ModuleParameters) -> Self {
         try! update(parameters: parameters, verify: .none)
     }
 
@@ -427,7 +427,7 @@ open class Module {
     /// - ``parameters()``
     /// - ``mapParameters(map:isLeaf:)``
     /// - ``update(modules:verify:)``
-    public func update(parameters: ModuleParameters, verify: VerifyUpdate) throws {
+    public func update(parameters: ModuleParameters, verify: VerifyUpdate) throws -> Self {
 
         func apply(key: String, _ item: ModuleItem, _ value: NestedItem<String, MLXArray>) throws {
             if case .none = value {
@@ -475,6 +475,8 @@ open class Module {
             throw UpdateError.unhandledKeys(
                 base: describeType(self), keys: processed.sorted())
         }
+
+        return self
     }
 
     /// Apply a closure to the parameters in a `Module` recursively.
@@ -493,7 +495,7 @@ open class Module {
     public func apply(
         filter: (Module, String, ModuleItem) -> Bool = Module.filterValidParameters,
         map: @escaping (MLXArray) -> MLXArray
-    ) {
+    ) -> Self {
         update(parameters: mapParameters(map: map))
     }
 
@@ -501,7 +503,7 @@ open class Module {
     ///
     /// This passes `verify: .none`.  Note that there may still be `fatalErrors()` if
     /// for example an `Module` is set on a `MLXArray`.
-    public func update(modules: ModuleChildren) {
+    public func update(modules: ModuleChildren) -> Self {
         try! update(modules: modules, verify: .none)
     }
 
@@ -547,7 +549,7 @@ open class Module {
     /// - ``children()``
     /// - ``leafModules()``
     /// - ``QuantizedLinear/quantize(model:groupSize:bits:predicate:)``
-    public func update(modules: ModuleChildren, verify: VerifyUpdate) throws {
+    public func update(modules: ModuleChildren, verify: VerifyUpdate) throws -> Self {
 
         func apply(key: String, _ item: ModuleItem, _ value: NestedItem<String, Module>) throws {
             if case .none = value {
@@ -648,6 +650,8 @@ open class Module {
 
         // rebuild the caches because the modules may have changed
         buildCaches()
+
+        return self
     }
 
     private func updateModule(key: String, _ value: Any) throws {

--- a/Source/MLXRandom/Random.swift
+++ b/Source/MLXRandom/Random.swift
@@ -203,6 +203,33 @@ public func normal(
             shape.asInt32, shape.count, dtype.cmlxDtype, loc, scale, key.ctx, stream.ctx))
 }
 
+/// Generate jointly-normal random samples given a mean and covariance.
+///
+/// The matrix `covariance` must be positive semi-definite. The behavior is
+/// undefined if it is not.  The only supported `dtype` is `.float32`.
+///
+/// - Parameters:
+///   - mean: array of shape `[..., n]`, the mean of the distribution.
+///   - covariance: array  of shape `[..., n, n]`, the covariance
+/// matrix of the distribution. The batch shape `...` must be
+/// broadcast-compatible with that of `mean`.
+///   - shape:  The output shape must be
+/// broadcast-compatible with `mean.shape.dropLast()` and `covariance.shape.dropLast(2)`.
+/// If empty, the result shape is determined by broadcasting the batch
+/// shapes of `mean` and `covariance`.
+///   - dtype: DType of the result
+///   - key: PRNG key
+public func multivariateNormal(
+    mean: MLXArray, covariance: MLXArray, shape: [Int] = [], dtype: DType = .float32,
+    key: MLXArray? = nil, stream: StreamOrDevice = .default
+) -> MLXArray {
+    let key = key ?? globalState.next()
+    return MLXArray(
+        mlx_random_multivariate_normal(
+            mean.ctx, covariance.ctx, shape.asInt32, shape.count, dtype.cmlxDtype, key.ctx,
+            stream.ctx))
+}
+
 /// Generate random integers from the given interval using a `RangeExpression<Int>`.
 ///
 /// The values are sampled with equal probability from the integers in


### PR DESCRIPTION
- some changes from mlx were skipped as we were just updating what we built against
- this pulls in remaining changes from https://github.com/ml-explore/mlx/compare/v0.8.1...v0.12.1
- with the exception of the bitwise operators: https://github.com/ml-explore/mlx-c/issues/23