### PR TITLE
Fixed wrong expected ndim Dropout3d's precondition

### DIFF
--- a/Source/MLXNN/Dropout.swift
+++ b/Source/MLXNN/Dropout.swift
@@ -111,7 +111,7 @@ open class Dropout3d: Module, UnaryLayer {
 
     open func callAsFunction(_ x: MLXArray) -> MLXArray {
         let ndim = x.ndim
-        precondition(ndim == 3 || ndim == 4)
+        precondition(ndim == 4 || ndim == 5)
 
         if p1 == 1 || !self.training {
             return x


### PR DESCRIPTION
The `Dropout3d` module should expect 4D or 5D input tensor. See python version here: https://github.com/ml-explore/mlx/blob/67b6bf530d1ad895495dc48650afb172a79c3a39/python/mlx/nn/layers/dropout.py#L122