### PR TITLE
Fix optional module updates

### DIFF
--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -243,6 +243,9 @@ open class Module {
 
             // handle structure
             switch v {
+            case .none:
+                return .none
+
             case .value(.module(let module)):
                 return module.filterMap(filter: filter, map: map, isLeaf: isLeaf).asItem()
 
@@ -594,10 +597,6 @@ open class Module {
     open func update(modules: ModuleChildren, verify: VerifyUpdate) throws -> Self {
 
         func apply(key: String, _ item: ModuleItem, _ value: NestedItem<String, Module>) throws {
-            if case .none = value {
-                return
-            }
-
             // item: single item from `items()`
             // value: single item with matching structure from `children()`
             //
@@ -687,6 +686,12 @@ open class Module {
 
             case (.value(.module), .value(let newModule)):
                 try self.updateModule(key: key, newModule)
+
+            case (.none, .value(let newModule)):
+                try self.updateModule(key: key, newModule)
+
+            case (.value(.module), .none):
+                try self.updateModule(key: key, Optional<Module>.none as Any)
 
             case (.value(.module(let module)), .dictionary(let values)):
                 try module.update(modules: NestedDictionary(values: values), verify: verify)
@@ -1264,6 +1269,8 @@ public enum ModuleValue {
             return .value(.parameters(v))
         case let v as Module:
             return .value(.module(v))
+        case let v as Module? where v == nil:
+            return .none
         case let v as [Any]:
             return .array(v.map { build(value: $0) })
 


### PR DESCRIPTION
### What
- Fixed setting a value for an optional child module
- Fixed resetting an optional child module back to `nil`

### Motivation
Consider the following example with an optional child module:
```swift
class Example: Module {
    @ModuleInfo(key: "a") var a: Linear = Linear(1, 1)
    @ModuleInfo(key: "b") var b: Linear?
}
```

Currently, attempting to update `b` via `update(modules:verify:)` fails:
```swift
let linear = Linear(1, 1)
let update = ModuleChildren(values: ["b": .value(linear)])
try example.update(modules: update, verify: .noUnusedKeys) // Fatal error: Unable to set b on Example(b=nil)
```

The reason is it has double optional value inside:
```
(lldb) po (value, type(of: value))
▿ 2 elements
  - .0 : nil
  - .1 : Swift.Optional<Swift.Optional<MLXNN.Linear>>
``` 

Comparing to a non-optional child module:
```
(lldb) po (value, type(of: value))
▿ 2 elements
  ▿ .0 : Optional<Linear>
    ▿ some : Linear(inputDimensions=1, outputDimensions=1, bias=true)
  - .1 : Swift.Optional<MLXNN.Linear>
```

Due to the double optional, `ModuleValue.build(value:)` maps the value to `.other(nil)` instead of `.none` and prevents updates from being applied correctly. This fix ensures that setting a value when the current value is `nil` works as expected and resetting an optional module back to `nil` is supported as well.