### PR TITLE
Return correct value in memory limit getter functions

### DIFF
--- a/Source/MLX/GPU.swift
+++ b/Source/MLX/GPU.swift
@@ -187,8 +187,9 @@ public enum GPU {
             // set it to a reasonable value in order to read it, then set it back
             // to current
             var current: size_t = 0
+            var discard: size_t = 0
             mlx_metal_set_cache_limit(&current, cacheMemory)
-            mlx_metal_set_cache_limit(&current, current)
+            mlx_metal_set_cache_limit(&discard, current)
             _cacheLimit = current
             return current
         }
@@ -229,6 +230,7 @@ public enum GPU {
             var discard: size_t = 0
             mlx_metal_set_memory_limit(&current, activeMemory, _relaxedMemoryLimit)
             mlx_metal_set_memory_limit(&discard, current, _relaxedMemoryLimit)
+            _memoryLimit = current
             return current
         }
     }
@@ -241,7 +243,7 @@ public enum GPU {
     /// swap) if `relaxed` is true.
     ///
     /// The memory limit defaults to 1.5 times the maximum recommended working set
-    /// size reported by the device ([recommendedMaxWorkingSetSize](https://developer.apple.com/documentation/metal/mtldevice/2369280-recommendedmaxworkingsetsize))
+    /// size reported by the device ([recommendedMaxWorkingSetSize](https://developer.apple.com/documentation/metal/mtldevice/recommendedmaxworkingsetsize))
     public static func set(memoryLimit: Int, relaxed: Bool = true) {
         queue.sync {
             _relaxedMemoryLimit = relaxed

--- a/Source/MLX/GPU.swift
+++ b/Source/MLX/GPU.swift
@@ -288,10 +288,10 @@ public enum GPU {
     }
 
     public struct DeviceInfo: Sendable {
-        let architecture: String
-        let maxBufferSize: Int
-        let maxRecommendedWorkingSetSize: UInt64
-        let memorySize: Int
+        public let architecture: String
+        public let maxBufferSize: Int
+        public let maxRecommendedWorkingSetSize: UInt64
+        public let memorySize: Int
     }
 
     /// Get information about the GPU device and system settings


### PR DESCRIPTION
This PR covers two small bugs in the GPU memory limit related functions

When calling `cacheLimit` without having previously set any limit, the function would incorrectly report erroneous values (it would report whatever was the current cache value).
The logic has been fixed to report the actual value.

When calling `memoryLimit`, the value would not get saved to the cached variable, prompting the code to call the C function every time. 

Finally the link to the metal doc has been updated.