### PR TITLE
Fix scaled dot product attention mask argument

### DIFF
--- a/Source/MLX/MLXFast.swift
+++ b/Source/MLX/MLXFast.swift
@@ -94,7 +94,7 @@ public enum MLXFast {
         mlx_fast_scaled_dot_product_attention(
             &result,
             queries.ctx, keys.ctx, values.ctx, scale,
-            mask != nil ? "causal" : "", masks,
+            "", masks,
             stream.ctx)
         return MLXArray(result)
     }

--- a/Source/MLX/MLXFast.swift
+++ b/Source/MLX/MLXFast.swift
@@ -94,7 +94,7 @@ public enum MLXFast {
         mlx_fast_scaled_dot_product_attention(
             &result,
             queries.ctx, keys.ctx, values.ctx, scale,
-            mask == nil ? "causal" : "", masks,
+            mask != nil ? "causal" : "", masks,
             stream.ctx)
         return MLXArray(result)
     }


### PR DESCRIPTION
It looks like the value passed in the `mask_mode` should be the empty string by default.