### PR TITLE
Fix tvOS Build Error

### DIFF
--- a/Source/MLX/GPU.swift
+++ b/Source/MLX/GPU.swift
@@ -340,7 +340,7 @@ public enum GPU {
 
         if let device = MTLCreateSystemDefaultDevice() {
             let architecture: String
-            if #available(macOS 14.0, iOS 17.0, *) {
+            if #available(macOS 14.0, iOS 17.0, tvOS 17.0, *) {
                 architecture = device.architecture.name
             } else {
                 architecture = device.name


### PR DESCRIPTION
Current builds fail for tvOS with:
```
/mlx-swift/Source/MLX/GPU.swift:344:39: error: 'architecture' is only available in tvOS 17.0 or newer
                architecture = device.architecture.name
                                      ^
/mlx-swift/Source/MLX/GPU.swift:344:39: note: add 'if #available' version check
                architecture = device.architecture.name
                                      ^
/mlx-swift/Source/MLX/GPU.swift:335:24: note: add '@available' attribute to enclosing static method
    public static func deviceInfo() -> DeviceInfo {
                       ^
/mlx-swift/Source/MLX/GPU.swift:23:13: note: add '@available' attribute to enclosing enum
public enum GPU {
            ^
```
Adding tvOS 17.0 in the availability check results in a successful build. 