### PR TITLE
Change default reduction type of `binaryCrossEntropy` to `mean`

### DIFF
--- a/Source/MLXNN/Activations.swift
+++ b/Source/MLXNN/Activations.swift
@@ -459,7 +459,7 @@ open class ReLU6: Module, UnaryLayer {
 }
 
 @available(*, deprecated, renamed: "Softmax")
-@_documentation(visibility:internal)
+@_documentation(visibility: internal)
 open class SoftMax: Module, UnaryLayer {
     open func callAsFunction(_ x: MLXArray) -> MLXArray {
         softmax(x)

--- a/Source/MLXNN/Losses.swift
+++ b/Source/MLXNN/Losses.swift
@@ -92,7 +92,7 @@ public func crossEntropy(
 public func binaryCrossEntropy(
     logits: MLXArray, targets: MLXArray,
     weights: MLXArray? = nil, withLogits: Bool = true,
-    reduction: LossReduction = .none
+    reduction: LossReduction = .mean
 ) -> MLXArray {
     var loss: MLXArray
     if withLogits {


### PR DESCRIPTION
The python API uses `"mean"` as the default loss reduction type (https://github.com/ml-explore/mlx/blob/1bdc038bf9b88d91a4f022c23a1bbcaf32a06157/python/mlx/nn/losses.py#L122).

Closes #141 