### PR TITLE
Update links to MLX packages in documentation

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -12,21 +12,21 @@
 
 ## Adding a New Package
 
-Here is adding `MLXFFT`:
+Here is adding `MLXOptimizers`:
 
 1. `Package.swift` add a new product (for anything that should be exported) and target:
 
 ```
 products: [
     ...
-    .library(name: "MLXFFT", targets: ["MLXFFT"]),
+    .library(name: "MLXOptimizers", targets: ["MLXOptimizers"]),
 ```
 
 ```
 targets: [
     ...
     .target(
-        name: "MLXFFT",
+        name: "MLXOptimizers",
         dependencies: ["MLX"]
     ),
 ```
@@ -36,18 +36,17 @@ add to MLXTests:
 ```
         .testTarget(
             name: "MLXTests",
-            dependencies: ["MLX", "MLXRandom", "MLXNN", "MLXOptimizers", "MLXFFT"]
+            dependencies: ["MLX", "MLXNN", "MLXOptimizers"]
         ),
 ```
 
-    
 2. Update `CMakeLists`
-    
+
 ```
-# MLXFFT package
-file(GLOB MLXFFT-src ${CMAKE_CURRENT_LIST_DIR}/Source/MLXFFT/*.swift)
-add_library(MLXFFT STATIC ${MLXFFT-src})
-target_link_libraries(MLXFFT PRIVATE MLX)
+# MLXOptimizers package
+file(GLOB MLXOptimizers-src ${CMAKE_CURRENT_LIST_DIR}/Source/MLXOptimizers/*.swift)
+add_library(MLXOptimizers STATIC ${MLXOptimizers-src})
+target_link_libraries(MLXOptimizers PRIVATE MLX)
 ```
 
 3. Create directory in `Source`
@@ -56,18 +55,13 @@ target_link_libraries(MLXFFT PRIVATE MLX)
 
 5. Add source files and documentation
 
-6. Add linkage to the other documentation, e.g. in `MLXFFT.md`
+6. Add linkage to the other documentation, e.g. in `MLXOptimizers.md`
 
 ```
 ## Other MLX Packages
 
 - [MLX](mlx)
-- [MLXRandom](mlxrandom)
 - [MLXNN](mlxnn)
-- [MLXOptimizers](mlxoptimizers)
-- [MLXFFT](mlxfft)
-- [MLXLinalg](mlxlinalg)
-- [MLXFast](mlxfast)
 
 - [Python `mlx`](https://ml-explore.github.io/mlx/build/html/index.html)
 ```
@@ -78,27 +72,23 @@ target_link_libraries(MLXFFT PRIVATE MLX)
 ## Other MLX Packages
 
 ...
-- [MLXFFT](../mlxfft/)
+- [MLXOptimizers](../mlxoptimizers/)
 ```
 
 8. Update README.md
 
 ```
 dependencies: [.product(name: "MLX", package: "mlx-swift"),
-               .product(name: "MLXRandom", package: "mlx-swift"),
                .product(name: "MLXNN", package: "mlx-swift"),
-               .product(name: "MLXOptimizers", package: "mlx-swift"),
-               .product(name: "MLXFFT", package: "mlx-swift")]
+               .product(name: "MLXOptimizers", package: "mlx-swift")]
 ```
 
 9. Update install.md
 
 ```
 dependencies: [.product(name: "MLX", package: "mlx-swift"),
-               .product(name: "MLXRandom", package: "mlx-swift"),
                .product(name: "MLXNN", package: "mlx-swift"),
-               .product(name: "MLXOptimizers", package: "mlx-swift"),
-               .product(name: "MLXFFT", package: "mlx-swift")]
+               .product(name: "MLXOptimizers", package: "mlx-swift")]
 ```
 
 10. Update `tools/generate_integration_tests.py` as needed
@@ -113,7 +103,7 @@ import MLXNN
 12. Update `tools/build-documentation.sh`
 
 ```
