### PR TITLE
add .arrays back to ScaledDotProductAttentionMaskMode

### DIFF
--- a/Source/MLX/MLXFast.swift
+++ b/Source/MLX/MLXFast.swift
@@ -97,13 +97,19 @@ public enum MLXFast {
     public enum ScaledDotProductAttentionMaskMode {
         case none
         case array(MLXArray)
+
+        @available(*, deprecated, message: "Use .array instead")
+        case arrays([MLXArray])
         case causal
 
         public var mask: MLXArray? {
             switch self {
-            case .none: nil
-            case .array(let array): array
-            case .causal: nil
+            case .none: return nil
+            case .array(let array): return array
+            case .arrays(let arrays):
+                precondition(arrays.count <= 1, "Only a single array is allowed")
+                return arrays.first
+            case .causal: return nil
             }
         }
 
@@ -111,6 +117,7 @@ public enum MLXFast {
             switch self {
             case .none: ""
             case .array: ""
+            case .arrays: ""
             case .causal: "causal"
             }
         }


### PR DESCRIPTION
- https://github.com/ml-explore/mlx-swift-lm/issues/17
- no longer supported, but we can deprecate and add a runtime check
- keeps source compatibility -- this would have otherwise been tricky to support

## Proposed changes

Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
