### PR TITLE
fix disconnected (moved, new params, etc.) links in documentation

### DIFF
--- a/Source/MLX/Documentation.docc/Articles/compilation.md
+++ b/Source/MLX/Documentation.docc/Articles/compilation.md
@@ -1,11 +1,11 @@
 # Compilation
 
-MLX has a ``compile(inputs:outputs:shapeless:_:)-7korq`` function transformation which compiles computation
+MLX has a ``compile(inputs:outputs:shapeless:_:)-8wq3u`` function transformation which compiles computation
 graphs. Function compilation results in smaller graphs by merging common work
 and fusing certain operations. In many cases this can lead to big improvements
 in run-time and memory use.
 
-Getting started with ``compile(inputs:outputs:shapeless:_:)-7korq`` is simple, but there are 
+Getting started with ``compile(inputs:outputs:shapeless:_:)-8wq3u`` is simple, but there are 
 some edge cases that are good to be aware of for more complex graphs and advanced usage.
 
 ## Basics of Compile
@@ -70,7 +70,7 @@ public func gelu(_ x: MLXArray) -> MLXArray {
 If you use this function with small arrays, it will be overhead bound. If you
 use it with large arrays it will be memory bandwidth bound.  However, all of
 the operations in the `gelu` are fusible into a single kernel with
-``compile(inputs:outputs:shapeless:_:)-29n3k``. This can speedup both cases considerably.
+``compile(inputs:outputs:shapeless:_:)-8wq3u``. This can speedup both cases considerably.
 
 Let's compare the runtime of the regular function versus the compiled
 function. We'll use the following timing helper which does a warm up and
@@ -182,7 +182,7 @@ print(state)
 ```
 
 In some cases returning updated state can be pretty inconvenient. Hence,
-``compile(inputs:outputs:shapeless:_:)-7korq`` has a parameter to capture implicit state:
+``compile(inputs:outputs:shapeless:_:)-8wq3u`` has a parameter to capture implicit state:
 
 ```swift
 var state = [MLXArray]()
@@ -242,10 +242,10 @@ XCTAssertFalse(allClose(c2a, c2b).item())
 
 ## Compiling Training Graphs 
 
-This section will step through how to use ``compile(inputs:outputs:shapeless:_:)-7korq`` 
+This section will step through how to use ``compile(inputs:outputs:shapeless:_:)-8wq3u`` 
 with a simple example of a common setup: training a model with `Module` using an
 `Optimizer` with state. We will show how to compile the
-full forward, backward, and update with ``compile(inputs:outputs:shapeless:_:)-7korq``.
+full forward, backward, and update with ``compile(inputs:outputs:shapeless:_:)-8wq3u``.
 
 Here is the basic scenario:
 
@@ -319,7 +319,7 @@ for _ in 0 ..< 30 {
 
 ### Functions
 
-- ``compile(inputs:outputs:shapeless:_:)-7korq``
-- ``compile(inputs:outputs:shapeless:_:)-29n3k``
-- ``compile(inputs:outputs:shapeless:_:)-4msdm``
+- ``compile(inputs:outputs:shapeless:_:)-8wq3u``
+- ``compile(inputs:outputs:shapeless:_:)-15bpz``
+- ``compile(inputs:outputs:shapeless:_:)-47dv3``
 - ``compile(enable:)``

--- a/Source/MLX/Documentation.docc/Articles/converting-python.md
+++ b/Source/MLX/Documentation.docc/Articles/converting-python.md
@@ -211,7 +211,7 @@ This is a mapping of `mx` free functions to their ``MLX`` counterparts.
 `not_equal` | ``MLX/notEqual(_:_:stream:)``
 `ones` | ``MLXArray/ones(_:type:stream:)``
 `ones_like` | ``MLXArray/ones(like:stream:)``
-`pad` | ``MLX/padded(_:widths:value:stream:)``
+`pad` | ``MLX/padded(_:width:mode:value:stream:)``
 `partition` | ``MLX/partitioned(_:kth:axis:stream:)``
 `power` | ``MLX/pow(_:_:stream:)-8ie9c``
 `prod` | ``MLX/product(_:axes:keepDims:stream:)``

--- a/Source/MLX/Documentation.docc/Organization/shapes.md
+++ b/Source/MLX/Documentation.docc/Organization/shapes.md
@@ -66,8 +66,8 @@ These methods manipulate the shape and contents of the array:
 - ``concatenated(_:axis:stream:)``
 - ``expandedDimensions(_:axes:stream:)``
 - ``movedAxis(_:source:destination:stream:)``
-- ``padded(_:width:value:stream:)``
-- ``padded(_:widths:value:stream:)``
+- ``padded(_:width:mode:value:stream:)``
+- ``padded(_:widths:mode:value:stream:)``
 - ``split(_:indices:axis:stream:)``
 - ``split(_:parts:axis:stream:)``
 - ``split(_:axis:stream:)``

--- a/Source/MLX/Documentation.docc/free-functions.md
+++ b/Source/MLX/Documentation.docc/free-functions.md
@@ -166,8 +166,8 @@ operations as methods for convenience.
 - ``expandedDimensions(_:axes:stream:)``
 - ``expandedDimensions(_:axis:stream:)``
 - ``movedAxis(_:source:destination:stream:)``
-- ``padded(_:width:value:stream:)``
-- ``padded(_:widths:value:stream:)``
+- ``padded(_:width:mode:value:stream:)``
+- ``padded(_:widths:mode:value:stream:)``
 - ``reshaped(_:_:stream:)-5x3y0``
 - ``reshaped(_:_:stream:)-96lgr``
 - ``split(_:indices:axis:stream:)``

--- a/Source/MLX/FFT.swift
+++ b/Source/MLX/FFT.swift
@@ -259,9 +259,9 @@ public enum MLXFFT {
     ///
     /// - Parameters:
     ///   - array: input array
-    ///   - n: size of the transformed axis.  The corresponding axis in the input is truncated or padded with zeros to
     ///   match `n / 2 + 1`.  If not specified `array.dim(axis) / 2 + 1` will be used.
-    ///   - axis: axis along which to perform the FFT
+    ///   - s: sizes of the transformed axis.  The corresponding axes in the input are truncated or padded with zeros to
+    ///   - axes: axes along which to perform the FFT
     ///   - stream: stream or device to evaluate on
     /// - Returns: inverse of ``rfft2(_:s:axes:stream:)``
     ///
@@ -333,9 +333,9 @@ public enum MLXFFT {
     ///
     /// - Parameters:
     ///   - array: input array
-    ///   - n: size of the transformed axis.  The corresponding axis in the input is truncated or padded with zeros to
+    ///   - s: sizes of the transformed axis.  The corresponding axes in the input are truncated or padded with zeros to
     ///   match `n / 2 + 1`.  If not specified `array.dim(axis) / 2 + 1` will be used.
-    ///   - axis: axis along which to perform the FFT
+    ///   - axes: axes along which to perform the FFT
     ///   - stream: stream or device to evaluate on
     /// - Returns: inverse of ``rfftn(_:s:axes:stream:)``
     ///
@@ -560,9 +560,9 @@ public func rfft2(
 ///
 /// - Parameters:
 ///   - array: input array
-///   - n: size of the transformed axis.  The corresponding axis in the input is truncated or padded with zeros to
-///   match `n / 2 + 1`.  If not specified `array.dim(axis) / 2 + 1` will be used.
-///   - axis: axis along which to perform the FFT
+///   - s: sizes of the transformed axis.  The corresponding axes in the input are truncated or padded with zeros to
+///   match `s`.  If not specified `array.dim(axes)` will be used.
+///   - axes: axes along which to perform the FFT
 ///   - stream: stream or device to evaluate on
 /// - Returns: inverse of ``rfft2(_:s:axes:stream:)``
 ///
@@ -605,9 +605,9 @@ public func rfftn(
 ///
 /// - Parameters:
 ///   - array: input array
-///   - n: size of the transformed axis.  The corresponding axis in the input is truncated or padded with zeros to
-///   match `n / 2 + 1`.  If not specified `array.dim(axis) / 2 + 1` will be used.
-///   - axis: axis along which to perform the FFT
+///   - s: sizes of the transformed axis.  The corresponding axes in the input are truncated or padded with zeros to
+///   match `s`.  If not specified `array.dim(axes)` will be used.
+///   - axes: axes along which to perform the FFT
 ///   - stream: stream or device to evaluate on
 /// - Returns: inverse of ``rfftn(_:s:axes:stream:)``
 ///

--- a/Source/MLX/Factory.swift
+++ b/Source/MLX/Factory.swift
@@ -40,7 +40,7 @@ extension MLXArray {
     ///
     /// - Parameters:
     ///     - shape: desired shape
-    ///     - type: dtype of the values
+    ///     - dtype: dtype of the values
     ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
@@ -65,7 +65,7 @@ extension MLXArray {
     /// ```
     ///
     /// - Parameters:
-    ///     - like: array to copy shape and dtype from
+    ///     - array: array to copy shape and dtype from
     ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
@@ -113,7 +113,7 @@ extension MLXArray {
     ///
     /// - Parameters:
     ///     - shape: desired shape
-    ///     - type: dtype of the values
+    ///     - dtype: dtype of the values
     ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
@@ -138,7 +138,7 @@ extension MLXArray {
     /// ```
     ///
     /// - Parameters:
-    ///     - like: array to copy shape and dtype from
+    ///     - array: array to copy shape and dtype from
     ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
@@ -472,7 +472,7 @@ public func zeros<T: HasDType>(
 /// ```
 ///
 /// - Parameters:
-///     - like: array to copy shape and dtype from
+///     - array: array to copy shape and dtype from
 ///     - stream: stream or device to evaluate on
 ///
 /// ### See Also
@@ -520,7 +520,7 @@ public func ones<T: HasDType>(
 /// ```
 ///
 /// - Parameters:
-///     - like: array to copy shape and dtype from
+///     - array: array to copy shape and dtype from
 ///     - stream: stream or device to evaluate on
 ///
 /// ### See Also

--- a/Source/MLX/Linalg.swift
+++ b/Source/MLX/Linalg.swift
@@ -8,8 +8,8 @@ public enum MLXLinalg {
     /// Types of norms available.
     ///
     /// ### See Also
-    /// - ``norm(_:ord:axes:keepDims:stream:)-4dwwp``
-    /// - ``norm(_:ord:axes:keepDims:stream:)-3t3ay``
+    /// - ``norm(_:ord:axes:keepDims:stream:)``
+    /// - ``norm(_:ord:axes:keepDims:stream:)-8zljj``
     /// - ``MLXLinalg``
     public enum NormKind: String, Sendable {
         /// Frobenius norm
@@ -56,7 +56,7 @@ public enum MLXLinalg {
     /// - Returns: output containing the norm(s)
     ///
     /// ### See Also
-    /// - ``norm(_:ord:axes:keepDims:stream:)-3t3ay``
+    /// - ``norm(_:ord:axes:keepDims:stream:)``
     public static func norm(
         _ array: MLXArray, ord: NormKind? = nil, axes: [Int], keepDims: Bool = false,
         stream: StreamOrDevice = .default
@@ -141,7 +141,7 @@ public enum MLXLinalg {
 
     /// Matrix or vector norm.
     ///
-    /// See ``norm(_:ord:axes:keepDims:stream:)-3t3ay``
+    /// See ``norm(_:ord:axes:keepDims:stream:)``
     public static func norm(
         _ array: MLXArray, ord: Double, axis: Int, keepDims: Bool = false,
         stream: StreamOrDevice = .default
@@ -173,7 +173,7 @@ public enum MLXLinalg {
 
     /// Matrix or vector norm.
     ///
-    /// See ``norm(_:ord:axes:keepDims:stream:)-3t3ay``
+    /// See ``norm(_:ord:axes:keepDims:stream:)``
     public static func norm(
         _ array: MLXArray, ord: Double, axis: IntOrArray? = nil,
         keepDims: Bool = false, stream: StreamOrDevice = .default
@@ -327,11 +327,11 @@ public enum MLXLinalg {
         return MLXArray(result)
     }
 
-    /// Compute the LU factorization of the given matrix ``A``.
+    /// Compute the LU factorization of the given matrix `A`.
     ///
-    /// Note, unlike the default behavior of ``scipy.linalg.lu``, the pivots
-    /// are indices. To reconstruct the input use ``L[P] @ U`` for 2
-    /// dimensions or ``takeAlong(L, P[.ellipsis, .newAxis], axis: -2) @ U``
+    /// Note, unlike the default behavior of `scipy.linalg.lu`, the pivots
+    /// are indices. To reconstruct the input use `L[P] @ U` for 2
+    /// dimensions or `takeAlong(L, P[.ellipsis, .newAxis], axis: -2) @ U`
     /// for more than 2 dimensions.
     ///
     /// To construct the full permuation matrix do:
@@ -365,7 +365,7 @@ public enum MLXLinalg {
         return (MLXArray(res_0), MLXArray(res_1))
     }
 
-    /// Compute the solution to a system of linear equations ``AX = B``.
+    /// Compute the solution to a system of linear equations `AX = B`.
     ///
     /// -Parameters:
     ///   - a: input array.
@@ -379,7 +379,7 @@ public enum MLXLinalg {
         return MLXArray(result)
     }
 
-    ///Computes the solution of a triangular system of linear equations ``AX = B``.
+    ///Computes the solution of a triangular system of linear equations `AX = B`.
     ///
     /// -Parameters:
     ///   - a: input array.
@@ -438,7 +438,7 @@ public enum MLXLinalg {
 /// - Returns: output containing the norm(s)
 ///
 /// ### See Also
-/// - ``norm(_:ord:axes:keepDims:stream:)-3t3ay``
+/// - ``norm(_:ord:axes:keepDims:stream:)``
 public func norm(
     _ array: MLXArray, ord: MLXLinalg.NormKind? = nil, axes: [Int], keepDims: Bool = false,
     stream: StreamOrDevice = .default
@@ -496,7 +496,7 @@ public func norm(
 
 /// Matrix or vector norm.
 ///
-/// See ``norm(_:ord:axes:keepDims:stream:)-3t3ay``
+/// See ``norm(_:ord:axes:keepDims:stream:)``
 public func norm(
     _ array: MLXArray, ord: Double, axis: Int, keepDims: Bool = false,
     stream: StreamOrDevice = .default
@@ -516,7 +516,7 @@ public func norm(
 
 /// Matrix or vector norm.
 ///
-/// See ``norm(_:ord:axes:keepDims:stream:)-3t3ay``
+/// See ``norm(_:ord:axes:keepDims:stream:)``
 public func norm(
     _ array: MLXArray, ord: Double, axis: IntOrArray? = nil,
     keepDims: Bool = false, stream: StreamOrDevice = .default
@@ -669,7 +669,7 @@ public func lu_factor(_ a: MLXArray, stream: StreamOrDevice = .default)
     return MLXLinalg.lu_factor(a, stream: stream)
 }
 
-/// Compute the solution to a system of linear equations ``AX = B``.
+/// Compute the solution to a system of linear equations `AX = B`.
 ///
 /// -Parameters:
 ///   - a: input array.
@@ -681,7 +681,7 @@ public func solve(_ a: MLXArray, _ b: MLXArray, stream: StreamOrDevice = .defaul
     return MLXLinalg.solve(a, b, stream: stream)
 }
 
-///Computes the solution of a triangular system of linear equations ``AX = B``.
+///Computes the solution of a triangular system of linear equations `AX = B`.
 ///
 /// -Parameters:
 ///   - a: input array.

--- a/Source/MLX/MLXFastKernel.swift
+++ b/Source/MLX/MLXFastKernel.swift
@@ -1,7 +1,6 @@
 // Copyright © 2024 Apple Inc.
 
 import Cmlx
-import MLX
 
 /// Marker protocol for types that can be used in the `template` of a kernel call.
 ///
@@ -10,7 +9,7 @@ import MLX
 /// - `Bool`
 /// - `DType`
 ///
-/// See also: ``MLXFastKernel``
+/// See also: ``MLXFast/MLXFastKernel``
 public protocol KernelTemplateArg {}
 
 extension Bool: KernelTemplateArg {}

--- a/Source/MLX/Protocols.swift
+++ b/Source/MLX/Protocols.swift
@@ -9,7 +9,7 @@ import Foundation
 /// implemention detail for MLX and should not be depended on by outside callers.
 ///
 /// ### See Also
-/// - ``compile(inputs:outputs:shapeless:_:)-7korq``
+/// - ``compile(inputs:outputs:shapeless:_:)-8wq3u``
 public protocol Updatable {
     func innerState() -> [MLXArray]
 }

--- a/Source/MLX/Transforms+Compile.swift
+++ b/Source/MLX/Transforms+Compile.swift
@@ -126,8 +126,6 @@ final class CompiledFunction: @unchecked (Sendable) {
 ///
 /// ### See Also
 /// - <doc:compilation>
-/// - ``compile(inputs:outputs:shapeless:_:)-29n3k``
-/// - ``compile(inputs:outputs:shapeless:_:)-4msdm``
 public func compile(
     inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f: @escaping ([MLXArray]) -> [MLXArray]
@@ -139,12 +137,12 @@ public func compile(
     }
 }
 
-/// Overload of ``compile(inputs:outputs:shapeless:_:)-7korq`` that takes a single ``MLXArray`` and
+/// Overload of ``compile(inputs:outputs:shapeless:_:)-8wq3u`` that takes a single ``MLXArray`` and
 /// produces a single ``MLXArray``.
 ///
 /// ### See Also
 /// - <doc:compilation>
-/// - ``compile(inputs:outputs:shapeless:_:)-7korq``
+/// - ``compile(inputs:outputs:shapeless:_:)-8wq3u``
 public func compile(
     inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f: @escaping (MLXArray) -> MLXArray
@@ -158,12 +156,12 @@ public func compile(
     }
 }
 
-/// Overload of ``compile(inputs:outputs:shapeless:_:)-7korq`` that takes two ``MLXArray`` and
+/// Overload of ``compile(inputs:outputs:shapeless:_:)-8wq3u`` that takes two ``MLXArray`` and
 /// produces a single ``MLXArray``.
 ///
 /// ### See Also
 /// - <doc:compilation>
-/// - ``compile(inputs:outputs:shapeless:_:)-7korq``
+/// - ``compile(inputs:outputs:shapeless:_:)-8wq3u``
 public func compile(
     inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f: @escaping (MLXArray, MLXArray) -> MLXArray
@@ -179,12 +177,12 @@ public func compile(
     }
 }
 
-/// Overload of ``compile(inputs:outputs:shapeless:_:)-7korq`` that takes three ``MLXArray`` and
+/// Overload of ``compile(inputs:outputs:shapeless:_:)-8wq3u`` that takes three ``MLXArray`` and
 /// produces a single ``MLXArray``.
 ///
 /// ### See Also
 /// - <doc:compilation>
-/// - ``compile(inputs:outputs:shapeless:_:)-7korq``
+/// - ``compile(inputs:outputs:shapeless:_:)-8wq3u``
 public func compile(
     inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f: @Sendable @escaping (MLXArray, MLXArray, MLXArray) -> MLXArray
@@ -200,7 +198,7 @@ public func compile(
     }
 }
 
-/// Globally enable or disable ``compile(inputs:outputs:shapeless:_:)-7korq``.
+/// Globally enable or disable ``compile(inputs:outputs:shapeless:_:)-8wq3u``.
 ///
 /// Default is enabled.
 public func compile(enable: Bool = true) {

--- a/Source/MLXFast/MLXFastKernel.swift
+++ b/Source/MLXFast/MLXFastKernel.swift
@@ -6,7 +6,7 @@ import MLX
 /// Container for a kernel created by
 /// ``metalKernel(name:inputNames:outputNames:source:header:ensureRowContiguous:atomicOutputs:template:grid:threadGroup:outputShapes:outputDTypes:initValue:verbose:)``
 ///
-/// The ``callAsFunction(_:stream:)`` can be used to evaluate the kernel with inputs:
+/// The ``MLXFast/MLXFastKernel`` can be used to evaluate the kernel with inputs:
 ///
 /// ```swift
 /// let a = normal([2, 2])
@@ -56,7 +56,7 @@ public func metalKernel(
     initValue: Float? = nil,
     verbose: Bool = false
 ) -> MLXFast.MLXFastKernel {
-    return metalKernel(
+    return MLX.MLXFast.metalKernel(
         name: name, inputNames: inputNames, outputNames: outputNames, source: source,
         header: header,
         ensureRowContiguous: ensureRowContiguous, atomicOutputs: atomicOutputs,

--- a/Source/MLXLinalg/Linalg.swift
+++ b/Source/MLXLinalg/Linalg.swift
@@ -50,7 +50,7 @@ public let deprecationWarning: Void = ()
 /// - Returns: output containing the norm(s)
 ///
 /// ### See Also
-/// - ``norm(_:ord:axes:keepDims:stream:)-3t3ay``
+/// - ``norm(_:ord:axes:keepDims:stream:)``
 @available(*, deprecated, message: "norm is now avaiable in the main MLX module")
 @_disfavoredOverload
 public func norm(
@@ -124,7 +124,7 @@ public func norm(
 
 /// Matrix or vector norm.
 ///
-/// See ``norm(_:ord:axes:keepDims:stream:)-3t3ay``
+/// See ``norm(_:ord:axes:keepDims:stream:)``
 @available(*, deprecated, message: "norm is now avaiable in the main MLX module")
 @_disfavoredOverload
 public func norm(
@@ -148,7 +148,7 @@ public func norm(
 
 /// Matrix or vector norm.
 ///
-/// See ``norm(_:ord:axes:keepDims:stream:)-3t3ay``
+/// See ``norm(_:ord:axes:keepDims:stream:)``
 @available(*, deprecated, message: "norm is now avaiable in the main MLX module")
 @_disfavoredOverload
 public func norm(
@@ -321,7 +321,7 @@ public func lu_factor(_ a: MLXArray, stream: StreamOrDevice = .default)
     return MLXLinalg.lu_factor(a, stream: stream)
 }
 
-/// Compute the solution to a system of linear equations ``AX = B``.
+/// Compute the solution to a system of linear equations `AX = B`.
 ///
 /// -Parameters:
 ///   - a: input array.
@@ -335,7 +335,7 @@ public func solve(_ a: MLXArray, _ b: MLXArray, stream: StreamOrDevice = .defaul
     return MLXLinalg.solve(a, b, stream: stream)
 }
 
-///Computes the solution of a triangular system of linear equations ``AX = B``.
+///Computes the solution of a triangular system of linear equations `AX = B`.
 ///
 /// -Parameters:
 ///   - a: input array.

--- a/Source/MLXNN/Convolution.swift
+++ b/Source/MLXNN/Convolution.swift
@@ -8,7 +8,7 @@ import MLX
 /// ### See Also
 /// - ``Conv2d``
 /// - ``Conv3d``
-/// - ``init(inputChannels:outputChannels:kernelSize:stride:padding:bias:)``
+/// - ``init(inputChannels:outputChannels:kernelSize:stride:padding:dilation:groups:bias:)``
 open class Conv1d: Module, UnaryLayer {
 
     public let weight: MLXArray
@@ -71,7 +71,7 @@ open class Conv1d: Module, UnaryLayer {
 /// ### See Also
 /// - ``Conv1d``
 /// - ``Conv3d``
-/// - ``init(inputChannels:outputChannels:kernelSize:stride:padding:bias:)``
+/// - ``init(inputChannels:outputChannels:kernelSize:stride:padding:dilation:groups:bias:)``
 open class Conv2d: Module, UnaryLayer {
 
     public let weight: MLXArray
@@ -137,7 +137,7 @@ open class Conv2d: Module, UnaryLayer {
 /// ### See Also
 /// - ``Conv1d``
 /// - ``Conv2d``
-/// - ``init(inputChannels:outputChannels:kernelSize:stride:padding:bias:)``
+/// - ``init(inputChannels:outputChannels:kernelSize:stride:padding:dilation:groups:bias:)``
 open class Conv3d: Module, UnaryLayer {
 
     public let weight: MLXArray

--- a/Source/MLXNN/ConvolutionTransposed.swift
+++ b/Source/MLXNN/ConvolutionTransposed.swift
@@ -8,7 +8,7 @@ import MLX
 /// ### See Also
 /// - ``ConvTransposed2d``
 /// - ``ConvTransposed3d``
-/// - ``init(inputChannels:outputChannels:kernelSize:stride:padding:bias:)``
+/// - ``init(inputChannels:outputChannels:kernelSize:stride:padding:dilation:groups:bias:)``
 open class ConvTransposed1d: Module, UnaryLayer {
 
     public let weight: MLXArray
@@ -71,7 +71,7 @@ open class ConvTransposed1d: Module, UnaryLayer {
 /// ### See Also
 /// - ``ConvTransposed1d``
 /// - ``ConvTransposed3d``
-/// - ``init(inputChannels:outputChannels:kernelSize:stride:padding:bias:)``
+/// - ``init(inputChannels:outputChannels:kernelSize:stride:padding:dilation:groups:bias:)``
 open class ConvTransposed2d: Module, UnaryLayer {
 
     public let weight: MLXArray
@@ -137,7 +137,7 @@ open class ConvTransposed2d: Module, UnaryLayer {
 /// ### See Also
 /// - ``ConvTransposed1d``
 /// - ``ConvTransposed2d``
-/// - ``init(inputChannels:outputChannels:kernelSize:stride:padding:bias:)``
+/// - ``init(inputChannels:outputChannels:kernelSize:stride:padding:dilation:groups:bias:)``
 open class ConvTransposed3d: Module, UnaryLayer {
 
     public let weight: MLXArray

--- a/Source/MLXNN/Documentation.docc/MLXNN.md
+++ b/Source/MLXNN/Documentation.docc/MLXNN.md
@@ -151,7 +151,7 @@ These can be used with ``Sequential``.
 - ``SELU``
 - ``SiLU``
 - ``Sigmoid``
-- ``SoftMax``
+- ``Softmax``
 - ``Softplus``
 - ``Softsign``
 - ``Step``
@@ -159,7 +159,7 @@ These can be used with ``Sequential``.
 
 ### Loss Functions
 
-- ``binaryCrossEntropy(logits:targets:reduction:)``
+- ``binaryCrossEntropy(logits:targets:weights:withLogits:reduction:)``
 - ``cosineSimilarityLoss(x1:x2:axis:eps:reduction:)``
 - ``crossEntropy(logits:targets:weights:axis:labelSmoothing:reduction:)``
 - ``hingeLoss(inputs:targets:reduction:)``

--- a/Source/MLXNN/Documentation.docc/activations.md
+++ b/Source/MLXNN/Documentation.docc/activations.md
@@ -48,7 +48,7 @@ such as `alpha`.
 - ``SELU``
 - ``SiLU``
 - ``Sigmoid``
-- ``SoftMax``
+- ``Softmax-63x8p``
 - ``Softplus``
 - ``Softsign``
 - ``Step``

--- a/Source/MLXNN/Documentation.docc/losses.md
+++ b/Source/MLXNN/Documentation.docc/losses.md
@@ -6,7 +6,7 @@ Built-in loss functions
 
 ### Loss Functions
 
-- ``binaryCrossEntropy(logits:targets:reduction:)``
+- ``binaryCrossEntropy(logits:targets:weights:withLogits:reduction:)``
 - ``cosineSimilarityLoss(x1:x2:axis:eps:reduction:)``
 - ``crossEntropy(logits:targets:weights:axis:labelSmoothing:reduction:)``
 - ``hingeLoss(inputs:targets:reduction:)``

--- a/Source/MLXRandom/Random.swift
+++ b/Source/MLXRandom/Random.swift
@@ -14,8 +14,6 @@ public let deprecationWarning: Void = ()
 ///
 /// ### See Also
 /// - ``key(_:)``
-/// - ``RandomState``
-/// - ``globalState``
 @available(*, deprecated, message: "seed is now avaiable in the main MLX module")
 @_disfavoredOverload
 public func seed(_ seed: UInt64) {


### PR DESCRIPTION
Per report of `padded()` not linking in the docs.