### PR TITLE
fix: Fix wrong layer norm used in `TransformerDecoderLayer`

### DIFF
--- a/Source/MLXNN/Activations.swift
+++ b/Source/MLXNN/Activations.swift
@@ -459,7 +459,7 @@ open class ReLU6: Module, UnaryLayer {
 }
 
 @available(*, deprecated, renamed: "Softmax")
-@_documentation(visibility:internal)
+@_documentation(visibility: internal)
 open class SoftMax: Module, UnaryLayer {
     open func callAsFunction(_ x: MLXArray) -> MLXArray {
         softmax(x)

--- a/Source/MLXNN/Transformer.swift
+++ b/Source/MLXNN/Transformer.swift
@@ -267,7 +267,7 @@ class TransformerDecoderLayer: Module {
 
             y = crossAttention(y, keys: memory, values: memory, mask: memoryMask)
             y = dropout2(y)
-            x = ln1(x + y)
+            x = ln2(x + y)
 
             y = linear1(x)
             y = activation(y)


### PR DESCRIPTION
Fixes: #169 