### PR TITLE
Sequential layers should be mutable to support quantizaton

### DIFF
--- a/Source/MLXNN/Containers.swift
+++ b/Source/MLXNN/Containers.swift
@@ -39,7 +39,7 @@ import MLX
 /// ```
 open class Sequential: Module, UnaryLayer {
 
-    public let layers: [UnaryLayer]
+    @ModuleInfo public var layers: [UnaryLayer]
 
     public init(layers: [UnaryLayer]) {
         self.layers = layers

--- a/Tests/MLXTests/ModuleTests.swift
+++ b/Tests/MLXTests/ModuleTests.swift
@@ -949,4 +949,16 @@ class ModuleTests: XCTestCase {
             }
         }
     }
+
+    func testSequentialQuantization() {
+        let s = Sequential {
+            Linear(64, 64)
+            Linear(64, 64)
+            Linear(64, 64)
+        }
+
+        // https://github.com/ml-explore/mlx-swift/issues/317
+        // Unable to get @ModuleInfo for Sequential.layers -- must be wrapped to receive updates
+        quantize(model: s)
+    }
 }


### PR DESCRIPTION
- fixes #317

## Proposed changes

The `Sequential` layer had an immutable `layers`.  This doesn't support replacing items in that array, e.g. if you `quantize` the model.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
