### PR TITLE
Fix https://github.com/ml-explore/mlx-swift-examples/issues/218

### DIFF
--- a/Tests/MLXTests/ModuleTests.swift
+++ b/Tests/MLXTests/ModuleTests.swift
@@ -770,4 +770,27 @@ class ModuleTests: XCTestCase {
         XCTAssertTrue(pm.mlp.0 is QuantizedLinear)
         XCTAssertTrue(pm.mlp.2 is QuantizedLinear)
     }
+
+    func testModulesWithMLXArrayProperties() throws {
+        // https://github.com/ml-explore/mlx-swift-examples/issues/218
+
+        class SuScaledRotaryEmbedding: Module {
+            let _freqs: MLXArray
+
+            override init() {
+                _freqs = MLXArray(7)
+            }
+        }
+
+        let rope = SuScaledRotaryEmbedding()
+
+        // no parameters
+        XCTAssertEqual(rope.parameters().count, 0)
+
+        // but it can see the _freqs property
+        XCTAssertEqual(rope.items().count, 1)
+
+        // this should not throw because _freqs is not considered
+        try rope.update(parameters: .init(), verify: .all)
+    }
 }


### PR DESCRIPTION
- do not fail parameter update validation for "invalid" keys (e.g. _freqs)

In particular SuScaledRotaryEmbedding is failing validation on `update(parameters:)` because of a missing `_freqs`:

```swift
public class SuScaledRotaryEmbedding: Module {
    let _freqs: MLXArray

    public init(
...
    ) {
...
        let exponent =
            MLXArray(stride(from: 0, to: dimensions, by: 2)).asType(.float32) / Float(dimensions)
        let freqs = MLX.pow(MLXArray(base), exponent)
        self._freqs = MLXArray(longFactor).asType(.float32) * freqs
```

`_freqs` isn't really a parameter -- it is not meant to be updated, hence the naming with `_`.