### PR TITLE
consistent treatment of HasDType (Float.self) vs dtype (.float32)

### DIFF
--- a/Source/MLX/DType.swift
+++ b/Source/MLX/DType.swift
@@ -112,6 +112,84 @@ public enum DType: Hashable, Sendable, CaseIterable {
     public var size: Int {
         mlx_dtype_size(cmlxDtype)
     }
+
+    /// For floating point values return the floating point info, similar to `numpy.finfo`.
+    public var finfo: FInfo? {
+        isFloatingPoint ? FInfo(dtype: self) : nil
+    }
+
+    /// Floating point info.
+    public struct FInfo: Sendable {
+        public let dtype: DType
+
+        /// The difference between 1.0 and the next smallest representable float larger than 1.0
+        ///
+        /// In Swift this is e.g. ``Double.ulpOfOne``
+        public var eps: Double {
+            switch dtype {
+            case .float16: Double(Float16.ulpOfOne)
+            case .float32: Double(Float.ulpOfOne)
+            case .bfloat16: 0.0078125
+            case .complex64: Double.ulpOfOne
+            case .float64: Double.ulpOfOne
+            default:
+                fatalError("\(dtype) is not a floating point type")
+            }
+        }
+
+        /// The smallest representable number
+        public var min: Double {
+            switch dtype {
+            case .float16: -Double(Float16.greatestFiniteMagnitude)
+            case .float32: -Double(Float.greatestFiniteMagnitude)
+            case .bfloat16: -3.3895313892515355e+38
+            case .complex64: -Double.greatestFiniteMagnitude
+            case .float64: -Double.greatestFiniteMagnitude
+            default:
+                fatalError("\(dtype) is not a floating point type")
+            }
+        }
+
+        /// The largest representable number
+        public var max: Double {
+            switch dtype {
+            case .float16: Double(Float16.greatestFiniteMagnitude)
+            case .float32: Double(Float.greatestFiniteMagnitude)
+            case .bfloat16: 3.3895313892515355e+38
+            case .complex64: Double.greatestFiniteMagnitude
+            case .float64: Double.greatestFiniteMagnitude
+            default:
+                fatalError("\(dtype) is not a floating point type")
+            }
+        }
+
+        /// Return the value for the smallest normal
+        public var smallestNormal: Double {
+            switch dtype {
+            case .float16: Double(Float16.leastNormalMagnitude)
+            case .float32: Double(Float.leastNormalMagnitude)
+            case .bfloat16: 1.1754943508222875e-38
+            case .complex64: Double.leastNormalMagnitude
+            case .float64: Double.leastNormalMagnitude
+            default:
+                fatalError("\(dtype) is not a floating point type")
+            }
+        }
+
+        /// The smallest positive floating point number with 0 as leading bit in the mantissa following IEEE-754
+        public var smallestSubnormal: Double {
+            switch dtype {
+            case .float16: Double(Float16.leastNonzeroMagnitude)
+            case .float32: Double(Float.leastNonzeroMagnitude)
+            case .bfloat16: 1.1754943508222875e-38
+            case .complex64: Double.leastNonzeroMagnitude
+            case .float64: Double.leastNonzeroMagnitude
+            default:
+                fatalError("\(dtype) is not a floating point type")
+            }
+        }
+    }
+
 }
 
 extension DType: Encodable {

--- a/Source/MLX/Factory.swift
+++ b/Source/MLX/Factory.swift
@@ -297,7 +297,7 @@ extension MLXArray {
         MLX.identity(n, type: type, stream: stream)
     }
 
-    /// Create a square identity matrix given a ``DType``.
+    /// Create a square identity matrix with a given ``DType``.
     ///
     /// Example:
     ///
@@ -818,7 +818,7 @@ public func identity<T: HasDType>(
     return MLXArray(result)
 }
 
-/// Create a square identity matrix and a given ``DType``.
+/// Create a square identity matrix with a given ``DType``.
 ///
 /// Example:
 ///

--- a/Source/MLX/Factory.swift
+++ b/Source/MLX/Factory.swift
@@ -165,7 +165,7 @@ extension MLXArray {
         MLX.eye(n, m: m, k: k, type: type, stream: stream)
     }
 
-    /// Create an identity matrix or a general diagonal matrix a given ``DType``.
+    /// Create an identity matrix or a general diagonal matrix given a ``DType``.
     ///
     /// Example:
     ///
@@ -178,7 +178,7 @@ extension MLXArray {
     ///     - n: number of rows in the output
     ///     - m: number of columns in the output -- equal to `n` if not specified
     ///     - k: index of the diagonal
-    ///     - type: data type of the output array
+    ///     - dtype: data type of the output array
     ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
@@ -297,7 +297,7 @@ extension MLXArray {
         MLX.identity(n, type: type, stream: stream)
     }
 
-    /// Create a square identity matrix and a given ``DType``.
+    /// Create a square identity matrix given a ``DType``.
     ///
     /// Example:
     ///
@@ -308,7 +308,7 @@ extension MLXArray {
     ///
     /// - Parameters:
     ///     - n: number of rows and columns in the output
-    ///     - type: data type of the output array
+    ///     - dtype: data type of the output array
     ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
@@ -485,7 +485,7 @@ extension MLXArray {
     ///     - n: number of rows in the output
     ///     - m: number of columns in the output -- equal to `n` if not specified
     ///     - k: index of the diagonal
-    ///     - type: data type of the output array
+    ///     - dtype: data type of the output array
     ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
@@ -597,7 +597,7 @@ public func ones<T: HasDType>(
     return MLXArray(result)
 }
 
-/// Construct an array of zeros with a given ``DType``
+/// Construct an array of ones with a given ``DType``
 ///
 /// Example:
 ///
@@ -673,7 +673,7 @@ public func eye<T: HasDType>(
     return MLXArray(result)
 }
 
-/// Create an identity matrix or a general diagonal matrix and a given ``DType``.
+/// Create an identity matrix or a general diagonal matrix given a ``DType``.
 ///
 /// Example:
 ///
@@ -686,7 +686,7 @@ public func eye<T: HasDType>(
 ///     - n: number of rows in the output
 ///     - m: number of columns in the output -- equal to `n` if not specified
 ///     - k: index of the diagonal
-///     - type: data type of the output array
+///     - dtype: data type of the output array
 ///     - stream: stream or device to evaluate on
 ///
 /// ### See Also
@@ -829,7 +829,7 @@ public func identity<T: HasDType>(
 ///
 /// - Parameters:
 ///     - n: number of rows and columns in the output
-///     - type: data type of the output array
+///     - dtype: data type of the output array
 ///     - stream: stream or device to evaluate on
 ///
 /// ### See Also
@@ -1018,7 +1018,7 @@ public func tri<T: HasDType>(
 ///     - n: number of rows in the output
 ///     - m: number of columns in the output -- equal to `n` if not specified
 ///     - k: index of the diagonal
-///     - type: data type of the output array
+///     - dtype: data type of the output array
 ///     - stream: stream or device to evaluate on
 ///
 /// ### See Also

--- a/Source/MLX/Factory.swift
+++ b/Source/MLX/Factory.swift
@@ -25,9 +25,7 @@ extension MLXArray {
     static public func zeros<T: HasDType>(
         _ shape: [Int], type: T.Type = Float.self, stream: StreamOrDevice = .default
     ) -> MLXArray {
-        var result = mlx_array_new()
-        mlx_zeros(&result, shape.map { Int32($0) }, shape.count, T.dtype.cmlxDtype, stream.ctx)
-        return MLXArray(result)
+        MLX.zeros(shape, type: type, stream: stream)
     }
 
     /// Construct an array of zeros with a given ``DType``
@@ -35,7 +33,7 @@ extension MLXArray {
     /// Example:
     ///
     /// ```swift
-    /// let z = MLXArray.zeros([5, 10], type: Int.self)
+    /// let z = MLXArray.zeros([5, 10], dtype: .int32)
     /// ```
     ///
     /// - Parameters:
@@ -50,9 +48,7 @@ extension MLXArray {
     static public func zeros(
         _ shape: [Int], dtype: DType = .float32, stream: StreamOrDevice = .default
     ) -> MLXArray {
-        var result = mlx_array_new()
-        mlx_zeros(&result, shape.map { Int32($0) }, shape.count, dtype.cmlxDtype, stream.ctx)
-        return MLXArray(result)
+        MLX.zeros(shape, dtype: dtype, stream: stream)
     }
 
     /// Construct an array of zeros.
@@ -73,9 +69,7 @@ extension MLXArray {
     /// - ``zeros(_:type:stream:)``
     /// - ``ones(_:type:stream:)``
     static public func zeros(like array: MLXArray, stream: StreamOrDevice = .default) -> MLXArray {
-        var result = mlx_array_new()
-        mlx_zeros_like(&result, array.ctx, stream.ctx)
-        return MLXArray(result)
+        MLX.zeros(like: array, stream: stream)
     }
 
     /// Construct an array of ones.
@@ -98,9 +92,7 @@ extension MLXArray {
     static public func ones<T: HasDType>(
         _ shape: [Int], type: T.Type = Float.self, stream: StreamOrDevice = .default
     ) -> MLXArray {
-        var result = mlx_array_new()
-        mlx_ones(&result, shape.map { Int32($0) }, shape.count, T.dtype.cmlxDtype, stream.ctx)
-        return MLXArray(result)
+        MLX.ones(shape, type: type, stream: stream)
     }
 
     /// Construct an array of ones with a given ``DType``
@@ -108,7 +100,7 @@ extension MLXArray {
     /// Example:
     ///
     /// ```swift
-    /// let r = MLXArray.ones([5, 10], type: Int.self)
+    /// let r = MLXArray.ones([5, 10], dtype: .int32)
     /// ```
     ///
     /// - Parameters:
@@ -123,9 +115,7 @@ extension MLXArray {
     static public func ones(
         _ shape: [Int], dtype: DType = .float32, stream: StreamOrDevice = .default
     ) -> MLXArray {
-        var result = mlx_array_new()
-        mlx_ones(&result, shape.map { Int32($0) }, shape.count, dtype.cmlxDtype, stream.ctx)
-        return MLXArray(result)
+        MLX.ones(shape, dtype: dtype, stream: stream)
     }
 
     /// Construct an array of ones.
@@ -146,9 +136,7 @@ extension MLXArray {
     /// - ``ones(_:type:stream:)``
     /// - ``zeros(_:type:stream:)``
     static public func ones(like array: MLXArray, stream: StreamOrDevice = .default) -> MLXArray {
-        var result = mlx_array_new()
-        mlx_ones_like(&result, array.ctx, stream.ctx)
-        return MLXArray(result)
+        MLX.ones(like: array, stream: stream)
     }
 
     /// Create an identity matrix or a general diagonal matrix.
@@ -174,9 +162,33 @@ extension MLXArray {
         _ n: Int, m: Int? = nil, k: Int = 0, type: T.Type = Float.self,
         stream: StreamOrDevice = .default
     ) -> MLXArray {
-        var result = mlx_array_new()
-        mlx_eye(&result, n.int32, (m ?? n).int32, k.int32, T.dtype.cmlxDtype, stream.ctx)
-        return MLXArray(result)
+        MLX.eye(n, m: m, k: k, type: type, stream: stream)
+    }
+
+    /// Create an identity matrix or a general diagonal matrix a given ``DType``.
+    ///
+    /// Example:
+    ///
+    /// ```swift
+    /// //  create [10, 10] array with 1's on the diagonal.
+    /// let r = MLXArray.eye(10, dtype: .int32)
+    /// ```
+    ///
+    /// - Parameters:
+    ///     - n: number of rows in the output
+    ///     - m: number of columns in the output -- equal to `n` if not specified
+    ///     - k: index of the diagonal
+    ///     - type: data type of the output array
+    ///     - stream: stream or device to evaluate on
+    ///
+    /// ### See Also
+    /// - <doc:initialization>
+    /// - ``identity(_:type:stream:)``
+    static public func eye(
+        _ n: Int, m: Int? = nil, k: Int = 0, dtype: DType = .float32,
+        stream: StreamOrDevice = .default
+    ) -> MLXArray {
+        MLX.eye(n, m: m, k: k, dtype: dtype, stream: stream)
     }
 
     /// Construct an array with the given value.
@@ -204,9 +216,35 @@ extension MLXArray {
     static public func full<T: HasDType>(
         _ shape: [Int], values: MLXArray, type: T.Type, stream: StreamOrDevice = .default
     ) -> MLXArray {
-        var result = mlx_array_new()
-        mlx_full(&result, shape.asInt32, shape.count, values.ctx, T.dtype.cmlxDtype, stream.ctx)
-        return MLXArray(result)
+        MLX.full(shape, values: values, type: type, stream: stream)
+    }
+
+    /// Construct an array with the given value and a given ``DType``.
+    ///
+    /// Constructs an array of size `shape` filled with `vals`. If `vals`
+    /// is an :obj:`array` it must be <doc:broadcasting> to the given `shape`.
+    ///
+    /// Example:
+    ///
+    /// ```swift
+    /// //  create [5, 4] array filled with 7
+    /// let r = MLXArray.full([5, 4], values: 7, dtype: .float32)
+    /// ```
+    ///
+    /// - Parameters:
+    ///     - shape: shape of the output array
+    ///     - values: values to be bradcast into the array
+    ///     - dtype: data type of the output array
+    ///     - stream: stream or device to evaluate on
+    ///
+    /// ### See Also
+    /// - <doc:initialization>
+    /// - ``full(_:values:stream:)``
+    /// - ``repeated(_:count:axis:stream:)``
+    static public func full(
+        _ shape: [Int], values: MLXArray, dtype: DType = .float32, stream: StreamOrDevice = .default
+    ) -> MLXArray {
+        MLX.full(shape, values: values, dtype: dtype, stream: stream)
     }
 
     /// Construct an array with the given value.
@@ -233,11 +271,7 @@ extension MLXArray {
     static public func full(_ shape: [Int], values: MLXArray, stream: StreamOrDevice = .default)
         -> MLXArray
     {
-        var result = mlx_array_new()
-
-        mlx_full(
-            &result, shape.asInt32, shape.count, values.ctx, values.dtype.cmlxDtype, stream.ctx)
-        return MLXArray(result)
+        MLX.full(shape, values: values, stream: stream)
     }
 
     /// Create a square identity matrix.
@@ -260,9 +294,30 @@ extension MLXArray {
     static public func identity<T: HasDType>(
         _ n: Int, type: T.Type = Float.self, stream: StreamOrDevice = .default
     ) -> MLXArray {
-        var result = mlx_array_new()
-        mlx_identity(&result, n.int32, T.dtype.cmlxDtype, stream.ctx)
-        return MLXArray(result)
+        MLX.identity(n, type: type, stream: stream)
+    }
+
+    /// Create a square identity matrix and a given ``DType``.
+    ///
+    /// Example:
+    ///
+    /// ```swift
+    /// //  create [10, 10] array with 1's on the diagonal.
+    /// let r = MLXArray.identity(10, dtype: .int32)
+    /// ```
+    ///
+    /// - Parameters:
+    ///     - n: number of rows and columns in the output
+    ///     - type: data type of the output array
+    ///     - stream: stream or device to evaluate on
+    ///
+    /// ### See Also
+    /// - <doc:initialization>
+    /// - ``eye(_:m:k:type:stream:)``
+    static public func identity(
+        _ n: Int, dtype: DType = .float32, stream: StreamOrDevice = .default
+    ) -> MLXArray {
+        MLX.identity(n, dtype: dtype, stream: stream)
     }
 
     /// Generate `num` evenly spaced numbers over interval `[start, stop]` for `BinaryInteger`.
@@ -286,11 +341,7 @@ extension MLXArray {
     static public func linspace<T: HasDType>(
         _ start: T, _ stop: T, count: Int = 50, stream: StreamOrDevice = .default
     ) -> MLXArray where T: BinaryInteger {
-        var result = mlx_array_new()
-
-        mlx_linspace(
-            &result, Double(start), Double(stop), count.int32, T.dtype.cmlxDtype, stream.ctx)
-        return MLXArray(result)
+        MLX.linspace(start, stop, count: count, stream: stream)
     }
 
     /// Generate `num` evenly spaced numbers over interval `[start, stop]` for `BinaryFloatingPoint`.
@@ -314,11 +365,7 @@ extension MLXArray {
     static public func linspace<T: HasDType>(
         _ start: T, _ stop: T, count: Int = 50, stream: StreamOrDevice = .default
     ) -> MLXArray where T: BinaryFloatingPoint {
-        var result = mlx_array_new()
-
-        mlx_linspace(
-            &result, Double(start), Double(stop), count.int32, T.dtype.cmlxDtype, stream.ctx)
-        return MLXArray(result)
+        MLX.linspace(start, stop, count: count, stream: stream)
     }
 
     /// Repeat an array along a specified axis.
@@ -333,9 +380,7 @@ extension MLXArray {
     static public func `repeat`(
         _ array: MLXArray, count: Int, axis: Int, stream: StreamOrDevice = .default
     ) -> MLXArray {
-        var result = mlx_array_new()
-        mlx_repeat(&result, array.ctx, count.int32, axis.int32, stream.ctx)
-        return MLXArray(result)
+        MLX.repeated(array, count: count, axis: axis, stream: stream)
     }
 
     /// Repeat a flattened array along axis 0.
@@ -350,9 +395,7 @@ extension MLXArray {
     static public func `repeat`(_ array: MLXArray, count: Int, stream: StreamOrDevice = .default)
         -> MLXArray
     {
-        var result = mlx_array_new()
-        mlx_repeat_all(&result, array.ctx, count.int32, stream.ctx)
-        return MLXArray(result)
+        MLX.repeated(array, count: count, stream: stream)
     }
 
     /// Repeat an array along a specified axis.
@@ -377,9 +420,7 @@ extension MLXArray {
     static public func repeated(
         _ array: MLXArray, count: Int, axis: Int, stream: StreamOrDevice = .default
     ) -> MLXArray {
-        var result = mlx_array_new()
-        mlx_repeat(&result, array.ctx, count.int32, axis.int32, stream.ctx)
-        return MLXArray(result)
+        MLX.repeated(array, count: count, axis: axis, stream: stream)
     }
 
     /// Repeat a flattened array along axis 0.
@@ -403,9 +444,7 @@ extension MLXArray {
     static public func repeated(_ array: MLXArray, count: Int, stream: StreamOrDevice = .default)
         -> MLXArray
     {
-        var result = mlx_array_new()
-        mlx_repeat_all(&result, array.ctx, count.int32, stream.ctx)
-        return MLXArray(result)
+        MLX.repeated(array, count: count, stream: stream)
     }
 
     /// An array with ones at and below the given diagonal and zeros elsewhere.
@@ -430,9 +469,32 @@ extension MLXArray {
         _ n: Int, m: Int? = nil, k: Int = 0, type: T.Type = Float.self,
         stream: StreamOrDevice = .default
     ) -> MLXArray {
-        var result = mlx_array_new()
-        mlx_tri(&result, n.int32, (m ?? n).int32, k.int32, T.dtype.cmlxDtype, stream.ctx)
-        return MLXArray(result)
+        MLX.tri(n, m: m, k: k, type: type, stream: stream)
+    }
+
+    /// An array with ones at and below the given diagonal and zeros elsewhere and a given ``DType``.
+    ///
+    /// Example:
+    ///
+    /// ```swift
+    /// // [5, 5] array with the lower triangle filled with 1s
+    /// let r = MLXArray.triangle(5, dtype: .int32)
+    /// ```
+    ///
+    /// - Parameters:
+    ///     - n: number of rows in the output
+    ///     - m: number of columns in the output -- equal to `n` if not specified
+    ///     - k: index of the diagonal
+    ///     - type: data type of the output array
+    ///     - stream: stream or device to evaluate on
+    ///
+    /// ### See Also
+    /// - <doc:initialization>
+    static public func tri(
+        _ n: Int, m: Int? = nil, k: Int = 0, dtype: DType = .float32,
+        stream: StreamOrDevice = .default
+    ) -> MLXArray {
+        MLX.tri(n, m: m, k: k, dtype: dtype, stream: stream)
     }
 
 }
@@ -459,6 +521,31 @@ public func zeros<T: HasDType>(
 ) -> MLXArray {
     var result = mlx_array_new()
     mlx_zeros(&result, shape.map { Int32($0) }, shape.count, T.dtype.cmlxDtype, stream.ctx)
+    return MLXArray(result)
+}
+
+/// Construct an array of zeros with a given ``DType``
+///
+/// Example:
+///
+/// ```swift
+/// let z = MLXArray.zeros([5, 10], dtype: .int32)
+/// ```
+///
+/// - Parameters:
+///     - shape: desired shape
+///     - dtype: dtype of the values
+///     - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - <doc:initialization>
+/// - ``zeros(like:stream:)``
+/// - ``ones(_:type:stream:)``
+public func zeros(
+    _ shape: [Int], dtype: DType = .float32, stream: StreamOrDevice = .default
+) -> MLXArray {
+    var result = mlx_array_new()
+    mlx_zeros(&result, shape.map { Int32($0) }, shape.count, dtype.cmlxDtype, stream.ctx)
     return MLXArray(result)
 }
 
@@ -507,6 +594,31 @@ public func ones<T: HasDType>(
 ) -> MLXArray {
     var result = mlx_array_new()
     mlx_ones(&result, shape.map { Int32($0) }, shape.count, T.dtype.cmlxDtype, stream.ctx)
+    return MLXArray(result)
+}
+
+/// Construct an array of zeros with a given ``DType``
+///
+/// Example:
+///
+/// ```swift
+/// let r = MLXArray.ones([5, 10], dtype: .int32)
+/// ```
+///
+/// - Parameters:
+///     - shape: desired shape
+///     - dtype: dtype of the values
+///     - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - <doc:initialization>
+/// - ``zeros(like:stream:)``
+/// - ``ones(_:type:stream:)``
+public func ones(
+    _ shape: [Int], dtype: DType = .float32, stream: StreamOrDevice = .default
+) -> MLXArray {
+    var result = mlx_array_new()
+    mlx_ones(&result, shape.map { Int32($0) }, shape.count, dtype.cmlxDtype, stream.ctx)
     return MLXArray(result)
 }
 
@@ -561,6 +673,34 @@ public func eye<T: HasDType>(
     return MLXArray(result)
 }
 
+/// Create an identity matrix or a general diagonal matrix and a given ``DType``.
+///
+/// Example:
+///
+/// ```swift
+/// //  create [10, 10] array with 1's on the diagonal.
+/// let r = MLXArray.eye(10, dtype: .int32)
+/// ```
+///
+/// - Parameters:
+///     - n: number of rows in the output
+///     - m: number of columns in the output -- equal to `n` if not specified
+///     - k: index of the diagonal
+///     - type: data type of the output array
+///     - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - <doc:initialization>
+/// - ``identity(_:type:stream:)``
+public func eye(
+    _ n: Int, m: Int? = nil, k: Int = 0, dtype: DType = .float32,
+    stream: StreamOrDevice = .default
+) -> MLXArray {
+    var result = mlx_array_new()
+    mlx_eye(&result, n.int32, (m ?? n).int32, k.int32, dtype.cmlxDtype, stream.ctx)
+    return MLXArray(result)
+}
+
 /// Construct an array with the given value.
 ///
 /// Constructs an array of size `shape` filled with `vals`. If `vals`
@@ -589,6 +729,37 @@ public func full<T: HasDType>(
     var result = mlx_array_new()
     let values = values.asMLXArray(dtype: nil)
     mlx_full(&result, shape.asInt32, shape.count, values.ctx, T.dtype.cmlxDtype, stream.ctx)
+    return MLXArray(result)
+}
+
+/// Construct an array with the given value and a given ``DType``.
+///
+/// Constructs an array of size `shape` filled with `vals`. If `vals`
+/// is an :obj:`array` it must be <doc:broadcasting> to the given `shape`.
+///
+/// Example:
+///
+/// ```swift
+/// //  create [5, 4] array filled with 7
+/// let r = MLXArray.full([5, 4], values: 7, dtype: .float32)
+/// ```
+///
+/// - Parameters:
+///     - shape: shape of the output array
+///     - values: values to be bradcast into the array
+///     - dtype: data type of the output array
+///     - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - <doc:initialization>
+/// - ``full(_:values:stream:)``
+/// - ``repeated(_:count:axis:stream:)``
+public func full(
+    _ shape: [Int], values: MLXArray, dtype: DType = .float32,
+    stream: StreamOrDevice = .default
+) -> MLXArray {
+    var result = mlx_array_new()
+    mlx_full(&result, shape.asInt32, shape.count, values.ctx, dtype.cmlxDtype, stream.ctx)
     return MLXArray(result)
 }
 
@@ -644,6 +815,31 @@ public func identity<T: HasDType>(
 ) -> MLXArray {
     var result = mlx_array_new()
     mlx_identity(&result, n.int32, T.dtype.cmlxDtype, stream.ctx)
+    return MLXArray(result)
+}
+
+/// Create a square identity matrix and a given ``DType``.
+///
+/// Example:
+///
+/// ```swift
+/// //  create [10, 10] array with 1's on the diagonal.
+/// let r = MLXArray.identity(10, dtype: .int32)
+/// ```
+///
+/// - Parameters:
+///     - n: number of rows and columns in the output
+///     - type: data type of the output array
+///     - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - <doc:initialization>
+/// - ``eye(_:m:k:type:stream:)``
+public func identity(
+    _ n: Int, dtype: DType = .float32, stream: StreamOrDevice = .default
+) -> MLXArray {
+    var result = mlx_array_new()
+    mlx_identity(&result, n.int32, dtype.cmlxDtype, stream.ctx)
     return MLXArray(result)
 }
 
@@ -806,5 +1002,32 @@ public func tri<T: HasDType>(
 ) -> MLXArray {
     var result = mlx_array_new()
     mlx_tri(&result, n.int32, (m ?? n).int32, k.int32, T.dtype.cmlxDtype, stream.ctx)
+    return MLXArray(result)
+}
+
+/// An array with ones at and below the given diagonal and zeros elsewhere and a given ``DType``.
+///
+/// Example:
+///
+/// ```swift
+/// // [5, 5] array with the lower triangle filled with 1s
+/// let r = MLXArray.triangle(5, dtype: .int32)
+/// ```
+///
+/// - Parameters:
+///     - n: number of rows in the output
+///     - m: number of columns in the output -- equal to `n` if not specified
+///     - k: index of the diagonal
+///     - type: data type of the output array
+///     - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - <doc:initialization>
+public func tri(
+    _ n: Int, m: Int? = nil, k: Int = 0, dtype: DType = .float32,
+    stream: StreamOrDevice = .default
+) -> MLXArray {
+    var result = mlx_array_new()
+    mlx_tri(&result, n.int32, (m ?? n).int32, k.int32, dtype.cmlxDtype, stream.ctx)
     return MLXArray(result)
 }


### PR DESCRIPTION
- fixes #199
- there were inconsistent methods for creating MLXArrays with various patterns using Float.self vs .float32
- add an FInfo struct also in support of dtype
- encountered when porting VLMs