### PR TITLE
Update check all set

### DIFF
--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -456,6 +456,11 @@ open class Module {
                 for (i, (arrayItem, valueItem)) in zip(array, values).enumerated() {
                     try apply(key: "\(key).\(i)", arrayItem, valueItem)
                 }
+                if verify.contains(.allModelKeysSet) {
+                    for i in values.count ..< array.count {
+                        try apply(key: "\(key).\(i)", array[i], .none)
+                    }
+                }
 
             case (.array(let array), .none):
                 for (i, arrayItem) in array.enumerated() {

--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -382,7 +382,7 @@ open class Module {
         /// are used -- there are no names that don't match.
         static public let noUnusedKeys = VerifyUpdate(rawValue: 1 << 0)
 
-        // TODO: add a load_weights style strict -- verify that all keys on the model are specified
+        static public let allModelKeysSet = VerifyUpdate(rawValue: 1 << 1)
 
         static public let all = VerifyUpdate(rawValue: -1)
         static public let none = VerifyUpdate([])
@@ -432,7 +432,7 @@ open class Module {
     open func update(parameters: ModuleParameters, verify: VerifyUpdate) throws -> Self {
 
         func apply(key: String, _ item: ModuleItem, _ value: NestedItem<String, MLXArray>) throws {
-            if case .none = value {
+            if case .none = value, !verify.contains(.allModelKeysSet) {
                 return
             }
 
@@ -449,20 +449,41 @@ open class Module {
                 }
                 p.update(newArray)
 
+            case (.value(.parameters(let p)), .none):
+                throw UpdateError.keyNotFound(base: describeType(self), key: key)
+
             case (.array(let array), .array(let values)):
                 for (i, (arrayItem, valueItem)) in zip(array, values).enumerated() {
                     try apply(key: "\(key).\(i)", arrayItem, valueItem)
                 }
 
+            case (.array(let array), .none):
+                for (i, arrayItem) in array.enumerated() {
+                    try apply(key: "\(key).\(i)", arrayItem, .none)
+                }
+
             case (.dictionary(let dictionary), .dictionary(let values)):
-                for (valueKey, valueItem) in values {
-                    if let dictionaryItem = dictionary[key] {
-                        try apply(key: "\(key).\(valueKey)", dictionaryItem, valueItem)
+                for (dictionaryKey, dictionaryItem) in dictionary {
+                    if let valueItem = values[key] {
+                        try apply(key: "\(key).\(dictionaryKey)", dictionaryItem, valueItem)
+                    } else if verify.contains(.allModelKeysSet) {
+                        try apply(key: "\(key).\(dictionaryKey)", dictionaryItem, .none)
                     }
+                }
+
+            case (.dictionary(let dictionary), .none):
+                for (dictionaryKey, dictionaryItem) in dictionary {
+                    try apply(key: "\(key).\(dictionaryKey)", dictionaryItem, .none)
                 }
 
             case (.value(.module(let module)), .dictionary(let values)):
                 try module.update(parameters: NestedDictionary(values: values), verify: verify)
+
+            case (.value(.module(let module)), .none):
+                try module.update(parameters: NestedDictionary(), verify: verify)
+
+            case (.none, .none), (.value(.none), .none), (.value(.other(_)), .none):
+                break
 
             default:
                 fatalError("Unable to set \(key) on \(self): \(item) not compatible with \(value)")
@@ -474,6 +495,8 @@ open class Module {
             if let value = parameters[key] {
                 processed.remove(key)
                 try apply(key: key, item, value)
+            } else if verify.contains(.allModelKeysSet) {
+                try apply(key: key, item, .none)
             }
         }
 

--- a/Tests/MLXTests/ModuleTests.swift
+++ b/Tests/MLXTests/ModuleTests.swift
@@ -557,7 +557,7 @@ class ModuleTests: XCTestCase {
             guard let error = error as? UpdateError,
                 case let .keyNotFound(base: base, key: key) = error
             else {
-                XCTFail("Expected to fail with UpdateError.mismatchedSize, but got: \(error)")
+                XCTFail("Expected to fail with UpdateError.keyNotFound, but got: \(error)")
                 return
             }
             XCTAssertEqual(key, "bias")


### PR DESCRIPTION
When calling `m.update(parameters: ..., verify: .all)` on a module, there is no check that is performed to ensure that all the parameters under `m` have been set. This has bitten me a couple times when porting a model to mlx-swift, and I think it's related to this todo in [Module.swift](https://github.com/ml-explore/mlx-swift/blob/70dbb62128a5a1471a5ab80363430adb33470cab/Source/MLXNN/Module.swift#L385).

This PR adds some support to check also for this. A couple comments:
- Most of the change is in the recursive call to `.apply` where the `.value` can be `.none` for the case where we don't have anything in the parameters but have to go through the modules to check that there is no parameter to be set.
- When handling the `.dictionary` case , the iteration has been changed so that we ensure to go over all the model items rather than going through all the parameters.
- This modifies the default behavior so it's a breaking change. Another possibility could be to set `.all` not to include the new `.allModelKeysSet` and have a new `.strict` flag that is `.all + .allModelKeysSet`. 
- This only affects the parameters update, not the update with modules.
- A dedicated test has been added.

Any feedback on this is very welcome.