### PR TITLE
fix #315 -- do not reshape during SDPA

### DIFF
--- a/Source/MLXNN/PositionalEncoding.swift
+++ b/Source/MLXNN/PositionalEncoding.swift
@@ -37,12 +37,9 @@ final public class RoPE: Module, UnaryLayer {
     }
 
     public func callAsFunction(_ x: MLXArray, offset: Int) -> MLXArray {
-        let shape = x.shape
-        var x = x.reshaped(-1, x.dim(-2), x.dim(-1))
-        x = MLXFast.RoPE(
+        MLXFast.RoPE(
             x, dimensions: dimensions, traditional: traditional, base: base, scale: scale,
             offset: offset)
-        return x.reshaped(shape)
     }
 
     /// Evaluate with `offset` of `0`.


### PR DESCRIPTION
- this was changed on the python side in https://github.com/ml-explore/mlx/commit/16546c70d8983e9860f7456c0dfc63176fc95568
- in v0.29.1 this still produced the correct result but in v0.30.0 it does not
	- in particular a different specialized function is used

- #315 

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
