### PR TITLE
add protocol for array + offset -- to be used by RoPE utils

### DIFF
--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -1006,11 +1006,6 @@ public protocol UnaryLayer: Module {
     func callAsFunction(_ x: MLXArray) -> MLXArray
 }
 
-/// A `Layer`  (``Module`` subclass) that can be evaluated with an array and offset.
-public protocol OffsetLayer: Module {
-    func callAsFunction(_ x: MLXArray, offset: Int) -> MLXArray
-}
-
 // MARK: - Filters and Maps
 
 extension Module {

--- a/Source/MLXNN/PositionalEncoding.swift
+++ b/Source/MLXNN/PositionalEncoding.swift
@@ -3,6 +3,11 @@
 import Foundation
 import MLX
 
+/// A `Layer`  (``Module`` subclass) that can be evaluated with an array and offset.
+public protocol OffsetLayer: Module {
+    func callAsFunction(_ x: MLXArray, offset: Int) -> MLXArray
+}
+
 /// Implements the rotary positional encoding.
 ///
 /// The traditional implementation rotates consecutive pairs of elements in the


### PR DESCRIPTION
## Proposed changes

Adds a protocol:

```swift
public protocol OffsetLayer: Module {
    func callAsFunction(_ x: MLXArray, offset: Int) -> MLXArray
}
```

This will be useful in the RoPE utils in mlx-swift-lm.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
