### PR TITLE
thread safety -- hold lock while calling stream sync

### DIFF
--- a/Source/MLX/Stream.swift
+++ b/Source/MLX/Stream.swift
@@ -140,7 +140,9 @@ public final class Stream: @unchecked Sendable, Equatable {
 
     /// Synchronize with the given stream
     public func synchronize() {
-        mlx_synchronize(ctx)
+        _ = evalLock.withLock {
+            mlx_synchronize(ctx)
+        }
     }
 
     static public func defaultStream(_ device: Device) -> Stream {


### PR DESCRIPTION
## Proposed changes

Observed:  stream synchronization is not thread safe in roughly the same way that eval is not (if this were to be called while asyncEval was running it can manipulate the same global state in the command encoders).  Hold the eval lock while calling.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