-for x in MLX MLXRandom MLXNN MLXOptimizers MLXFFT; do
+for x in MLX MLXNN MLXOptimizers; do
 ```
 
 13. Add to `.spi.yml` for swift package index
@@ -129,25 +119,24 @@ pre-commit run --all-files
 ## Updating `mlx` and `mlx-c`
 
 SwiftPM is able to fetch repositories from github and build them _if_ they have
-a `Package.swift` at the top level.  It is unable to do this for repositories
-that do not have a `Package.swift`.  For this reason `mlx-swift` uses
+a `Package.swift` at the top level. It is unable to do this for repositories
+that do not have a `Package.swift`. For this reason `mlx-swift` uses
 git submodules to include the `mlx` and `mlx-c` repositories.
 
 When a new version of `mlx` and its equivalent `mlx-c` are to be used, there is a
 process to go through to update `mlx-swift`.
 
 Additionally, SwiftPM supports plugins that can produce derived source for
-building, but this can only produce new swift source.  It is possible to use
+building, but this can only produce new swift source. It is possible to use
 plugins to generate new source `.cpp` files and even compile them, but at
 best the `.o` is copied into the output as a resource, not linked.
 This is important because `mlx` has some build-time source generation
-(e.g. `make_compiled_preamble.sh`).  This is handled in `mlx-swift` by
+(e.g. `make_compiled_preamble.sh`). This is handled in `mlx-swift` by
 pre-generating the source when updating the `mlx` version.
 
 1. Update the `mlx` and `mlx-c` submodules via `git pull` or `git checkout ...`
-    - `Source/Cmlx/mlx`
-    - `Source/Cmlx/mlx-c`
-    
+   - `Source/Cmlx/mlx`
+   - `Source/Cmlx/mlx-c`
 2. Add any vendored dependencies as needed in `/vendor`
 
 3. Regenerate any build-time source: `./tools/update-mlx.sh`

--- a/Source/MLX/Documentation.docc/MLX.md
+++ b/Source/MLX/Documentation.docc/MLX.md
@@ -35,7 +35,6 @@ are the CPU and GPU.
 
 ## Other MLX Packages
 
-- [MLX](mlx)
 - [MLXNN](mlxnn)
 - [MLXOptimizers](mlxoptimizers)
 

--- a/Source/MLXNN/Documentation.docc/MLXNN.md
+++ b/Source/MLXNN/Documentation.docc/MLXNN.md
@@ -44,12 +44,7 @@ See <doc:training>
 ## Other MLX Packages
 
 - [MLX](mlx)
-- [MLXRandom](mlxrandom)
-- [MLXNN](mlxnn)
 - [MLXOptimizers](mlxoptimizers)
-- [MLXFFT](mlxfft)
-- [MLXLinalg](mlxlinalg)
-- [MLXFast](mlxfast)
 
 - [Python `mlx`](https://ml-explore.github.io/mlx/build/html/index.html)
 

--- a/Source/MLXOptimizers/Documentation.docc/MLXOptimizers.md
+++ b/Source/MLXOptimizers/Documentation.docc/MLXOptimizers.md
@@ -32,12 +32,7 @@ for _ in 0 ..< epochs {
 ## Other MLX Packages
 
 - [MLX](mlx)
-- [MLXRandom](mlxrandom)
 - [MLXNN](mlxnn)
-- [MLXOptimizers](mlxoptimizers)
-- [MLXFFT](mlxfft)
-- [MLXLinalg](mlxlinalg)
-- [MLXFast](mlxfast)
 
 - [Python `mlx`](https://ml-explore.github.io/mlx/build/html/index.html)
 


### PR DESCRIPTION
Currently, the top-level documentation for modules includes an "Other MLX Packages" section with self-links and links to deprecated frameworks.

For example, here's the landing page for [MLXNN](https://swiftpackageindex.com/ml-explore/mlx-swift/main/documentation/mlxnn) as it appears on Swift Package Index:

<img width="342" height="368" alt="Screenshot 2025-09-29 at 05 30 27" src="https://github.com/user-attachments/assets/3f3ae8b6-1159-4af7-b545-0d2bb7e72ca6" />

This PR removes all self-links (e.g. linking to `MLXNN` on the landing page for `MLXNN`) and links to deprecated frameworks. This will help prevent new users from navigating to the docs and being confused about the extent of modules available in the MLX package. This PR also updates `MAINTENANCE.md`, but I'm less confident in that change.