### PR TITLE
Add setErrorHandler and fatalErrorHandler

### DIFF
--- a/Source/MLX/Documentation.docc/free-functions.md
+++ b/Source/MLX/Documentation.docc/free-functions.md
@@ -230,3 +230,5 @@ operations as methods for convenience.
 - ``einsum(_:_:stream:)``
 - ``hadamardTransform(_:scale:stream:)``
 - ``view(_:dtype:stream:)``
+- ``setErrorHandler(_:data:dtor:)``
+- ``fatalErrorHandler``

--- a/Source/MLX/ErrorHandler.swift
+++ b/Source/MLX/ErrorHandler.swift
@@ -1,0 +1,20 @@
+import Cmlx
+import Foundation
+
+/// Sets the error handler. The default error handler will simply print out the error, then exit.
+/// - Parameters:
+///   - handler: An error handler. Pass nil to reset to the default error handler. Pass
+///   ``fatalErrorHandler`` to make the error handler call `fatalError` for improved Xcode debugging.
+public func setErrorHandler(
+    _ handler: (@convention(c) (UnsafePointer<CChar>?, UnsafeMutableRawPointer?) -> Void)?,
+    data: UnsafeMutableRawPointer? = nil,
+    dtor: (@convention(c) (UnsafeMutableRawPointer?) -> Void)? = nil
+) {
+    mlx_set_error_handler(handler, data, dtor)
+}
+
+/// An error handler that calls `fatalError`.
+public let fatalErrorHandler:
+    @convention(c) (UnsafePointer<CChar>?, UnsafeMutableRawPointer?) -> Void = { message, _ in
+        fatalError(message.map { String(cString: $0) } ?? "")
+    }


### PR DESCRIPTION
- exposes `setErrorHandler` from mlx-c
- Adds a `fatalErrorHandler` which calls `fatalError`, recording a stack trace and attaching the debugger in Xcode. It would be nice to set this by default in mlx-swift, but I'm not sure if that's possible.

Usage: `setErrorHandler(fatalErrorHandler)`