### PR TITLE
Add support for tvOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,7 @@ let package = Package(
     platforms: [
         .macOS("13.3"),
         .iOS(.v16),
+        .tvOS(.v16),
         .visionOS(.v1),
     ],
 

--- a/Source/MLX/GPU.swift
+++ b/Source/MLX/GPU.swift
@@ -340,12 +340,8 @@ public enum GPU {
 
         if let device = MTLCreateSystemDefaultDevice() {
             let architecture: String
-            if #available(macOS 14.0, iOS 17.0, *) {
-                #if os(tvOS)
-                architecture = device.name
-                #else
+            if #available(macOS 14.0, iOS 17.0, tvOS 17.0, *) {
                 architecture = device.architecture.name
-                #endif
             } else {
                 architecture = device.name
             }

--- a/Source/MLX/GPU.swift
+++ b/Source/MLX/GPU.swift
@@ -341,7 +341,11 @@ public enum GPU {
         if let device = MTLCreateSystemDefaultDevice() {
             let architecture: String
             if #available(macOS 14.0, iOS 17.0, *) {
+                #if os(tvOS)
+                architecture = device.name
+                #else
                 architecture = device.architecture.name
+                #endif
             } else {
                 architecture = device.name
             }


### PR DESCRIPTION
This PR adds comprehensive tvOS support to MLX-Swift by updating the Package.swift manifest and providing architecture compatibility for tvOS devices.

  Changes

  1. Package.swift: Added .tvOS(.v16) to the list of supported platforms
  2. GPU.swift: Added tvOS 17.0 to the availability check for the architecture property

  Problem

  MLX-Swift currently doesn't support tvOS, preventing developers from bringing
  on-device ML capabilities to Apple TV applications. When attempting to use MLX-Swift
  in a tvOS project:
  - The package doesn't declare tvOS support in its manifest
  - Compilation fails due to the architecture property being unavailable on older tvOS
  versions

  Solution

  1. Explicitly declare tvOS v16+ support in Package.swift
  2. Add tvOS 17.0 to the #available check since the architecture property is available
  on tvOS 17.0 and later (as per Apple documentation)

  Impact

  - ✅ Enables MLX-Swift to be imported and used in tvOS projects
  - ✅ Maintains backward compatibility with tvOS 16+ (using device.name for older versions)
  - ✅ No changes to existing macOS/iOS functionality
  - ✅ Opens up on-device ML capabilities for Apple TV apps

  Testing

  Successfully tested on Apple TV (tvOS 18) with a production app:
  - Downloaded and ran Llama 3.2 1B model
  - Performed real-time text generation
  - No compilation or runtime issues

  Use Cases

  This enables exciting possibilities for tvOS apps:
  - On-device AI assistants for TV interfaces
  - Real-time content analysis and recommendations
  - Privacy-preserving ML features without cloud dependencies
  - Interactive educational content with local language models