### PR TITLE
fix: Fix wrong Wh shape in GRU and LSTM

### DIFF
--- a/Source/MLXNN/Activations.swift
+++ b/Source/MLXNN/Activations.swift
@@ -459,7 +459,7 @@ open class ReLU6: Module, UnaryLayer {
 }
 
 @available(*, deprecated, renamed: "Softmax")
-@_documentation(visibility:internal)
+@_documentation(visibility: internal)
 open class SoftMax: Module, UnaryLayer {
     open func callAsFunction(_ x: MLXArray) -> MLXArray {
         softmax(x)

--- a/Source/MLXNN/Recurrent.swift
+++ b/Source/MLXNN/Recurrent.swift
@@ -109,7 +109,7 @@ open class GRU: Module {
         self._wx.wrappedValue = MLXRandom.uniform(
             low: -scale, high: scale, [3 * hiddenSize, inputSize])
         self._wh.wrappedValue = MLXRandom.uniform(
-            low: -scale, high: scale, [3 * hiddenSize, inputSize])
+            low: -scale, high: scale, [3 * hiddenSize, hiddenSize])
         if bias {
             self.b = MLXRandom.uniform(low: -scale, high: scale, [3 * hiddenSize])
             self.bhn = MLXRandom.uniform(low: -scale, high: scale, [hiddenSize])
@@ -206,7 +206,7 @@ open class LSTM: Module {
         self._wx.wrappedValue = MLXRandom.uniform(
             low: -scale, high: scale, [4 * hiddenSize, inputSize])
         self._wh.wrappedValue = MLXRandom.uniform(
-            low: -scale, high: scale, [4 * hiddenSize, inputSize])
+            low: -scale, high: scale, [4 * hiddenSize, hiddenSize])
         if bias {
             self.bias = MLXRandom.uniform(low: -scale, high: scale, [4 * hiddenSize])
         } else {


### PR DESCRIPTION
The current implementation initializes `Wh` with shape `(3 * hiddenSize, inputSize)` and `(4 * hiddenSize, inputSize)` for `GRU` and `LSTM`, respectively. However, `Wh` in `GRU` and `LSTM` should be initialized with shape `(3 * hidden_size, hidden_size)` and `(4 * hidden_size, hidden_size)` as shown in the python code ([GRU](https://github.com/ml-explore/mlx/blob/211411faf2a22bb4e2637abe5a5df21c61e33af7/python/mlx/nn/layers/recurrent.py#L137) and [LSTM](https://github.com/ml-explore/mlx/blob/211411faf2a22bb4e2637abe5a5df21c61e33af7/python/mlx/nn/layers/recurrent.py#L246))