### PR TITLE
Throw if a module is being updated with a mismatched shape under verify all

### DIFF
--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -443,6 +443,10 @@ open class Module {
 
             switch (item, value) {
             case (.value(.parameters(let p)), .value(let newArray)):
+                if p.shape != newArray.shape, verify.contains(.all) {
+                    throw UpdateError.mismatchedSize(
+                        key: key, expectedShape: p.shape, actualShape: newArray.shape)
+                }
                 p.update(newArray)
 
             case (.array(let array), .array(let values)):
@@ -1395,6 +1399,7 @@ private protocol TypeErasedSetterProvider {
 enum UpdateError: Error {
     case unableToCollectModulesFromContainer(base: String, key: String)
     case mismatchedContainers(base: String, key: String)
+    case mismatchedSize(key: String, expectedShape: [Int], actualShape: [Int])
     case keyNotFound(base: String, key: String)
     case needModuleInfo(String)
     case unableToSet(String)
@@ -1409,6 +1414,9 @@ extension UpdateError: LocalizedError {
             return "Unable to collect modules from container: \(base) \(key)"
         case .mismatchedContainers(let base, let key):
             return "Mismatched containers: \(base) \(key)"
+        case let .mismatchedSize(key: key, expectedShape: expectedShape, actualShape: actualShape):
+            return
+                "Mismatched parameter \(key) shape. Actual \(actualShape), expected \(expectedShape)"
         case .keyNotFound(let base, let key):
             return "Key \(key) not found in \(base)"
         case .needModuleInfo(let string):

--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -443,7 +443,7 @@ open class Module {
 
             switch (item, value) {
             case (.value(.parameters(let p)), .value(let newArray)):
-                if p.shape != newArray.shape, verify.contains(.all) {
+                if verify.contains(.all), p.shape != newArray.shape {
                     throw UpdateError.mismatchedSize(
                         key: key, expectedShape: p.shape, actualShape: newArray.shape)
                 }

--- a/Tests/MLXTests/ModuleTests.swift
+++ b/Tests/MLXTests/ModuleTests.swift
@@ -518,6 +518,26 @@ class ModuleTests: XCTestCase {
         }
     }
 
+    func testLinearUpdateParameters() throws {
+        let linear = Linear(1, 2, bias: false)
+
+        XCTAssertEqual(linear.weight.shape, [2, 1])
+
+        let transposedWeights = MLXArray(0 ..< 2).reshaped([1, 2])
+        try linear.update(
+            parameters: .init(item: .dictionary(["weight": .value(transposedWeights)])),
+            verify: .all)
+
+        XCTAssertEqual(linear.weight.shape, [2, 1])
+
+        let mismatchedWeights = MLXArray(0 ..< 3).reshaped([1, 3])
+        try linear.update(
+            parameters: .init(item: .dictionary(["weight": .value(mismatchedWeights)])),
+            verify: .all)
+
+        XCTAssertEqual(linear.weight.shape, [2, 1])
+    }
+
     func testQuantize() throws {
         class C: Module {
             @ModuleInfo


### PR DESCRIPTION
Added a test highlighting this. 

Right now it changes the dimensionality of the Linear layer itself, whereas I would have expected it to throw under the `verify: .all` mode.

If it is preferred to throw in this scenario, I'm happy to create a PR for the change.