### PR TITLE
Fix race condition in clearCache causing Metal crash

### DIFF
--- a/Source/MLX/Memory.swift
+++ b/Source/MLX/Memory.swift
@@ -352,6 +352,8 @@ public enum Memory {
 
     /// Cause all cached buffers to be deallocated.
     public static func clearCache() {
-        mlx_clear_cache()
+        _ = evalLock.withLock {
+            mlx_clear_cache()
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

This PR fixes a crash that occurs when clearCache() is called while an asynchronous evaluation is still encoding commands.

MLX.GPU.clearCache() (which calls Memory.clearCache()) was not synchronized with the evaluation engine. If called during an active generation loop (for example:  quitting the app), it would invalidate Metal resources while the command encoder was still using them, leading to an objc_retain crash in CaptureMTLComputeCommandEncoder.


## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
