### PR TITLE
Update README with correct .git package URL for Xcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ More details are in the [documentation](https://swiftpackageindex.com/ml-explore
 
 ### Xcode
 
-In Xcode you can add `https://github.com/ml-explore/mlx-swift` as a package
+In Xcode you can add `https://github.com/ml-explore/mlx-swift.git` as a package
 dependency and link `MLX`, `MLXNN`, `MLXOptimizers` and `MLXRandom` as needed.
 
 ### SwiftPM


### PR DESCRIPTION
## 📘Description

This PR updates the `README.md` file to clarify the correct URL for adding the `mlx-swift` package in Xcode.

###  🐞 Problem
#247 

### ✅ Solution 
Update the README to recommend using the full URL with `.git` suffix:  `https://github.com/ml-explore/mlx-swift.git`

![Screen Shot 2025-06-11 at 16 36 28 PM](https://github.com/user-attachments/assets/0a93a193-315d-44de-967c-b0ed69e96cb8)

![Screen Shot 2025-06-11 at 16 41 48 PM](https://github.com/user-attachments/assets/c031f750-8d69-4a68-a015-8925f47086b1)


### ✅ Contribution Checklist

Following the [CONTRIBUTING.md](https://github.com/ml-explore/mlx-swift/blob/main/CONTRIBUTING.md) guidelines:

- [x] Forked the repository and created a new branch
- [x] No code or tests impacted(Made documentation-only changes)
- [x] Ensured the update is minimal and clear
- [x] Followed Markdown formatting guidelines
- [x] Explained the motivation and impact of the change in this PR

### Environment
- Xcode version: 16.4 (16F6)
- Device: MacBook Air 13" M3
- macOS version: 15.5 (24F74)