### PR TITLE
Unify operator implementation

### DIFF
--- a/Source/MLX/MLXArray+Ops.swift
+++ b/Source/MLX/MLXArray+Ops.swift
@@ -50,9 +50,7 @@ extension MLXArray {
     /// - <doc:arithmetic>
     /// - ``MLXArray/+(_:_:)-1rv98``
     public static func + <T: ScalarOrArray>(lhs: MLXArray, rhs: T) -> MLXArray {
-        let s = StreamOrDevice.default
-        let rhs = rhs.asMLXArray(dtype: lhs.dtype)
-        return MLXArray(mlx_add(lhs.ctx, rhs.ctx, s.ctx))
+        lhs + rhs.asMLXArray(dtype: lhs.dtype)
     }
 
     /// Element-wise addition with a ``ScalarOrArray`` (scalar) argument.
@@ -61,9 +59,7 @@ extension MLXArray {
     /// - <doc:arithmetic>
     /// - ``MLXArray/+(_:_:)-1rv98``
     public static func + <T: ScalarOrArray>(lhs: T, rhs: MLXArray) -> MLXArray {
-        let s = StreamOrDevice.default
-        let lhs = lhs.asMLXArray(dtype: rhs.dtype)
-        return MLXArray(mlx_add(lhs.ctx, rhs.ctx, s.ctx))
+        lhs.asMLXArray(dtype: rhs.dtype) + rhs
     }
 
     /// Element-wise subtraction.
@@ -92,9 +88,7 @@ extension MLXArray {
     /// ### See Also
     /// - <doc:arithmetic>
     public static func - <T: ScalarOrArray>(lhs: MLXArray, rhs: T) -> MLXArray {
-        let s = StreamOrDevice.default
-        let rhs = rhs.asMLXArray(dtype: lhs.dtype)
-        return MLXArray(mlx_subtract(lhs.ctx, rhs.ctx, s.ctx))
+        lhs - rhs.asMLXArray(dtype: lhs.dtype)
     }
 
     /// Element-wise subtraction with a ``ScalarOrArray`` (scalar) argument.
@@ -102,9 +96,7 @@ extension MLXArray {
     /// ### See Also
     /// - <doc:arithmetic>
     public static func - <T: ScalarOrArray>(lhs: T, rhs: MLXArray) -> MLXArray {
-        let s = StreamOrDevice.default
-        let lhs = lhs.asMLXArray(dtype: rhs.dtype)
-        return MLXArray(mlx_subtract(lhs.ctx, rhs.ctx, s.ctx))
+        lhs.asMLXArray(dtype: rhs.dtype) - rhs
     }
 
     /// Unary element-wise negation.
@@ -154,9 +146,7 @@ extension MLXArray {
     /// - <doc:arithmetic>
     /// - ``MLXArray/*(_:_:)-1z2ck``
     public static func * <T: ScalarOrArray>(lhs: MLXArray, rhs: T) -> MLXArray {
-        let s = StreamOrDevice.default
-        let rhs = rhs.asMLXArray(dtype: lhs.dtype)
-        return MLXArray(mlx_multiply(lhs.ctx, rhs.ctx, s.ctx))
+        lhs * rhs.asMLXArray(dtype: lhs.dtype)
     }
 
     /// Element-wise multiplication with a ``ScalarOrArray`` (scalar) argument.
@@ -165,9 +155,7 @@ extension MLXArray {
     /// - <doc:arithmetic>
     /// - ``MLXArray/*(_:_:)-1z2ck``
     public static func * <T: ScalarOrArray>(lhs: T, rhs: MLXArray) -> MLXArray {
-        let s = StreamOrDevice.default
-        let lhs = lhs.asMLXArray(dtype: rhs.dtype)
-        return MLXArray(mlx_multiply(lhs.ctx, rhs.ctx, s.ctx))
+        lhs.asMLXArray(dtype: rhs.dtype) * rhs
     }
 
     /// Element-wise power operation.
@@ -200,9 +188,7 @@ extension MLXArray {
     /// - <doc:arithmetic>
     /// - ``MLXArray/**(_:_:)-8xxt3``
     public static func ** <T: ScalarOrArray>(lhs: MLXArray, rhs: T) -> MLXArray {
-        let s = StreamOrDevice.default
-        let rhs = rhs.asMLXArray(dtype: lhs.dtype)
-        return MLXArray(mlx_power(lhs.ctx, rhs.ctx, s.ctx))
+        lhs ** rhs.asMLXArray(dtype: lhs.dtype)
     }
 
     /// Element-wise power with a ``ScalarOrArray`` (scalar) argument.
@@ -211,9 +197,7 @@ extension MLXArray {
     /// - <doc:arithmetic>
     /// - ``MLXArray/**(_:_:)-8xxt3``
     public static func ** <T: ScalarOrArray>(lhs: T, rhs: MLXArray) -> MLXArray {
-        let s = StreamOrDevice.default
-        let lhs = lhs.asMLXArray(dtype: rhs.dtype)
-        return MLXArray(mlx_power(lhs.ctx, rhs.ctx, s.ctx))
+        lhs.asMLXArray(dtype: rhs.dtype) ** rhs
     }
 
     /// Element-wise division.
@@ -243,9 +227,7 @@ extension MLXArray {
     /// ### See Also
     /// - <doc:arithmetic>
     public static func / <T: ScalarOrArray>(lhs: MLXArray, rhs: T) -> MLXArray {
-        let s = StreamOrDevice.default
-        let rhs = rhs.asMLXArray(dtype: lhs.dtype)
-        return MLXArray(mlx_divide(lhs.ctx, rhs.ctx, s.ctx))
+        lhs / rhs.asMLXArray(dtype: lhs.dtype)
     }
 
     /// Element-wise division with a ``ScalarOrArray`` (scalar) argument.
@@ -253,9 +235,7 @@ extension MLXArray {
     /// ### See Also
     /// - <doc:arithmetic>
     public static func / <T: ScalarOrArray>(lhs: T, rhs: MLXArray) -> MLXArray {
-        let s = StreamOrDevice.default
-        let lhs = lhs.asMLXArray(dtype: rhs.dtype)
-        return MLXArray(mlx_divide(lhs.ctx, rhs.ctx, s.ctx))
+        lhs.asMLXArray(dtype: rhs.dtype) / rhs
     }
 
     /// Element-wise remainder of division.
@@ -284,9 +264,7 @@ extension MLXArray {
     /// - <doc:arithmetic>
     /// - ``MLXArray/%(_:_:)-3ubwd``
     public static func % <T: ScalarOrArray>(lhs: T, rhs: MLXArray) -> MLXArray {
-        let s = StreamOrDevice.default
-        let lhs = lhs.asMLXArray(dtype: rhs.dtype)
-        return MLXArray(mlx_remainder(lhs.ctx, rhs.ctx, s.ctx))
+        lhs.asMLXArray(dtype: rhs.dtype) % rhs
     }
 
     /// Element-wise remainder with a ``ScalarOrArray`` (scalar) argument.
@@ -295,9 +273,7 @@ extension MLXArray {
     /// - <doc:arithmetic>
     /// - ``MLXArray/%(_:_:)-3ubwd``
     public static func % <T: ScalarOrArray>(lhs: MLXArray, rhs: T) -> MLXArray {
-        let s = StreamOrDevice.default
-        let rhs = rhs.asMLXArray(dtype: lhs.dtype)
-        return MLXArray(mlx_remainder(lhs.ctx, rhs.ctx, s.ctx))
+        lhs % rhs.asMLXArray(dtype: lhs.dtype)
     }
 
     // MARK: - Logical Operators
@@ -351,9 +327,7 @@ extension MLXArray {
     /// - <doc:arithmetic>
     /// - ``MLXArray/.==(_:_:)-56m0a``
     public static func .== <T: ScalarOrArray>(lhs: MLXArray, rhs: T) -> MLXArray {
-        let s = StreamOrDevice.default
-        let rhs = rhs.asMLXArray(dtype: lhs.dtype)
-        return MLXArray(mlx_equal(lhs.ctx, rhs.ctx, s.ctx))
+        lhs .== rhs.asMLXArray(dtype: lhs.dtype)
     }
 
     /// Element-wise less than or equal.
@@ -385,9 +359,7 @@ extension MLXArray {
     /// - <doc:arithmetic>
     /// - ``MLXArray/.<=(_:_:)-2a0s9``
     public static func .<= <T: ScalarOrArray>(lhs: MLXArray, rhs: T) -> MLXArray {
-        let s = StreamOrDevice.default
-        let rhs = rhs.asMLXArray(dtype: lhs.dtype)
-        return MLXArray(mlx_less_equal(lhs.ctx, rhs.ctx, s.ctx))
+        lhs .<= rhs.asMLXArray(dtype: lhs.dtype)
     }
 
     /// Element-wise less greater than or equal.
@@ -419,9 +391,7 @@ extension MLXArray {
     /// - <doc:arithmetic>
     /// - ``MLXArray/.>=(_:_:)-2gqml``
     public static func .>= <T: ScalarOrArray>(lhs: MLXArray, rhs: T) -> MLXArray {
-        let s = StreamOrDevice.default
-        let rhs = rhs.asMLXArray(dtype: lhs.dtype)
-        return MLXArray(mlx_greater_equal(lhs.ctx, rhs.ctx, s.ctx))
+        lhs .>= rhs.asMLXArray(dtype: lhs.dtype)
     }
 
     /// Element-wise not equal.
@@ -453,9 +423,7 @@ extension MLXArray {
     /// - <doc:arithmetic>
     /// - ``MLXArray/.!=(_:_:)-mbw0``
     public static func .!= <T: ScalarOrArray>(lhs: MLXArray, rhs: T) -> MLXArray {
-        let s = StreamOrDevice.default
-        let rhs = rhs.asMLXArray(dtype: lhs.dtype)
-        return MLXArray(mlx_not_equal(lhs.ctx, rhs.ctx, s.ctx))
+        lhs .!= rhs.asMLXArray(dtype: lhs.dtype)
     }
 
     /// Element-wise less than.
@@ -487,9 +455,7 @@ extension MLXArray {
     /// - <doc:arithmetic>
     /// - ``MLXArray/.<(_:_:)-9rzup``
     public static func .< <T: ScalarOrArray>(lhs: MLXArray, rhs: T) -> MLXArray {
-        let s = StreamOrDevice.default
-        let rhs = rhs.asMLXArray(dtype: lhs.dtype)
-        return MLXArray(mlx_less(lhs.ctx, rhs.ctx, s.ctx))
+        lhs .< rhs.asMLXArray(dtype: lhs.dtype)
     }
 
     /// Element-wise greater than.
@@ -521,9 +487,7 @@ extension MLXArray {
     /// - <doc:arithmetic>
     /// - ``MLXArray/.>(_:_:)-fwi1``
     public static func .> <T: ScalarOrArray>(lhs: MLXArray, rhs: T) -> MLXArray {
-        let s = StreamOrDevice.default
-        let rhs = rhs.asMLXArray(dtype: lhs.dtype)
-        return MLXArray(mlx_greater(lhs.ctx, rhs.ctx, s.ctx))
+        lhs .> rhs.asMLXArray(dtype: lhs.dtype)
     }
 
     /// Element-wise logical and.


### PR DESCRIPTION
While working on #91, I noticed that there are several overloaded operators with duplicate implementation code. 

To improve code maintainability and adhere to the DRY (Don't Repeat Yourself) principle, I have refactored these operators to call a unified variant that handles the operation for `(lhs: MLXArray, rhs: MLXArray)`.