### PR TITLE
Make `MLXError` provide a description

### DIFF
--- a/Source/MLX/ErrorHandler.swift
+++ b/Source/MLX/ErrorHandler.swift
@@ -216,6 +216,12 @@ public func withError<R>(_ body: () async throws -> R) async throws -> R {
 /// Error type for caught errors during ``withError(_:)-6g4wn``.
 public enum MLXError: Error {
     case caught(String)
+
+    var localizedDescription: String {
+        switch self {
+        case .caught(let message): message
+        }
+    }
 }
 
 /// Boxed error type usable with ``withError(_:)-2wfiu``.

--- a/Source/MLX/ErrorHandler.swift
+++ b/Source/MLX/ErrorHandler.swift
@@ -219,7 +219,7 @@ public enum MLXError: Error {
 
     var localizedDescription: String {
         switch self {
-        case .caught(let message): message
+        case .caught(let message): "MLX Error: \(message)"
         }
     }
 }


### PR DESCRIPTION
This small PR makes  catchers of `MLXError` able to extract the error message in a generic way that works for all `Error`s, thus without having to cast it. 