### PR TITLE
Fix document symbol links

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 // Copyright © 2024 Apple Inc.
 

--- a/Source/MLX/Documentation.docc/Articles/converting-python.md
+++ b/Source/MLX/Documentation.docc/Articles/converting-python.md
@@ -79,13 +79,13 @@ Note: some of the symbols are not linkable.
 `__iter__` | implements `Sequence`
 `__add__` | ``MLXArray/+(_:_:)-1rv98``
 `__iadd__` | ``MLXArray/+=(_:_:)-3feg7``
-`__sub__` | `-`
-`__isub__` | `-=`
+`__sub__` | ``MLXArray/-(_:_:)-7frdo``
+`__isub__` | ``MLXArray/-=(_:_:)-4d4ei``
 `__mul__` | ``MLXArray/*(_:_:)-1z2ck``
 `__imul__` | ``MLXArray/*=(_:_:)-9ukv3``
-`__truediv__` | `/`
-`__div__` | `/`
-`__idiv__` | `/=`
+`__truediv__` | ``MLXArray//(_:_:)-6ijef``
+`__div__` | ``MLXArray//(_:_:)-6ijef``
+`__idiv__` | ``MLXArray//=(_:_:)-9egbn``
 `__floordiv__` | ``MLXArray/floorDivide(_:stream:)``
 `__mod__` | ``MLXArray/%(_:_:)-3ubwd``
 `__eq__` | ``MLXArray/.==(_:_:)-56m0a``


### PR DESCRIPTION
There is a bug around swift-docc that could not generate symbol links for `-` `-=` `/` `/=`. 

And this was fixed in Swift 5.10 based on https://github.com/apple/swift-docc/issues/808. So this PR adds symbol links for these operators.