### PR TITLE
new[CI]: add linux container cmake swift builds

### DIFF
--- a/.github/scripts/setup+build-linux-container-cmake.sh
+++ b/.github/scripts/setup+build-linux-container-cmake.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -ex
+
+# [Setup] Install dependencies inside the container.
+if command -v apt-get >/dev/null 2>&1; then
+    apt-get update -y
+    apt-get install -y \
+        build-essential \
+        cmake \
+        ninja-build \
+        libblas-dev \
+        liblapacke-dev \
+        libopenblas-dev
+
+elif command -v dnf >/dev/null 2>&1; then
+    dnf update -y
+    dnf install -y \
+        blas-devel \
+        lapack-devel \
+        openblas-devel \
+        make \
+        cmake \
+        clang \
+        ninja-build
+
+else
+    echo "No supported package manager found (apt-get, dnf)"
+    exit 1
+fi
+
+# [CMake] CI Build Sanity Check: Verifies code compilation, not for release.
+export CMAKE_ARGS="-DCMAKE_COMPILE_WARNING_AS_ERROR=ON"
+export DEBUG=1
+export CMAKE_C_COMPILER=/usr/bin/clang
+export CMAKE_CXX_COMPILER=/usr/bin/clang++
+
+rm -rf build
+mkdir -p build
+pushd build
+cmake -DMLX_BUILD_METAL=OFF .. -G Ninja
+ninja
+./example1
+./tutorial
+popd

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -75,3 +75,33 @@ jobs:
           cmake .. -G Ninja
           ninja
 
+  linux_build_cmake_container:
+    name: Linux Container CMake Swift Build (${{ matrix.container }} ${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # See https://github.com/swiftlang/swift-docker/tree/main/
+          - host: ubuntu-22.04
+            arch: x86_64
+            container: swift:bookworm
+          - host: ubuntu-22.04
+            arch: x86_64
+            container: swift:fedora39
+          - host: ubuntu-22.04-arm
+            arch: aarch64
+            container: swift:bookworm
+          - host: ubuntu-22.04-arm
+            arch: aarch64
+            container: swift:fedora39
+
+    runs-on: ${{ matrix.host }}
+    container:
+      image: ${{ matrix.container }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Linux Container CMake Swift Build - No Release
+        run: |
+          bash .github/scripts/setup+build-linux-container-cmake.sh


### PR DESCRIPTION
## Proposed changes

Proposing to add " Linux Container CMake Swift Build (${{ matrix.container }} ${{ matrix.arch }})".

@Joannis once SwiftPM works for native Linux builds (https://github.com/ml-explore/mlx-swift/pull/304) we could add another Linux CI in order to test the usual n supported Swift versions + running swift test etc.

This CI is more focused on testing the CMake builds only within the specified containers ...

CC @davidkoski @madrob 

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
