### PR TITLE
fix smoothL1Loss

### DIFF
--- a/Source/MLXNN/Losses.swift
+++ b/Source/MLXNN/Losses.swift
@@ -213,7 +213,7 @@ public func smoothL1Loss(
 ) -> MLXArray {
     precondition(predictions.shape == targets.shape)
 
-    let diff = predictions - targets
+    let diff = abs(predictions - targets)
     let loss = which(diff .< beta, 0.5 * square(diff) / beta, abs(diff) - 0.5 * beta)
 
     return reduction.reduce(loss: loss)

--- a/Source/MLXNN/Losses.swift
+++ b/Source/MLXNN/Losses.swift
@@ -214,7 +214,7 @@ public func smoothL1Loss(
     precondition(predictions.shape == targets.shape)
 
     let diff = abs(predictions - targets)
-    let loss = which(diff .< beta, 0.5 * square(diff) / beta, abs(diff) - 0.5 * beta)
+    let loss = which(diff .< beta, 0.5 * square(diff) / beta, diff - 0.5 * beta)
 
     return reduction.reduce(loss: loss)
 }


### PR DESCRIPTION
file: `Source/MLXNN/Losses.swift`

```
public func smoothL1Loss(
    predictions: MLXArray, targets: MLXArray, beta: Float = 1, reduction: LossReduction = .mean
) -> MLXArray {
    precondition(predictions.shape == targets.shape)

    let diff = abs(predictions - targets)
    let loss = which(diff .< beta, 0.5 * square(diff) / beta, abs(diff) - 0.5 * beta)

    return reduction.reduce(loss: loss)
}
```

According to the definition of smooth l1 loss

$$l = 
\begin{cases} 
0.5(x - y)^2 / \beta, & \text{if } |x - y| < \beta \\
|x - y| - 0.5\beta, & \text{otherwise}
\end{cases}$$

```
    let diff = predictions - targets
```

should be 
```
    let diff = abs(predictions - targets)
```