### PR TITLE
Support using class probabilities as targets in `func crossEntropy()`

### DIFF
--- a/Source/MLXNN/Activations.swift
+++ b/Source/MLXNN/Activations.swift
@@ -459,7 +459,7 @@ open class ReLU6: Module, UnaryLayer {
 }
 
 @available(*, deprecated, renamed: "Softmax")
-@_documentation(visibility:internal)
+@_documentation(visibility: internal)
 open class SoftMax: Module, UnaryLayer {
     open func callAsFunction(_ x: MLXArray) -> MLXArray {
         softmax(x)

--- a/Source/MLXNN/Losses.swift
+++ b/Source/MLXNN/Losses.swift
@@ -28,7 +28,7 @@ public enum LossReduction: String, Sendable {
 ///
 /// - Parameters:
 ///   - logits: unnormalized predicted logits
-///   - targets: target values, as class indices
+///   - targets: target values, as class indices or class probabilities
 ///   - weights: weights for each target
 ///   - axis: axis over which to compute softmax
 ///   - labelSmoothing: label smoothing factor, range [0, 1)
@@ -45,8 +45,16 @@ public func crossEntropy(
         fatalError("labelSmoothing must be in [0, 1): \(labelSmoothing)")
     }
 
-    let score = takeAlong(logits, targets.expandedDimensions(axis: -1), axis: axis).squeezed(
+    let targets_as_probs = targets.ndim == logits.ndim
+    
+    var score: MLXArray
+    if targets_as_probs {
+        score = sum(logits * targets, axis: axis)
+    } else {
+        score = takeAlong(logits, targets.expandedDimensions(axis: -1), axis: axis).squeezed(
         axis: -1)
+    }
+    
     let logSumExpLogits = logSumExp(logits, axis: axis)
 
     var loss: MLXArray

--- a/Source/MLXNN/Losses.swift
+++ b/Source/MLXNN/Losses.swift
@@ -46,15 +46,15 @@ public func crossEntropy(
     }
 
     let targets_as_probs = targets.ndim == logits.ndim
-    
+
     var score: MLXArray
     if targets_as_probs {
         score = sum(logits * targets, axis: axis)
     } else {
         score = takeAlong(logits, targets.expandedDimensions(axis: -1), axis: axis).squeezed(
-        axis: -1)
+            axis: -1)
     }
-    
+
     let logSumExpLogits = logSumExp(logits, axis: axis)
 
     var loss: MLXArray

--- a/Tests/MLXTests/LossTests.swift
+++ b/Tests/MLXTests/LossTests.swift
@@ -1,0 +1,33 @@
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+import MLX
+import MLXNN
+import XCTest
+
+class LossTests: XCTestCase {
+    override class func setUp() {
+        setDefaultDevice()
+    }
+    
+    func testCrossEntropy() {
+        // This is just testing that crossEntropy supports both class indices and class
+        // probabilities as targets.
+
+        // test class indices
+        let logits = zeros([2, 2])
+        logits[0, 1] = MLXArray(-Float.infinity)
+        logits[1, 0] = MLXArray(-Float.infinity)
+        let indices = MLXArray([0, 1])
+        let expected = MLXArray(converting: [0.0, 0.0])
+        let loss = crossEntropy(logits: logits, targets: indices, reduction: .none)
+        XCTAssertTrue(allClose(loss, expected).item())
+
+        // test class probabilities
+        let probs = zeros([2, 2])
+        probs[0, 0] = MLXArray(1)
+        probs[1, 1] = MLXArray(1)
+        let loss2 = crossEntropy(logits: logits, targets: probs, reduction: .none)
+        XCTAssertTrue(all(isNaN(loss2)).item())
+    }
+}

--- a/Tests/MLXTests/LossTests.swift
+++ b/Tests/MLXTests/LossTests.swift
@@ -9,7 +9,7 @@ class LossTests: XCTestCase {
     override class func setUp() {
         setDefaultDevice()
     }
-    
+
     func testCrossEntropy() {
         // This is just testing that crossEntropy supports both class indices and class
         // probabilities as targets.


### PR DESCRIPTION
Added support for using class probabilities as targets in `func crossEntropy()` based on the python implementation (https://github.com/ml-explore/mlx/blob/1bdc038bf9b88d91a4f022c23a1bbcaf32a06157/python/mlx/nn/losses.py#L22)

Closes #140 