### PR TITLE
ensure that the ErrorHandler is installed

### DIFF
--- a/Source/MLX/ErrorHandler.swift
+++ b/Source/MLX/ErrorHandler.swift
@@ -282,6 +282,11 @@ private let errorHandler: ErrorHandler = {
     return ErrorHandler()
 }()
 
+/// Ensure that the error handler is installed.
+func initError() {
+    _ = errorHandler
+}
+
 /// Forward the error to the `ErrorHandler` singleton.  See `errorHandler` (above) for how this is
 /// installed.
 private func errorHandlerTrampoline(message: UnsafePointer<CChar>?, data: UnsafeMutableRawPointer?)

--- a/Source/MLX/MLXArray.swift
+++ b/Source/MLX/MLXArray.swift
@@ -14,6 +14,9 @@ public final class MLXArray {
     ///
     /// This initializer is for `Cmlx` interoperation.
     public init(_ ctx: consuming mlx_array) {
+        // We don't have lifecycle control over the MLX system but all interesting
+        // paths will come through here -- make sure the error handler is installed.
+        initError()
         self.ctx = ctx
     }
 


### PR DESCRIPTION
- this will force all fatal errors to go through the swift code rather than the mlx-c code
- and produce a fatalError which will stop in the debugger