### PR TITLE
fix many documentation disambiguation warnings

### DIFF
--- a/Source/MLX/DType.swift
+++ b/Source/MLX/DType.swift
@@ -21,8 +21,8 @@ import Numerics
 ///
 /// ### See Also
 /// - ``HasDType``
-/// - ``MLXArray/asType(_:stream:)-6d44y``
-/// - ``MLXArray/asType(_:stream:)-4eqoc``
+/// - ``MLXArray/asType(_:stream:)-(DType,StreamOrDevice)``
+/// - ``MLXArray/asType(_:stream:)-(HasDType.Type,StreamOrDevice)``
 /// - ``MLXArray/init(_:dtype:)``
 public enum DType: Hashable, Sendable, CaseIterable {
     case bool
@@ -124,7 +124,7 @@ public enum DType: Hashable, Sendable, CaseIterable {
 
         /// The difference between 1.0 and the next smallest representable float larger than 1.0
         ///
-        /// In Swift this is e.g. ``Double.ulpOfOne``
+        /// In Swift this is e.g. `Double.ulpOfOne`
         public var eps: Double {
             switch dtype {
             #if !arch(x86_64)

--- a/Source/MLX/Documentation.docc/Articles/broadcasting.md
+++ b/Source/MLX/Documentation.docc/Articles/broadcasting.md
@@ -42,7 +42,7 @@ array([[1, 2, 3],
        [10, 11, 12]], dtype=int32)
 ```
 
-This uses ``MLXArray/+(_:_:)-2vili`` which uses ``ScalarOrArray`` to automatically convert scalar values
+This uses ``MLXArray/+(_:_:)-(MLXArray,ScalarOrArray)`` which uses ``ScalarOrArray`` to automatically convert scalar values
 into ``MLXArray``.
 
 A scalar can be broadcast to any shape array:  the scalar is repeated for each element in the array.

--- a/Source/MLX/Documentation.docc/Articles/compilation.md
+++ b/Source/MLX/Documentation.docc/Articles/compilation.md
@@ -1,11 +1,11 @@
 # Compilation
 
-MLX has a ``compile(inputs:outputs:shapeless:_:)-8wq3u`` function transformation which compiles computation
+MLX has a ``compile(inputs:outputs:shapeless:_:)-([Updatable],[Updatable],Bool,([MLXArray])->[MLXArray])`` function transformation which compiles computation
 graphs. Function compilation results in smaller graphs by merging common work
 and fusing certain operations. In many cases this can lead to big improvements
 in run-time and memory use.
 
-Getting started with ``compile(inputs:outputs:shapeless:_:)-8wq3u`` is simple, but there are 
+Getting started with ``compile(inputs:outputs:shapeless:_:)-([Updatable],[Updatable],Bool,([MLXArray])->[MLXArray])`` is simple, but there are 
 some edge cases that are good to be aware of for more complex graphs and advanced usage.
 
 ## Basics of Compile
@@ -70,7 +70,7 @@ public func gelu(_ x: MLXArray) -> MLXArray {
 If you use this function with small arrays, it will be overhead bound. If you
 use it with large arrays it will be memory bandwidth bound.  However, all of
 the operations in the `gelu` are fusible into a single kernel with
-``compile(inputs:outputs:shapeless:_:)-8wq3u``. This can speedup both cases considerably.
+``compile(inputs:outputs:shapeless:_:)-([Updatable],[Updatable],Bool,([MLXArray])->[MLXArray])``. This can speedup both cases considerably.
 
 Let's compare the runtime of the regular function versus the compiled
 function. We'll use the following timing helper which does a warm up and
@@ -182,7 +182,7 @@ print(state)
 ```
 
 In some cases returning updated state can be pretty inconvenient. Hence,
-``compile(inputs:outputs:shapeless:_:)-8wq3u`` has a parameter to capture implicit state:
+``compile(inputs:outputs:shapeless:_:)-([Updatable],[Updatable],Bool,([MLXArray])->[MLXArray])`` has a parameter to capture implicit state:
 
 ```swift
 var state = [MLXArray]()
@@ -242,10 +242,10 @@ XCTAssertFalse(allClose(c2a, c2b).item())
 
 ## Compiling Training Graphs 
 
-This section will step through how to use ``compile(inputs:outputs:shapeless:_:)-8wq3u`` 
+This section will step through how to use ``compile(inputs:outputs:shapeless:_:)-([Updatable],[Updatable],Bool,([MLXArray])->[MLXArray])`` 
 with a simple example of a common setup: training a model with `Module` using an
 `Optimizer` with state. We will show how to compile the
-full forward, backward, and update with ``compile(inputs:outputs:shapeless:_:)-8wq3u``.
+full forward, backward, and update with ``compile(inputs:outputs:shapeless:_:)-([Updatable],[Updatable],Bool,([MLXArray])->[MLXArray])``.
 
 Here is the basic scenario:
 
@@ -319,7 +319,7 @@ for _ in 0 ..< 30 {
 
 ### Functions
 
-- ``compile(inputs:outputs:shapeless:_:)-8wq3u``
-- ``compile(inputs:outputs:shapeless:_:)-15bpz``
-- ``compile(inputs:outputs:shapeless:_:)-47dv3``
+- ``compile(inputs:outputs:shapeless:_:)-([Updatable],[Updatable],Bool,([MLXArray])->[MLXArray])``
+- ``compile(inputs:outputs:shapeless:_:)-([Updatable],[Updatable],Bool,(MLXArray)->MLXArray)``
+- ``compile(inputs:outputs:shapeless:_:)-([Updatable],[Updatable],Bool,(MLXArray,MLXArray)->MLXArray)``
 - ``compile(enable:)``

--- a/Source/MLX/Documentation.docc/Articles/converting-python.md
+++ b/Source/MLX/Documentation.docc/Articles/converting-python.md
@@ -39,8 +39,8 @@ See <doc:indexing> for more information.
 
 Note that the element-wise logical operations such as:
 
-- ``MLXArray/.==(_:_:)-56m0a``
-- ``MLXArray/.==(_:_:)-79hbc``
+- ``MLXArray/.==(_:_:)-(MLXArray,MLXArray)``
+- ``MLXArray/.==(_:_:)-(MLXArray,ScalarOrArray)``
 
 are named using the Swift convention for SIMD operations, e.g. `.==`, `.<`, etc.  These
 operators produce a new ``MLXArray`` with `true`/`false` values for the elementwise comparison.
@@ -50,7 +50,7 @@ to `camelCase`.  A few exceptions to that rule follow swift naming for functions
 no side effects.  For example:
 
 - `flatten()` becomes ``flattened(_:start:end:stream:)``
-- `reshape()` becomes ``reshaped(_:_:stream:)-5x3y0``
+- `reshape()` becomes ``reshaped(_:_:stream:)-(_,Int...,_)``
 - `moveaxis()` becomes ``movedAxis(_:source:destination:stream:)``
 
 and so on.
@@ -64,7 +64,7 @@ Note: some of the symbols are not linkable.
 --- | ---
 `__init__` | see <doc:initialization>
 `__repr__` | ``MLXArray/description``
-`__eq__` | ``MLXArray/.==(_:_:)-56m0a``
+`__eq__` | ``MLXArray/.==(_:_:)-(MLXArray,MLXArray)``
 `size` | ``MLXArray/size``
 `ndim` | ``MLXArray/ndim``
 `itemsize` | ``MLXArray/itemSize``
@@ -73,32 +73,32 @@ Note: some of the symbols are not linkable.
 `dtype` | ``MLXArray/dtype``
 `item` | ``MLXArray/item(_:)``
 `tolist` | ``MLXArray/asArray(_:)``
-`astype` | ``MLXArray/asType(_:stream:)-4eqoc`` or ``MLXArray/asType(_:stream:)-6d44y``
-`__getitem__` | ``MLXArray/subscript(_:stream:)-375a0``
+`astype` | ``MLXArray/asType(_:stream:)-(HasDType.Type,StreamOrDevice)`` or ``MLXArray/asType(_:stream:)-(DType,StreamOrDevice)``
+`__getitem__` | ``MLXArray/subscript(_:stream:)-(MLXArrayIndex,StreamOrDevice)``
 `__len__` | ``MLXArray/count``
 `__iter__` | implements `Sequence`
-`__add__` | ``MLXArray/+(_:_:)-1rv98``
-`__iadd__` | ``MLXArray/+=(_:_:)-3feg7``
-`__sub__` | ``MLXArray/-(_:_:)-7frdo``
-`__isub__` | ``MLXArray/-=(_:_:)-4d4ei``
-`__mul__` | ``MLXArray/*(_:_:)-1z2ck``
-`__imul__` | ``MLXArray/*=(_:_:)-9ukv3``
-`__truediv__` | ``MLXArray//(_:_:)-6ijef``
-`__div__` | ``MLXArray//(_:_:)-6ijef``
-`__idiv__` | ``MLXArray//=(_:_:)-9egbn``
+`__add__` | ``MLXArray/+(_:_:)-(MLXArray,MLXArray)``
+`__iadd__` | ``MLXArray/+=(_:_:)-(inout_MLXArray,MLXArray)``
+`__sub__` | ``MLXArray/-(_:_:)-(MLXArray,MLXArray)``
+`__isub__` | ``MLXArray/-=(_:_:)-(inout_MLXArray,MLXArray)``
+`__mul__` | ``MLXArray/*(_:_:)-(MLXArray,MLXArray)``
+`__imul__` | ``MLXArray/*=(_:_:)-(inout_MLXArray,MLXArray)``
+`__truediv__` | ``MLXArray//(_:_:)-(MLXArray,MLXArray)``
+`__div__` | ``MLXArray//(_:_:)-(MLXArray,MLXArray)``
+`__idiv__` | ``MLXArray//=(_:_:)-(inout_MLXArray,MLXArray)``
 `__floordiv__` | ``MLXArray/floorDivide(_:stream:)``
-`__mod__` | ``MLXArray/%(_:_:)-3ubwd``
-`__eq__` | ``MLXArray/.==(_:_:)-56m0a``
-`__lt__` | ``MLXArray/.<(_:_:)-9rzup``
-`__le__` | ``MLXArray/.<=(_:_:)-2a0s9``
-`__gt__` | ``MLXArray/.>(_:_:)-fwi1``
-`__ge__` | ``MLXArray/.>=(_:_:)-2gqml``
-`__ne__` | ``MLXArray/.!=(_:_:)-mbw0``
+`__mod__` | ``MLXArray/%(_:_:)-(MLXArray,MLXArray)``
+`__eq__` | ``MLXArray/.==(_:_:)-(MLXArray,MLXArray)``
+`__lt__` | ``MLXArray/.<(_:_:)-(MLXArray,MLXArray)``
+`__le__` | ``MLXArray/.<=(_:_:)-(MLXArray,MLXArray)``
+`__gt__` | ``MLXArray/.>(_:_:)-(MLXArray,MLXArray)``
+`__ge__` | ``MLXArray/.>=(_:_:)-(MLXArray,MLXArray)``
+`__ne__` | ``MLXArray/.!=(_:_:)-(MLXArray,MLXArray)``
 `__neg__` | ``MLXArray/-(_:)``
 `__bool__` | ``MLXArray/all(keepDims:stream:)`` + ``MLXArray/item()``
 `__repr__` | ``MLXArray/description``
 `__matmul__` | ``MLXArray/matmul(_:stream:)``
-`__pow__` | ``MLXArray/**(_:_:)-8xxt3``
+`__pow__` | ``MLXArray/**(_:_:)-(MLXArray,MLXArray)``
 `abs` | ``MLXArray/abs(stream:)``
 `all` | ``MLXArray/all(axes:keepDims:stream:)``
 `any` | ``MLXArray/any(axes:keepDims:stream:)``
@@ -122,7 +122,7 @@ Note: some of the symbols are not linkable.
 `moveaxis` | ``MLXArray/movedAxis(source:destination:stream:)``
 `prod` | ``MLXArray/product(axes:keepDims:stream:)``
 `reciprocal` | ``MLXArray/reciprocal(stream:)``
-`reshape` | ``MLXArray/reshaped(_:stream:)-67a89``
+`reshape` | ``MLXArray/reshaped(_:stream:)-(Collection<Int>,StreamOrDevice)``
 `round` | ``MLXArray/round(decimals:stream:)``
 `rsqrt` | ``MLXArray/rsqrt(stream:)``
 `sin` | ``MLXArray/sin(stream:)``
@@ -173,7 +173,7 @@ This is a mapping of `mx` free functions to their ``MLX`` counterparts.
 `cummin` | ``MLX/cummin(_:axis:reverse:inclusive:stream:)``
 `cumprod` | ``MLX/cumprod(_:axis:reverse:inclusive:stream:)``
 `cumsum` | ``MLX/cumsum(_:axis:reverse:inclusive:stream:)``
-`dequantize` | ``MLX/dequantized(_:scales:biases:groupSize:bits:mode:stream:)``
+`dequantize` | ``MLX/dequantized(_:scales:biases:groupSize:bits:mode:dtype:stream:)``
 `divide` | ``MLX/divide(_:_:stream:)``
 `equal` | ``MLX/equal(_:_:stream:)``
 `erf` | ``MLX/erf(_:stream:)``
@@ -190,7 +190,7 @@ This is a mapping of `mx` free functions to their ``MLX`` counterparts.
 `identity` | ``MLXArray/identity(_:type:stream:)``
 `less` | ``MLX/less(_:_:stream:)``
 `less_equal` | ``MLX/lessEqual(_:_:stream:)``
-`linspace` | ``MLXArray/linspace(_:_:count:stream:)-92x6l``
+`linspace` | ``MLXArray/linspace(_:_:count:stream:)-(Int,Int,Int,StreamOrDevice)``
 `load` | ``MLX/loadArray(url:stream:)`` and ``MLX/loadArrays(url:stream:)``
 `log` | ``MLX/log(_:stream:)``
 `log10` | ``MLX/log10(_:stream:)``
@@ -213,7 +213,7 @@ This is a mapping of `mx` free functions to their ``MLX`` counterparts.
 `ones_like` | ``MLXArray/ones(like:stream:)``
 `pad` | ``MLX/padded(_:width:mode:value:stream:)``
 `partition` | ``MLX/partitioned(_:kth:axis:stream:)``
-`power` | ``MLX/pow(_:_:stream:)-8ie9c``
+`power` | ``MLX/pow(_:_:stream:)-(MLXArray,MLXArray,_)``
 `prod` | ``MLX/product(_:axes:keepDims:stream:)``
 `qqmm` | ``MLX/quantizedQuantizedMM(_:_:scales:groupSize:bits:mode:stream:)``
 `quantize` | ``MLX/quantized(_:groupSize:bits:mode:stream:)``
@@ -221,7 +221,7 @@ This is a mapping of `mx` free functions to their ``MLX`` counterparts.
 `reciprocal` | ``MLX/reciprocal(_:stream:)``
 `remainder` | ``MLX/remainder(_:_:stream:)``
 `repeat` | ``MLX/repeated(_:count:axis:stream:)``
-`reshape` | ``MLX/reshaped(_:_:stream:)-5x3y0``
+`reshape` | ``MLX/reshaped(_:_:stream:)-(MLXArray,Collection<Int>,StreamOrDevice)``
 `round` | ``MLX/round(_:decimals:stream:)``
 `rsqrt` | ``MLX/rsqrt(_:stream:)``
 `save` | ``MLX/save(array:url:stream:)`` and ``MLX/save(arrays:metadata:url:stream:)``

--- a/Source/MLX/Documentation.docc/Articles/lazy-evaluation.md
+++ b/Source/MLX/Documentation.docc/Articles/lazy-evaluation.md
@@ -10,7 +10,7 @@ See also [mlx python docs](https://ml-explore.github.io/mlx/build/html/usage/laz
 
 When you perform operations in MLX, no computation actually happens. Instead a
 compute graph is recorded. The actual computation only happens if an
-``eval(_:)-3b2g9`` is performed or an implicit eval is triggered.
+``eval(_:)-(Collection<MLXArray>)`` is performed or an implicit eval is triggered.
 
 MLX uses lazy evaluation because it has some nice features, some of which we
 describe below. 
@@ -49,7 +49,7 @@ code simple. Say you have a very large model `Model` derived from
 `Module`. You can instantiate this model with `model = Model()`.
 Typically, this will initialize all of the weights as `float32`, but the
 initialization does not actually compute anything until you perform an
-``eval(_:)-3b2g9``. If you update the model with `float16` weights, your maximum
+``eval(_:)-(Collection<MLXArray>)``. If you update the model with `float16` weights, your maximum
 consumed memory will be half that required if eager computation was used
 instead.
 
@@ -66,7 +66,7 @@ model.update(parameters: weights)
 
 ## When to Evaluate
 
-A common question is when to use ``eval(_:)-3b2g9``. The trade-off is between
+A common question is when to use ``eval(_:)-(Collection<MLXArray>)``. The trade-off is between
 letting graphs get too large and not batching enough useful work.
 
 For example:
@@ -94,7 +94,7 @@ evaluation should be okay.
 
 Most numerical computations have an iterative outer loop (e.g. the iteration in
 stochastic gradient descent). A natural and usually efficient place to use
-``eval(_:)-3b2g9`` is at each iteration of this outer loop.
+``eval(_:)-(Collection<MLXArray>)`` is at each iteration of this outer loop.
 
 Here is a concrete example:
 
@@ -124,7 +124,7 @@ a list (`losses.append(loss.item(Float.self))`) would cause a graph evaluation. 
 these lines are before `eval(loss, model.parameters())` then this
 will be a partial evaluation, computing only the forward pass.
 
-Also, calling ``eval(_:)-3b2g9`` on an array or set of arrays multiple times is
+Also, calling ``eval(_:)-(Collection<MLXArray>)`` on an array or set of arrays multiple times is
 perfectly fine. This is effectively a no-op.
 
 > Using scalar arrays for control-flow will cause an evaluation.

--- a/Source/MLX/Documentation.docc/Organization/arithmetic.md
+++ b/Source/MLX/Documentation.docc/Organization/arithmetic.md
@@ -30,8 +30,8 @@ use the methods on `MLXArray` or the free functions.
 
 Note that the element-wise logical operations such as:
 
-- ``MLXArray/.==(_:_:)-56m0a``
-- ``MLXArray/.==(_:_:)-79hbc``
+- ``MLXArray/.==(_:_:)-(MLXArray,MLXArray)``
+- ``MLXArray/.==(_:_:)-(MLXArray,ScalarOrArray)``
 
 are named using the Swift convention for SIMD operations, e.g. `.==`, `.<`, etc.  These
 operators produce a new ``MLXArray`` with `true`/`false` values for the elementwise comparison.
@@ -41,11 +41,11 @@ operators produce a new ``MLXArray`` with `true`/`false` values for the elementw
 Many functions and operators that work on ``MLXArray`` take a ``ScalarOrArray`` argument or have
 an overload that does.  A sampling:
 
-- ``MLXArray/+(_:_:)-2vili``
-- ``MLXArray/+(_:_:)-1jn5i``
+- ``MLXArray/+(_:_:)-(MLXArray,ScalarOrArray)``
+- ``MLXArray/+(_:_:)-(ScalarOrArray,MLXArray)``
 - ``MLX/minimum(_:_:stream:)``
-- ``MLX/pow(_:_:stream:)-7pe7j``
-- ``MLX/pow(_:_:stream:)-49xi0``
+- ``MLX/pow(_:_:stream:)-(MLXArray,ScalarOrArray,_)``
+- ``MLX/pow(_:_:stream:)-(ScalarOrArray,MLXArray,_)``
 
 ``ScalarOrArray`` is a protocol that various numeric types (`Int`, `Float`, etc.) implement and it
 provides a method to convert the scalar to an ``MLXArray`` using a suggested ``DType``.  This allows:
@@ -70,50 +70,50 @@ Scalars will not promote results to `float32` using these functions.
 
 Note: the `-` and `/` operators are not able to be linked here.
 
-- ``MLXArray/+(_:_:)-1rv98``
-- ``MLXArray/+(_:_:)-2vili``
-- ``MLXArray/+(_:_:)-1jn5i``
+- ``MLXArray/+(_:_:)-(MLXArray,MLXArray)``
+- ``MLXArray/+(_:_:)-(MLXArray,ScalarOrArray)``
+- ``MLXArray/+(_:_:)-(ScalarOrArray,MLXArray)``
 - ``MLXArray/-(_:)``
-- ``MLXArray/*(_:_:)-1z2ck``
-- ``MLXArray/*(_:_:)-sw3w``
-- ``MLXArray/*(_:_:)-7441r``
-- ``MLXArray/**(_:_:)-8xxt3``
-- ``MLXArray/**(_:_:)-6ve5u``
-- ``MLXArray/**(_:_:)-4lp4b``
-- ``MLXArray/%(_:_:)-3ubwd``
-- ``MLXArray/%(_:_:)-516wd``
-- ``MLXArray/%(_:_:)-8az7l``
+- ``MLXArray/*(_:_:)-(MLXArray,MLXArray)``
+- ``MLXArray/*(_:_:)-(MLXArray,ScalarOrArray)``
+- ``MLXArray/*(_:_:)-(ScalarOrArray,MLXArray)``
+- ``MLXArray/**(_:_:)-(MLXArray,MLXArray)``
+- ``MLXArray/**(_:_:)-(MLXArray,ScalarOrArray)``
+- ``MLXArray/**(_:_:)-(ScalarOrArray,MLXArray)``
+- ``MLXArray/%(_:_:)-(MLXArray,MLXArray)``
+- ``MLXArray/%(_:_:)-(ScalarOrArray,MLXArray)``
+- ``MLXArray/%(_:_:)-(MLXArray,ScalarOrArray)``
 - ``MLXArray/.!(_:)``
-- ``MLXArray/.==(_:_:)-56m0a``
-- ``MLXArray/.==(_:_:)-79hbc``
-- ``MLXArray/.!=(_:_:)-mbw0``
-- ``MLXArray/.!=(_:_:)-gkdj``
-- ``MLXArray/.<(_:_:)-9rzup``
-- ``MLXArray/.<(_:_:)-54ivt``
-- ``MLXArray/.<=(_:_:)-2a0s9``
-- ``MLXArray/.<=(_:_:)-6vb92``
-- ``MLXArray/.>(_:_:)-fwi1``
-- ``MLXArray/.>(_:_:)-2v86b``
-- ``MLXArray/.>=(_:_:)-2gqml``
-- ``MLXArray/.>=(_:_:)-6zxj9``
+- ``MLXArray/.==(_:_:)-(MLXArray,MLXArray)``
+- ``MLXArray/.==(_:_:)-(MLXArray,ScalarOrArray)``
+- ``MLXArray/.!=(_:_:)-(MLXArray,MLXArray)``
+- ``MLXArray/.!=(_:_:)-(MLXArray,ScalarOrArray)``
+- ``MLXArray/.<(_:_:)-(MLXArray,MLXArray)``
+- ``MLXArray/.<(_:_:)-(MLXArray,ScalarOrArray)``
+- ``MLXArray/.<=(_:_:)-(MLXArray,MLXArray)``
+- ``MLXArray/.<=(_:_:)-(MLXArray,ScalarOrArray)``
+- ``MLXArray/.>(_:_:)-(MLXArray,MLXArray)``
+- ``MLXArray/.>(_:_:)-(MLXArray,ScalarOrArray)``
+- ``MLXArray/.>=(_:_:)-(MLXArray,MLXArray)``
+- ``MLXArray/.>=(_:_:)-(MLXArray,ScalarOrArray)``
 - ``MLXArray/.&&(_:_:)``
 - ``MLXArray/.||(_:_:)``
 - ``MLXArray/~(_:)``
-- ``MLXArray/&(_:_:)-9in7a``
-- ``MLXArray/&(_:_:)-8js41``
-- ``MLXArray/&(_:_:)-7iu4h``
-- ``MLXArray/|(_:_:)-2upd6``
-- ``MLXArray/|(_:_:)-35lfz``
-- ``MLXArray/|(_:_:)-7c6lr``
-- ``MLXArray/^(_:_:)-8hj69``
-- ``MLXArray/^(_:_:)-2oktd``
-- ``MLXArray/^(_:_:)-dik7``
-- ``MLXArray/<<(_:_:)-1dfss``
-- ``MLXArray/<<(_:_:)-1dfss``
-- ``MLXArray/<<(_:_:)-7hmgt``
-- ``MLXArray/>>(_:_:)-zpp3``
-- ``MLXArray/>>(_:_:)-4z891``
-- ``MLXArray/>>(_:_:)-89b4j``
+- ``MLXArray/&(_:_:)-(MLXArray,MLXArray)``
+- ``MLXArray/&(_:_:)-(MLXArray,ScalarOrArray)``
+- ``MLXArray/&(_:_:)-(ScalarOrArray,MLXArray)``
+- ``MLXArray/|(_:_:)-(MLXArray,MLXArray)``
+- ``MLXArray/|(_:_:)-(MLXArray,ScalarOrArray)``
+- ``MLXArray/|(_:_:)-(ScalarOrArray,MLXArray)``
+- ``MLXArray/^(_:_:)-(MLXArray,MLXArray)``
+- ``MLXArray/^(_:_:)-(MLXArray,ScalarOrArray)``
+- ``MLXArray/^(_:_:)-(ScalarOrArray,MLXArray)``
+- ``MLXArray/<<(_:_:)-(MLXArray,MLXArray)``
+- ``MLXArray/<<(_:_:)-(MLXArray,ScalarOrArray)``
+- ``MLXArray/<<(_:_:)-(ScalarOrArray,MLXArray)``
+- ``MLXArray/>>(_:_:)-(MLXArray,MLXArray)``
+- ``MLXArray/>>(_:_:)-(MLXArray,ScalarOrArray)``
+- ``MLXArray/>>(_:_:)-(ScalarOrArray,MLXArray)``
 
 ### MLXArray Element-wise Arithmetic Functions
 
@@ -184,9 +184,9 @@ Note: the `-` and `/` operators are not able to be linked here.
 - ``nanToNum(_:nan:posInf:negInf:stream:)``
 - ``negative(_:stream:)``
 - ``notEqual(_:_:stream:)``
-- ``pow(_:_:stream:)-7pe7j``
-- ``pow(_:_:stream:)-49xi0``
-- ``pow(_:_:stream:)-8ie9c``
+- ``pow(_:_:stream:)-(MLXArray,ScalarOrArray,_)``
+- ``pow(_:_:stream:)-(ScalarOrArray,MLXArray,_)``
+- ``pow(_:_:stream:)-(MLXArray,MLXArray,_)``
 - ``radians(_:stream:)``
 - ``reciprocal(_:stream:)``
 - ``remainder(_:_:stream:)``
@@ -218,5 +218,5 @@ Note: the `-` and `/` operators are not able to be linked here.
 - ``quantizedQuantizedMM(_:_:scales:groupSize:bits:mode:stream:)``
 - ``inner(_:_:stream:)``
 - ``outer(_:_:stream:)``
-- ``tensordot(_:_:axes:stream:)-3qkgq``
-- ``tensordot(_:_:axes:stream:)-8yqyi``
+- ``tensordot(_:_:axes:stream:)-(MLXArray,MLXArray,Int,StreamOrDevice)``
+- ``tensordot(_:_:axes:stream:)-(MLXArray,MLXArray,((Int,Int),(Int,Int)),StreamOrDevice)``

--- a/Source/MLX/Documentation.docc/Organization/conversion.md
+++ b/Source/MLX/Documentation.docc/Organization/conversion.md
@@ -8,8 +8,8 @@ Conversion functions.
 
 MLX has several functions to support converting between ``DType``:
 
-- ``MLXArray/asType(_:stream:)-4eqoc``
-- ``MLXArray/asType(_:stream:)-6d44y``
+- ``MLXArray/asType(_:stream:)-(HasDType.Type,StreamOrDevice)``
+- ``MLXArray/asType(_:stream:)-(DType,StreamOrDevice)``
 - ``MLXArray/asArray(_:)``
 - ``MLXArray/asData(noCopy:)``
 - ``MLXArray/asMTLBuffer(device:noCopy:)``

--- a/Source/MLX/Documentation.docc/Organization/convolution.md
+++ b/Source/MLX/Documentation.docc/Organization/convolution.md
@@ -11,9 +11,9 @@ MLX has several functions to support convolutions:
 - ``conv1d(_:_:stride:padding:dilation:groups:stream:)``
 - ``conv2d(_:_:stride:padding:dilation:groups:stream:)``
 - ``conv3d(_:_:stride:padding:dilation:groups:stream:)``
-- ``convGeneral(_:_:strides:padding:kernelDilation:inputDilation:groups:flip:stream:)-9t1sj``
-- ``convGeneral(_:_:strides:padding:kernelDilation:inputDilation:groups:flip:stream:)-6j1nr``
-- ``convTransposed1d(_:_:stride:padding:dilation:groups:stream:)``
-- ``convTransposed2d(_:_:stride:padding:dilation:groups:stream:)``
-- ``convTransposed3d(_:_:stride:padding:dilation:groups:stream:)``
+- ``convGeneral(_:_:strides:padding:kernelDilation:inputDilation:groups:flip:stream:)-(MLXArray,MLXArray,IntOrArray,IntOrArray,IntOrArray,IntOrArray,Int,Bool,StreamOrDevice)``
+- ``convGeneral(_:_:strides:padding:kernelDilation:inputDilation:groups:flip:stream:)-(MLXArray,MLXArray,IntOrArray,(Int,Int),IntOrArray,IntOrArray,Int,Bool,StreamOrDevice)``
+- ``convTransposed1d(_:_:stride:padding:dilation:outputPadding:groups:stream:)``
+- ``convTransposed2d(_:_:stride:padding:dilation:outputPadding:groups:stream:)``
+- ``convTransposed3d(_:_:stride:padding:dilation:outputPadding:groups:stream:)``
 - ``convolve(_:_:mode:stream:)``

--- a/Source/MLX/Documentation.docc/Organization/indexes.md
+++ b/Source/MLX/Documentation.docc/Organization/indexes.md
@@ -34,6 +34,6 @@ let sorted = array[sortIndexes]
 
 ### Index Consuming Functions
 
-- ``MLXArray/subscript(_:stream:)-375a0``
+- ``MLXArray/subscript(_:stream:)-(MLXArrayIndex,StreamOrDevice)``
 - ``MLXArray/take(_:axis:stream:)``
 - ``takeAlong(_:_:axis:stream:)``

--- a/Source/MLX/Documentation.docc/Organization/indexing.md
+++ b/Source/MLX/Documentation.docc/Organization/indexing.md
@@ -227,10 +227,10 @@ array[.ellipsis, .newAxis]
 
 ### Subscript Functions
 
-- ``MLXArray/subscript(_:stream:)-375a0``
-- ``MLXArray/subscript(_:stream:)-7crp3``
-- ``MLXArray/subscript(_:axis:stream:)-1jy5n``
-- ``MLXArray/subscript(_:axis:stream:)-79psf``
+- ``MLXArray/subscript(_:stream:)-(MLXArrayIndex...,StreamOrDevice)``
+- ``MLXArray/subscript(_:stream:)-([MLXArrayIndex],StreamOrDevice)``
+- ``MLXArray/subscript(_:axis:stream:)-(Int,Int,StreamOrDevice)``
+- ``MLXArray/subscript(_:axis:stream:)-(RangeExpression<Int>,Int,StreamOrDevice)``
 - ``MLXArray/subscript(from:to:stride:axis:stream:)``
 
 ### Related Functions

--- a/Source/MLX/Documentation.docc/Organization/initialization.md
+++ b/Source/MLX/Documentation.docc/Organization/initialization.md
@@ -29,11 +29,11 @@ Sometimes scalars can be used in place of arrays (no need to explicitly create t
 Some functions and operators that work on ``MLXArray`` take a ``ScalarOrArray`` argument or have
 an overload that does.  A sampling:
 
-- ``MLXArray/+(_:_:)-2vili``
-- ``MLXArray/+(_:_:)-1jn5i``
+- ``MLXArray/+(_:_:)-(MLXArray,ScalarOrArray)``
+- ``MLXArray/+(_:_:)-(ScalarOrArray,MLXArray)``
 - ``MLX/minimum(_:_:stream:)``
-- ``MLX/pow(_:_:stream:)-7pe7j``
-- ``MLX/pow(_:_:stream:)-49xi0``
+- ``MLX/pow(_:_:stream:)-(MLXArray,ScalarOrArray,_)``
+- ``MLX/pow(_:_:stream:)-(ScalarOrArray,MLXArray,_)``
 
 ``ScalarOrArray`` is a protocol that various numeric types (`Int`, `Float`, etc.) implement and it
 provides a method to convert the scalar to an ``MLXArray`` using a suggested ``DType``.  This allows:
@@ -196,11 +196,11 @@ let c = r + i.asImaginary()
 
 ### MLXArray Scalar Initializers
 
-- ``MLXArray/init(_:)-9iiz7``
-- ``MLXArray/init(_:)-6zp01``
-- ``MLXArray/init(_:)-86r8u``
-- ``MLXArray/init(_:)-10m``
-- ``MLXArray/init(_:)-96nyv``
+- ``MLXArray/init(_:)-(Int32)``
+- ``MLXArray/init(_:)-(Bool)``
+- ``MLXArray/init(_:)-(Float)``
+- ``MLXArray/init(_:)-(Int)``
+- ``MLXArray/init(_:)-(T)``
 - ``MLXArray/init(_:dtype:)``
 - ``MLXArray/init(bfloat16:)``
 
@@ -210,25 +210,25 @@ Creating an ``MLXArray`` from `Int` will produce ``DType/int32`` rather
 than ``DType/int64`` (`Int` is really `Int64`).  If you need ``DType/int64``
 there are specific initializers to request it:
 
-- ``MLXArray/init(_:)-6nnka``
-- ``MLXArray/init(_:_:)-93flk``
+- ``MLXArray/init(_:)-(Int)``
+- ``MLXArray/init(_:_:)-([Int],_)``
 - ``MLXArray/init(int64:)``
-- ``MLXArray/init(int64:_:)-7bgj2``
-- ``MLXArray/init(int64:_:)-74tu0``
+- ``MLXArray/init(int64:_:)-([Int],_)``
+- ``MLXArray/init(int64:_:)-(Sequence<Int>,_)``
 
 ### MLXArray Array Initializers
 
-- ``MLXArray/init(_:_:)-4n0or``
-- ``MLXArray/init(_:_:)-dq8h``
-- ``MLXArray/init(_:_:)-89jw1``
+- ``MLXArray/init(_:_:)-([T],_)``
+- ``MLXArray/init(_:_:)-(Sequence,_)``
+- ``MLXArray/init(_:_:)-([Int],_)``
 - ``MLXArray/init(converting:_:)``
-- ``MLXArray/init(_:_:type:)-5esf9``
-- ``MLXArray/init(_:_:type:)-f9u5``
+- ``MLXArray/init(_:_:type:)-(UnsafeRawBufferPointer,_,_)``
+- ``MLXArray/init(_:_:type:)-(Data,_,_)``
 
 ### MLXArray Complex Initializers
 
 - ``MLXArray/init(real:imaginary:)``
-- ``MLXArray/init(_:)-6iii5``
+- ``MLXArray/init(_:)-(Complex<Float>)``
 
 ### MLXArray Factory Methods
 
@@ -242,8 +242,8 @@ there are specific initializers to request it:
 - ``MLXArray/full(_:values:type:stream:)``
 - ``MLXArray/full(_:values:stream:)``
 - ``MLXArray/identity(_:type:stream:)``
-- ``MLXArray/linspace(_:_:count:stream:)-92x6l``
-- ``MLXArray/linspace(_:_:count:stream:)-7m7eg``
+- ``MLXArray/linspace(_:_:count:stream:)-(Int,Int,Int,StreamOrDevice)``
+- ``MLXArray/linspace(_:_:count:stream:)-(Double,Double,Int,StreamOrDevice)``
 - ``MLXArray/repeated(_:count:axis:stream:)``
 - ``MLXArray/repeated(_:count:stream:)``
 - ``MLXArray/repeat(_:count:axis:stream:)``

--- a/Source/MLX/Documentation.docc/Organization/logical.md
+++ b/Source/MLX/Documentation.docc/Organization/logical.md
@@ -22,18 +22,18 @@ if (a < b).all().item() {
 ### MLXArray Operators
 
 - ``MLXArray/.!(_:)``
-- ``MLXArray/.==(_:_:)-56m0a``
-- ``MLXArray/.==(_:_:)-79hbc``
-- ``MLXArray/.!=(_:_:)-mbw0``
-- ``MLXArray/.!=(_:_:)-gkdj``
-- ``MLXArray/.<(_:_:)-9rzup``
-- ``MLXArray/.<(_:_:)-54ivt``
-- ``MLXArray/.<=(_:_:)-2a0s9``
-- ``MLXArray/.<=(_:_:)-6vb92``
-- ``MLXArray/.>(_:_:)-fwi1``
-- ``MLXArray/.>(_:_:)-2v86b``
-- ``MLXArray/.>=(_:_:)-2gqml``
-- ``MLXArray/.>=(_:_:)-6zxj9``
+- ``MLXArray/.==(_:_:)-(MLXArray,MLXArray)``
+- ``MLXArray/.==(_:_:)-(MLXArray,ScalarOrArray)``
+- ``MLXArray/.!=(_:_:)-(MLXArray,MLXArray)``
+- ``MLXArray/.!=(_:_:)-(MLXArray,ScalarOrArray)``
+- ``MLXArray/.<(_:_:)-(MLXArray,MLXArray)``
+- ``MLXArray/.<(_:_:)-(MLXArray,ScalarOrArray)``
+- ``MLXArray/.<=(_:_:)-(MLXArray,MLXArray)``
+- ``MLXArray/.<=(_:_:)-(MLXArray,ScalarOrArray)``
+- ``MLXArray/.>(_:_:)-(MLXArray,MLXArray)``
+- ``MLXArray/.>(_:_:)-(MLXArray,ScalarOrArray)``
+- ``MLXArray/.>=(_:_:)-(MLXArray,MLXArray)``
+- ``MLXArray/.>=(_:_:)-(MLXArray,ScalarOrArray)``
 - ``MLXArray/.&&(_:_:)``
 - ``MLXArray/.||(_:_:)``
 

--- a/Source/MLX/Documentation.docc/Organization/shapes.md
+++ b/Source/MLX/Documentation.docc/Organization/shapes.md
@@ -3,7 +3,7 @@
 Shape is a term to describe the number and size of the dimensions of an N dimension (ND) array.
 
 ``MLXArray`` is an N dimensional array.  The number of dimensions is described by ``MLXArray/ndim``
-and the size of each dimension can be examined with ``MLXArray/dim(_:)-8s2hf`` or ``MLXArray/shape``.
+and the size of each dimension can be examined with ``MLXArray/dim(_:)-(Int)`` or ``MLXArray/shape``.
 
 Some of these functions can manipulate the shape without changing the contents while others 
 will moves rows and columns as they modify the shape.
@@ -26,8 +26,8 @@ and ``MLXArray/shape`` of the dimensions without changing the number of elements
 - ``MLXArray/expandedDimensions(axis:stream:)``
 - ``MLXArray/expandedDimensions(axes:stream:)``
 - ``MLXArray/flattened(start:end:stream:)``
-- ``MLXArray/reshaped(_:stream:)-19x5z``
-- ``MLXArray/reshaped(_:stream:)-67a89``
+- ``MLXArray/reshaped(_:stream:)-(Collection<Int>,StreamOrDevice)``
+- ``MLXArray/reshaped(_:stream:)-(Int...,StreamOrDevice)``
 - ``MLXArray/squeezed(stream:)``
 - ``MLXArray/squeezed(axis:stream:)``
 - ``MLXArray/squeezed(axes:stream:)``
@@ -39,7 +39,7 @@ and ``MLXArray/shape`` of the dimensions without changing the number of elements
 - ``atLeast3D(_:stream:)``
 
 - ``flattened(_:start:end:stream:)``
-- ``reshaped(_:_:stream:)-5x3y0``
+- ``reshaped(_:_:stream:)-(MLXArray,Collection<Int>,StreamOrDevice)``
 - ``squeezed(_:axes:stream:)``
 - ``roll(_:shift:axis:stream:)``
 - ``roll(_:shift:axes:stream:)``
@@ -73,6 +73,6 @@ These methods manipulate the shape and contents of the array:
 - ``split(_:axis:stream:)``
 - ``stacked(_:axis:stream:)``
 - ``swappedAxes(_:_:_:stream:)``
-- ``tiled(_:repetitions:stream:)-72ntc``
-- ``tiled(_:repetitions:stream:)-eouf``
+- ``tiled(_:repetitions:stream:)-(MLXArray,Int,StreamOrDevice)``
+- ``tiled(_:repetitions:stream:)-(MLXArray,Collection<Int>,StreamOrDevice)``
 - ``transposed(_:axes:stream:)``

--- a/Source/MLX/Documentation.docc/free-functions.md
+++ b/Source/MLX/Documentation.docc/free-functions.md
@@ -41,9 +41,9 @@ operations as methods for convenience.
 - ``multiply(_:_:stream:)``
 - ``negative(_:stream:)``
 - ``notEqual(_:_:stream:)``
-- ``pow(_:_:stream:)-7pe7j``
-- ``pow(_:_:stream:)-49xi0``
-- ``pow(_:_:stream:)-8ie9c``
+- ``pow(_:_:stream:)-(MLXArray,ScalarOrArray,_)``
+- ``pow(_:_:stream:)-(ScalarOrArray,MLXArray,_)``
+- ``pow(_:_:stream:)-(MLXArray,MLXArray,_)``
 - ``reciprocal(_:stream:)``
 - ``remainder(_:_:stream:)``
 - ``round(_:decimals:stream:)``
@@ -106,7 +106,6 @@ operations as methods for convenience.
 - ``MLX/full(_:values:type:stream:)``
 - ``MLX/full(_:values:stream:)``
 - ``MLX/identity(_:type:stream:)``
-- ``MLX/linspace(_:_:count:stream:)-7vj0o``
 - ``MLX/linspace(_:_:count:stream:)-6w959``
 - ``MLX/repeated(_:count:axis:stream:)``
 - ``MLX/repeated(_:count:stream:)``
@@ -168,8 +167,8 @@ operations as methods for convenience.
 - ``movedAxis(_:source:destination:stream:)``
 - ``padded(_:width:mode:value:stream:)``
 - ``padded(_:widths:mode:value:stream:)``
-- ``reshaped(_:_:stream:)-5x3y0``
-- ``reshaped(_:_:stream:)-96lgr``
+- ``reshaped(_:_:stream:)-(MLXArray,Collection<Int>,StreamOrDevice)``
+- ``reshaped(_:_:stream:)-(MLXArray,Int...,StreamOrDevice)``
 - ``split(_:indices:axis:stream:)``
 - ``split(_:parts:axis:stream:)``
 - ``split(_:axis:stream:)``
@@ -195,24 +194,24 @@ operations as methods for convenience.
 
 ### Quantization
 
-- ``qqMatmul(_:_:scales:groupSize:bits:mode:stream:)``
+- ``quantizedQuantizedMM(_:_:scales:groupSize:bits:mode:stream:)``
 - ``quantized(_:groupSize:bits:mode:stream:)``
 - ``quantizedMatmul(_:_:scales:biases:transpose:groupSize:bits:mode:stream:)``
-- ``dequantized(_:scales:biases:groupSize:bits:mode:stream:)``
+- ``dequantized(_:scales:biases:groupSize:bits:mode:dtype:stream:)``
 
 ### Evaluation and Transformation
 
-- ``eval(_:)-190w1``
-- ``eval(_:)-3b2g9``
-- ``eval(_:)-8fexv``
-- ``eval(_:)-91pbd``
-- ``asyncEval(_:)-6j4zg``
-- ``asyncEval(_:)-6uc2e``
-- ``asyncEval(_:)-11gzm``
+- ``eval(_:)-(MLXArray...)``
+- ``eval(_:)-(Collection<MLXArray>)``
+- ``eval(_:)-(Any...)``
+- ``eval(_:)-(Sequence<Any>)``
+- ``asyncEval(_:)-(Collection<MLXArray>)``
+- ``asyncEval(_:)-(Any...)``
+- ``asyncEval(_:)-(Sequence<Any>)``
 - ``grad(_:)-r8dv``
 - ``grad(_:)-7z6i``
-- ``grad(_:argumentNumbers:)-2ictk``
-- ``grad(_:argumentNumbers:)-5va2g``
+- ``grad(_:argumentNumbers:)-(([MLXArray])->[MLXArray],Collection<Int>)``
+- ``grad(_:argumentNumbers:)-(([MLXArray])->MLXArray,Collection<Int>)``
 - ``valueAndGrad(_:)``
 - ``valueAndGrad(_:argumentNumbers:)``
 - ``stopGradient(_:stream:)``

--- a/Source/MLX/GPU+Metal.swift
+++ b/Source/MLX/GPU+Metal.swift
@@ -195,7 +195,7 @@ public enum GPU {
 
     /// Reset the peak memory to zero.
     ///
-    /// See ``Snapshot/peakMemory``.
+    /// See ``Memory/Snapshot/peakMemory``.
     public static func resetPeakMemory() {
         mlx_reset_peak_memory()
     }

--- a/Source/MLX/Linalg.swift
+++ b/Source/MLX/Linalg.swift
@@ -111,7 +111,7 @@ public enum MLXLinalg {
     /// - Returns: output containing the norm(s)
     ///
     /// ### See Also
-    /// - ``norm(_:ord:axes:keepDims:stream:)-8zljj``
+    /// - ``norm(_:ord:axes:keepDims:stream:)``
     public static func norm(
         _ array: MLXArray, ord: Double, axes: some Collection<Int>, keepDims: Bool = false,
         stream: StreamOrDevice = .default
@@ -123,7 +123,7 @@ public enum MLXLinalg {
 
     /// Matrix or vector norm.
     ///
-    /// See ``norm(_:ord:axes:keepDims:stream:)-8zljj``
+    /// - ``norm(_:ord:axes:keepDims:stream:)``
     public static func norm(
         _ array: MLXArray, ord: NormKind? = nil, axis: Int, keepDims: Bool = false,
         stream: StreamOrDevice = .default
@@ -153,7 +153,7 @@ public enum MLXLinalg {
 
     /// Matrix or vector norm.
     ///
-    /// See ``norm(_:ord:axes:keepDims:stream:)-8zljj``
+    /// - ``norm(_:ord:axes:keepDims:stream:)``
     public static func norm(
         _ array: MLXArray, ord: NormKind? = nil, axis: IntOrArray? = nil,
         keepDims: Bool = false, stream: StreamOrDevice = .default
@@ -507,7 +507,7 @@ public func norm(
 /// - Returns: output containing the norm(s)
 ///
 /// ### See Also
-/// - ``norm(_:ord:axes:keepDims:stream:)-8zljj``
+/// - ``norm(_:ord:axes:keepDims:stream:)``
 public func norm(
     _ array: MLXArray, ord: MLXLinalg.NormKind? = nil, axis: Int, keepDims: Bool = false,
     stream: StreamOrDevice = .default
@@ -527,7 +527,7 @@ public func norm(
 
 /// Matrix or vector norm.
 ///
-/// See ``norm(_:ord:axes:keepDims:stream:)-8zljj``
+/// - ``norm(_:ord:axes:keepDims:stream:)``
 public func norm(
     _ array: MLXArray, ord: MLXLinalg.NormKind? = nil, axis: IntOrArray? = nil,
     keepDims: Bool = false, stream: StreamOrDevice = .default

--- a/Source/MLX/MLXArray+Init.swift
+++ b/Source/MLX/MLXArray+Init.swift
@@ -60,7 +60,7 @@ extension MLXArray {
     /// let a = MLXArray(int64: Int(Int32.max) + 10)
     /// ```
     ///
-    /// Note ``init(_:)-6nnka`` (producing an `int32` scalar is preferred).
+    /// Note ``init(_:)-(Int)`` (producing an `int32` scalar is preferred).
     ///
     /// ### See Also
     /// - <doc:initialization>
@@ -292,11 +292,11 @@ extension MLXArray {
     /// ```
     ///
     /// Note: if the value is out of bounds for an `Int32` the precondition will fail.  If you
-    /// need an `Int` (`Int64`) scalar, please use ``init(int64:_:)-7bgj2``.
+    /// need an `Int` (`Int64`) scalar, please use ``init(int64:_:)-(Sequence<Int>,_)``.
     ///
     /// ### See Also
     /// - <doc:initialization>
-    /// - ``init(int64:_:)-7bgj2``
+    /// - ``init(int64:_:)-(Sequence<Int>,_)``
     public convenience init(_ value: [Int], _ shape: (some Collection<Int>)? = [Int]?.none) {
         shapePrecondition(shape: shape, count: value.count)
         precondition(
@@ -379,7 +379,7 @@ extension MLXArray {
     /// ```
     ///
     /// Note: if the element type is `Int` this will produce an ``DType/int32`` result.
-    /// See ``init(int64:_:)-74tu0`` if an `.int64` is required.
+    /// See ``init(int64:_:)-(Sequence<Int>,_)`` if an `.int64` is required.
     ///
     /// ### See Also
     /// - <doc:initialization>

--- a/Source/MLX/MLXArray+Ops.swift
+++ b/Source/MLX/MLXArray+Ops.swift
@@ -70,7 +70,7 @@ extension MLXArray {
     ///
     /// ### See Also
     /// - <doc:arithmetic>
-    /// - ``MLXArray/+(_:_:)-1rv98``
+    /// - ``MLXArray/+(_:_:)-(MLXArray,MLXArray)``
     public static func + (lhs: MLXArray, rhs: some ScalarOrArray) -> MLXArray {
         lhs + rhs.asMLXArray(dtype: lhs.dtype)
     }
@@ -79,7 +79,7 @@ extension MLXArray {
     ///
     /// ### See Also
     /// - <doc:arithmetic>
-    /// - ``MLXArray/+(_:_:)-1rv98``
+    /// - ``MLXArray/+(_:_:)-(MLXArray,MLXArray)``
     public static func += (lhs: inout MLXArray, rhs: some ScalarOrArray) {
         lhs += rhs.asMLXArray(dtype: lhs.dtype)
     }
@@ -88,7 +88,7 @@ extension MLXArray {
     ///
     /// ### See Also
     /// - <doc:arithmetic>
-    /// - ``MLXArray/+(_:_:)-1rv98``
+    /// - ``MLXArray/+(_:_:)-(MLXArray,MLXArray)``
     public static func + (lhs: some ScalarOrArray, rhs: MLXArray) -> MLXArray {
         lhs.asMLXArray(dtype: rhs.dtype) + rhs
     }
@@ -231,7 +231,7 @@ extension MLXArray {
     ///
     /// ### See Also
     /// - <doc:arithmetic>
-    /// - ``MLXArray/*(_:_:)-1z2ck``
+    /// - ``MLXArray/*(_:_:)-(MLXArray,MLXArray)``
     public static func * (lhs: MLXArray, rhs: some ScalarOrArray) -> MLXArray {
         lhs * rhs.asMLXArray(dtype: lhs.dtype)
     }
@@ -240,7 +240,7 @@ extension MLXArray {
     ///
     /// ### See Also
     /// - <doc:arithmetic>
-    /// - ``MLXArray/*(_:_:)-1z2ck``
+    /// - ``MLXArray/*(_:_:)-(MLXArray,MLXArray)``
     public static func *= (lhs: inout MLXArray, rhs: some ScalarOrArray) {
         lhs *= rhs.asMLXArray(dtype: lhs.dtype)
     }
@@ -249,7 +249,7 @@ extension MLXArray {
     ///
     /// ### See Also
     /// - <doc:arithmetic>
-    /// - ``MLXArray/*(_:_:)-1z2ck``
+    /// - ``MLXArray/*(_:_:)-(MLXArray,MLXArray)``
     public static func * (lhs: some ScalarOrArray, rhs: MLXArray) -> MLXArray {
         lhs.asMLXArray(dtype: rhs.dtype) * rhs
     }
@@ -271,8 +271,8 @@ extension MLXArray {
     /// ### See Also
     /// - <doc:arithmetic>
     /// - ``pow(_:stream:)``
-    /// - ``pow(_:_:stream:)-7pe7j``
-    /// - ``pow(_:_:stream:)-49xi0``
+    /// - ``pow(_:_:stream:)-(MLXArray,ScalarOrArray,_)``
+    /// - ``pow(_:_:stream:)-(ScalarOrArray,MLXArray,_)``
     public static func ** (lhs: MLXArray, rhs: MLXArray) -> MLXArray {
         let s = StreamOrDevice.default
         var result = mlx_array_new()
@@ -284,7 +284,7 @@ extension MLXArray {
     ///
     /// ### See Also
     /// - <doc:arithmetic>
-    /// - ``MLXArray/**(_:_:)-8xxt3``
+    /// - ``MLXArray/**(_:_:)-(MLXArray,MLXArray)``
     public static func ** (lhs: MLXArray, rhs: some ScalarOrArray) -> MLXArray {
         lhs ** rhs.asMLXArray(dtype: lhs.dtype)
     }
@@ -293,7 +293,7 @@ extension MLXArray {
     ///
     /// ### See Also
     /// - <doc:arithmetic>
-    /// - ``MLXArray/**(_:_:)-8xxt3``
+    /// - ``MLXArray/**(_:_:)-(MLXArray,MLXArray)``
     public static func ** (lhs: some ScalarOrArray, rhs: MLXArray) -> MLXArray {
         lhs.asMLXArray(dtype: rhs.dtype) ** rhs
     }
@@ -393,7 +393,7 @@ extension MLXArray {
     ///
     /// ### See Also
     /// - <doc:arithmetic>
-    /// - ``MLXArray/%(_:_:)-3ubwd``
+    /// - ``MLXArray/%(_:_:)-(MLXArray,MLXArray)``
     public static func % (lhs: some ScalarOrArray, rhs: MLXArray) -> MLXArray {
         lhs.asMLXArray(dtype: rhs.dtype) % rhs
     }
@@ -402,7 +402,7 @@ extension MLXArray {
     ///
     /// ### See Also
     /// - <doc:arithmetic>
-    /// - ``MLXArray/%(_:_:)-3ubwd``
+    /// - ``MLXArray/%(_:_:)-(MLXArray,MLXArray)``
     public static func % (lhs: MLXArray, rhs: some ScalarOrArray) -> MLXArray {
         lhs % rhs.asMLXArray(dtype: lhs.dtype)
     }
@@ -460,7 +460,7 @@ extension MLXArray {
     ///
     /// ### See Also
     /// - <doc:arithmetic>
-    /// - ``MLXArray/.==(_:_:)-56m0a``
+    /// - ``MLXArray/.==(_:_:)-(MLXArray,MLXArray)``
     public static func .== (lhs: MLXArray, rhs: some ScalarOrArray) -> MLXArray {
         lhs .== rhs.asMLXArray(dtype: lhs.dtype)
     }
@@ -494,7 +494,7 @@ extension MLXArray {
     ///
     /// ### See Also
     /// - <doc:arithmetic>
-    /// - ``MLXArray/.<=(_:_:)-2a0s9``
+    /// - ``MLXArray/.<=(_:_:)-(MLXArray,MLXArray)``
     public static func .<= (lhs: MLXArray, rhs: some ScalarOrArray) -> MLXArray {
         lhs .<= rhs.asMLXArray(dtype: lhs.dtype)
     }
@@ -528,7 +528,7 @@ extension MLXArray {
     ///
     /// ### See Also
     /// - <doc:arithmetic>
-    /// - ``MLXArray/.>=(_:_:)-2gqml``
+    /// - ``MLXArray/.>=(_:_:)-(MLXArray,MLXArray)``
     public static func .>= (lhs: MLXArray, rhs: some ScalarOrArray) -> MLXArray {
         lhs .>= rhs.asMLXArray(dtype: lhs.dtype)
     }
@@ -596,7 +596,7 @@ extension MLXArray {
     ///
     /// ### See Also
     /// - <doc:arithmetic>
-    /// - ``MLXArray/.<(_:_:)-9rzup``
+    /// - ``MLXArray/.<(_:_:)-(MLXArray,MLXArray)``
     public static func .< (lhs: MLXArray, rhs: some ScalarOrArray) -> MLXArray {
         lhs .< rhs.asMLXArray(dtype: lhs.dtype)
     }
@@ -1502,6 +1502,9 @@ extension MLXArray {
 
     /// Element-wise complex conjugate of the input.
     ///
+    /// - Parameters:
+    ///     - stream: stream or device to evaluate on
+    ///
     /// ### See Also
     /// - <doc:arithmetic>
     /// - ``conjugate(_:stream:)``
@@ -1512,6 +1515,9 @@ extension MLXArray {
     }
 
     /// Element-wise cosine.
+    ///
+    /// - Parameters:
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:arithmetic>
@@ -1530,6 +1536,12 @@ extension MLXArray {
     /// // result is [[5, 8], [5, 9]] -- cumulative max along the columns
     /// let result = array.cummax(axis: 0)
     /// ```
+    ///
+    /// - Parameters:
+    ///     - axis: axis to reduce over
+    ///     - reverse: reverse the reduction
+    ///     - inclusive: include the initial value
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:cumulative>
@@ -1551,6 +1563,11 @@ extension MLXArray {
     /// // result is [5, 8, 8, 9]
     /// let result = array.cummax()
     /// ```
+    ///
+    /// - Parameters:
+    ///     - reverse: reverse the reduction
+    ///     - inclusive: include the initial value
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:cumulative>
@@ -1574,6 +1591,12 @@ extension MLXArray {
     /// let result = array.cummin(axis: 0)
     /// ```
     ///
+    /// - Parameters:
+    ///     - axis: axis to reduce over
+    ///     - reverse: reverse the reduction
+    ///     - inclusive: include the initial value
+    ///     - stream: stream or device to evaluate on
+    ///
     /// ### See Also
     /// - <doc:cumulative>
     /// - ``cummin(reverse:inclusive:stream:)``
@@ -1594,6 +1617,11 @@ extension MLXArray {
     /// // result is [5, 5, 4, 4]
     /// let result = array.cummin()
     /// ```
+    ///
+    /// - Parameters:
+    ///     - reverse: reverse the reduction
+    ///     - inclusive: include the initial value
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:cumulative>
@@ -1617,6 +1645,12 @@ extension MLXArray {
     /// let result = array.cumprod(axis: 0)
     /// ```
     ///
+    /// - Parameters:
+    ///     - axis: axis to reduce over
+    ///     - reverse: reverse the reduction
+    ///     - inclusive: include the initial value
+    ///     - stream: stream or device to evaluate on
+    ///
     /// ### See Also
     /// - <doc:cumulative>
     /// - ``cumprod(reverse:inclusive:stream:)``
@@ -1637,6 +1671,11 @@ extension MLXArray {
     /// // result is [5, 40, 160, 1440]
     /// let result = array.cumprod()
     /// ```
+    ///
+    /// - Parameters:
+    ///     - reverse: reverse the reduction
+    ///     - inclusive: include the initial value
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:cumulative>
@@ -1660,6 +1699,12 @@ extension MLXArray {
     /// let result = array.cumsum(axis: 0)
     /// ```
     ///
+    /// - Parameters:
+    ///     - axis: axis to reduce over
+    ///     - reverse: reverse the reduction
+    ///     - inclusive: include the initial value
+    ///     - stream: stream or device to evaluate on
+    ///
     /// ### See Also
     /// - <doc:cumulative>
     /// - ``cumsum(reverse:inclusive:stream:)``
@@ -1680,6 +1725,11 @@ extension MLXArray {
     /// // result is [5, 13, 17, 26]
     /// let result = array.cumsum()
     /// ```
+    ///
+    /// - Parameters:
+    ///     - reverse: reverse the reduction
+    ///     - inclusive: include the initial value
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:cumulative>
@@ -1739,6 +1789,9 @@ extension MLXArray {
     }
 
     /// Element-wise exponential.
+    ///
+    /// - Parameters:
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:arithmetic>
@@ -1805,6 +1858,7 @@ extension MLXArray {
     /// - Parameters:
     ///     - start: first dimension to flatten
     ///     - end: last dimension to flatten
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:shapes>
@@ -1818,6 +1872,9 @@ extension MLXArray {
     }
 
     /// Element-wise floor.
+    ///
+    /// - Parameters:
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:arithmetic>
@@ -1845,6 +1902,10 @@ extension MLXArray {
     /// let r = a.floorDivide(b)
     /// ```
     ///
+    /// - Parameters:
+    ///     - other: the divisor
+    ///     - stream: stream or device to evaluate on
+    ///
     /// ### See Also
     /// - <doc:arithmetic>
     /// - ``floor(stream:)``
@@ -1860,6 +1921,9 @@ extension MLXArray {
 
     /// Element-wise natural logarithm.
     ///
+    /// - Parameters:
+    ///     - stream: stream or device to evaluate on
+    ///
     /// ### See Also
     /// - <doc:arithmetic>
     /// - ``log(_:stream:)``
@@ -1870,6 +1934,9 @@ extension MLXArray {
     }
 
     /// Element-wise base-2 logarithm.
+    ///
+    /// - Parameters:
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:arithmetic>
@@ -1885,6 +1952,9 @@ extension MLXArray {
 
     /// Element-wise base-10 logarithm.
     ///
+    /// - Parameters:
+    ///     - stream: stream or device to evaluate on
+    ///
     /// ### See Also
     /// - <doc:arithmetic>
     /// - ``log(stream:)``
@@ -1898,6 +1968,9 @@ extension MLXArray {
     }
 
     /// Element-wise natural log of one plus the array.
+    ///
+    /// - Parameters:
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:arithmetic>
@@ -2012,6 +2085,10 @@ extension MLXArray {
     /// // produces a [2, 3] result
     /// let r = a.matmul(b)
     /// ```
+    ///
+    /// - Parameters:
+    ///     - other: the right hand side array
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:arithmetic>
@@ -2288,6 +2365,11 @@ extension MLXArray {
     /// //          [7, 15]]]], dtype=int64)
     /// ```
     ///
+    /// - Parameters:
+    ///     - source: axis to move
+    ///     - destination: new position for the axis
+    ///     - stream: stream or device to evaluate on
+    ///
     /// ### See Also
     /// - <doc:shapes>
     /// - ``swappedAxes(_:_:stream:)``
@@ -2314,11 +2396,15 @@ extension MLXArray {
     /// let r = a.pow(b)
     /// ```
     ///
+    /// - Parameters:
+    ///     - other: the exponent
+    ///     - stream: stream or device to evaluate on
+    ///
     /// ### See Also
     /// - <doc:arithmetic>
     /// - <doc:arithmetic>
-    /// - ``**(_:_:)-8xxt3``
-    /// - ``pow(_:_:stream:)-8ie9c``
+    /// - ``**(_:_:)-(MLXArray,MLXArray)``
+    /// - ``pow(_:_:stream:)-(MLXArray,ScalarOrArray,_)``
     public func pow(_ other: some ScalarOrArray, stream: StreamOrDevice = .default) -> MLXArray {
         let other = other.asMLXArray(dtype: self.dtype)
         var result = mlx_array_new()
@@ -2408,6 +2494,9 @@ extension MLXArray {
 
     /// Element-wise reciprocal.
     ///
+    /// - Parameters:
+    ///     - stream: stream or device to evaluate on
+    ///
     /// ### See Also
     /// - <doc:arithmetic>
     /// - ``reciprocal(_:stream:)``
@@ -2425,10 +2514,14 @@ extension MLXArray {
     /// let r = array.reshaped([4, 3])
     /// ```
     ///
+    /// - Parameters:
+    ///     - newShape: the new shape
+    ///     - stream: stream or device to evaluate on
+    ///
     /// ### See Also
     /// - <doc:shapes>
     /// - ``reshaped(_:stream:)``
-    /// - ``reshaped(_:_:stream:)-96lgr``
+    /// - ``reshaped(_:_:stream:)-(MLXArray,Collection<Int>,StreamOrDevice)``
     public func reshaped(_ newShape: some Collection<Int>, stream: StreamOrDevice = .default)
         -> MLXArray
     {
@@ -2445,9 +2538,13 @@ extension MLXArray {
     /// let r = array.reshaped(4, 3)
     /// ```
     ///
+    /// - Parameters:
+    ///     - newShape: the new shape
+    ///     - stream: stream or device to evaluate on
+    ///
     /// ### See Also
     /// - <doc:shapes>
-    /// - ``reshaped(_:_:stream:)-5x3y0``
+    /// - ``reshaped(_:_:stream:)-(MLXArray,Int...,StreamOrDevice)``
     /// - ``reshaped(_:stream:)``
     public func reshaped(_ newShape: Int..., stream: StreamOrDevice = .default) -> MLXArray {
         var result = mlx_array_new()
@@ -2466,6 +2563,10 @@ extension MLXArray {
     /// let result = round(array * s) / s
     /// ```
     ///
+    /// - Parameters:
+    ///     - decimals: number of decimal places to round to
+    ///     - stream: stream or device to evaluate on
+    ///
     /// ### See Also
     /// - <doc:arithmetic>
     /// - ``floor(stream:)``
@@ -2478,6 +2579,9 @@ extension MLXArray {
 
     /// Element-wise reciprocal and square root.
     ///
+    /// - Parameters:
+    ///     - stream: stream or device to evaluate on
+    ///
     /// ### See Also
     /// - <doc:arithmetic>
     /// - ``sqrt(_:stream:)``
@@ -2488,6 +2592,9 @@ extension MLXArray {
     }
 
     /// Element-wise sine.
+    ///
+    /// - Parameters:
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:arithmetic>
@@ -2517,6 +2624,7 @@ extension MLXArray {
     /// - Parameters:
     ///     - parts: array is split into that many sections of equal size. It is a fatal error if this is not possible
     ///     - axis: axis to split along
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:shapes>
@@ -2542,6 +2650,7 @@ extension MLXArray {
     ///
     /// - Parameters:
     ///     - axis: axis to split along
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:shapes>
@@ -2561,6 +2670,7 @@ extension MLXArray {
     /// - Parameters:
     ///     - indices: the indices of the start of each subarray along the given axis
     ///     - axis: axis to split along
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:shapes>
@@ -2579,6 +2689,9 @@ extension MLXArray {
 
     /// Element-wise square root
     ///
+    /// - Parameters:
+    ///     - stream: stream or device to evaluate on
+    ///
     /// ### See Also
     /// - <doc:arithmetic>
     /// - ``sqrt(_:stream:)``
@@ -2589,6 +2702,9 @@ extension MLXArray {
     }
 
     /// Element-wise square.
+    ///
+    /// - Parameters:
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:arithmetic>
@@ -2603,6 +2719,7 @@ extension MLXArray {
     ///
     /// - Parameters:
     ///     - axes: axes to remove
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:shapes>
@@ -2620,6 +2737,7 @@ extension MLXArray {
     ///
     /// - Parameters:
     ///     - axis: axis to remove
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:shapes>
@@ -2633,6 +2751,9 @@ extension MLXArray {
     }
 
     /// Remove all length one axes from an array.
+    ///
+    /// - Parameters:
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:shapes>
@@ -2730,6 +2851,11 @@ extension MLXArray {
     /// //          [7, 15]]]], dtype=int64)
     /// ```
     ///
+    /// - Parameters:
+    ///     - axis1: first axis
+    ///     - axis2: second axis
+    ///     - stream: stream or device to evaluate on
+    ///
     /// ### See Also
     /// - <doc:shapes>
     /// - ``swappedAxes(_:_:_:stream:)``
@@ -2752,6 +2878,11 @@ extension MLXArray {
     /// let col = array.take([0, 2], axis: 1)
     /// ```
     ///
+    /// - Parameters:
+    ///     - indices: array of indices
+    ///     - axis: axis to take from
+    ///     - stream: stream or device to evaluate on
+    ///
     /// ### See Also
     /// - ``take(_:stream:)``
     /// - ``take(_:_:axis:stream:)``
@@ -2763,6 +2894,10 @@ extension MLXArray {
     }
 
     /// Take elements from flattened 1-D array.
+    ///
+    /// - Parameters:
+    ///     - indices: array of indices
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - ``take(_:axis:stream:)``
@@ -2778,6 +2913,7 @@ extension MLXArray {
     ///
     /// - Parameters:
     ///     - axes: Specifies the source axis for each axis in the new array
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:shapes>
@@ -2792,6 +2928,18 @@ extension MLXArray {
         return MLXArray(result)
     }
 
+    /// Transpose the dimensions of the array.
+    ///
+    /// - Parameters:
+    ///     - axes: Specifies the source axis for each axis in the new array
+    ///     - stream: stream or device to evaluate on
+    ///
+    /// ### See Also
+    /// - <doc:shapes>
+    /// - ``transposed(axes:stream:)``
+    /// - ``transposed(axis:stream:)``
+    /// - ``transposed(stream:)``
+    /// - ``transposed(_:axes:stream:)``
     public func transposed(_ axes: Int..., stream: StreamOrDevice = .default) -> MLXArray {
         var result = mlx_array_new()
         mlx_transpose_axes(&result, ctx, axes.asInt32, axes.count, stream.ctx)
@@ -2801,6 +2949,10 @@ extension MLXArray {
     /// Transpose the dimensions of the array.
     ///
     /// This swaps the position of the first dimension with the given axis.
+    ///
+    /// - Parameters:
+    ///     - axis: axis to swap with the first dimension
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:shapes>
@@ -2816,6 +2968,9 @@ extension MLXArray {
     /// Transpose the dimensions of the array.
     ///
     /// With no axes specified this will reverse the axes in the array.
+    ///
+    /// - Parameters:
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:shapes>
@@ -2841,6 +2996,7 @@ extension MLXArray {
     ///     - axes: axes to reduce over
     ///     - keepDims: if `true` keep the reduces axes as singleton dimensions
     ///     - ddof: the divisor to compute the variance is `N - ddof`
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:reduction>
@@ -2862,6 +3018,7 @@ extension MLXArray {
     ///     - axis: axes to reduce over
     ///     - keepDims: if `true` keep the reduces axis as singleton dimensions
     ///     - ddof: the divisor to compute the variance is `N - ddof`
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:reduction>
@@ -2881,7 +3038,7 @@ extension MLXArray {
     /// - Parameters:
     ///     - keepDims: if `true` keep the reduces axes as singleton dimensions
     ///     - ddof: the divisor to compute the variance is `N - ddof`
-    ///
+    ///     - stream: stream or device to evaluate on
     ///
     /// ### See Also
     /// - <doc:reduction>

--- a/Source/MLX/Nested.swift
+++ b/Source/MLX/Nested.swift
@@ -36,10 +36,10 @@ public func indentedDescription(_ value: Any, _ indent: Int) -> String {
 ///
 /// ### See Also
 /// - ``NestedDictionary``
-/// - ``NestedDictionary/mapValues(transform:)-1ehvq``
-/// - ``NestedDictionary/mapValues(transform:)-4q1m3``
+/// - ``NestedDictionary/mapValues(transform:)-((Element)->Result)``
+/// - ``NestedDictionary/mapValues(transform:)-((Element)->Result)``
 /// - ``NestedDictionary/flattened(prefix:)``
-/// - ``NestedDictionary/unflattened(_:)-4p8bn``
+/// - ``NestedDictionary/unflattened(_:)-([String:Element])``
 public indirect enum NestedItem<Key: Hashable, Element>: IndentedDescription {
     case none
     case value(Element)
@@ -63,10 +63,10 @@ public indirect enum NestedItem<Key: Hashable, Element>: IndentedDescription {
 
     /// Transform the values in the nested structure using the `transform()` function.
     ///
-    /// This is typically called via ``NestedDictionary/mapValues(transform:)-1ehvq``.
+    /// This is typically called via ``NestedDictionary/mapValues(transform:)-((Element)->Result)``.
     ///
     /// ### See Also
-    /// - ``NestedDictionary/mapValues(transform:)-1ehvq``
+    /// - ``NestedDictionary/mapValues(transform:)-((Element)->Result)``
     public func mapValues<Result>(_ transform: (Element) throws -> Result) rethrows -> NestedItem<
         Key, Result
     > {
@@ -94,12 +94,6 @@ public indirect enum NestedItem<Key: Hashable, Element>: IndentedDescription {
     /// - `.none` will match any value, e.g. you can iterate an empty second item
     /// - arrays do not need to be the same length -- the receiver's length is matched
     /// - dictionaries do not need to have the same keys -- the receivers keys are matched
-    ///
-    /// This is typically called via ``NestedDictionary/mapValues(_:transform:)-54sj2``.
-    ///
-    /// ### See Also
-    /// - ``NestedDictionary/mapValues(_:transform:)-54sj2``
-    /// - ``mapValues(_:_:_:)``
     public func mapValues<E2, R1, R2>(
         _ item: NestedItem<Key, E2>, _ transform: (Element, E2?) throws -> (R1, R2?)
     ) rethrows -> (NestedItem<Key, R1>, NestedItem<Key, R2>) {
@@ -249,12 +243,6 @@ public indirect enum NestedItem<Key: Hashable, Element>: IndentedDescription {
     /// - `.none` will match any value, e.g. you can iterate an empty second item
     /// - arrays do not need to be the same length -- the receiver's length is matched
     /// - dictionaries do not need to have the same keys -- the receivers keys are matched
-    ///
-    /// This is typically called via ``NestedDictionary/mapValues(_:_:transform:)-8yhzk``.
-    ///
-    /// ### See Also
-    /// - ``NestedDictionary/mapValues(_:_:transform:)-8yhzk``
-    /// - ``mapValues(_:_:_:)``
     public func mapValues<E2, E3, R1, R2, R3>(
         _ item1: NestedItem<Key, E2>, _ item2: NestedItem<Key, E3>,
         _ transform: (Element, E2?, E3?) throws -> (R1, R2?, R3?)
@@ -427,7 +415,7 @@ public indirect enum NestedItem<Key: Hashable, Element>: IndentedDescription {
     /// - ``unflattened(_:)``
     /// - ``NestedDictionary/flattened(prefix:)``
     /// - ``NestedDictionary/unflattened(_:)-4p8bn``
-    /// - ``NestedDictionary/unflattened(_:)-7xuiv``
+    /// - ``NestedDictionary/unflattened(_:)-([String:Element])``
     public func flattened(prefix: String? = nil) -> [(String, Element)] {
         func newPrefix(_ i: CustomStringConvertible) -> String {
             if let prefix {
@@ -464,7 +452,7 @@ public indirect enum NestedItem<Key: Hashable, Element>: IndentedDescription {
     /// - ``flattened(prefix:)``
     /// - ``NestedDictionary/flattened(prefix:)``
     /// - ``NestedDictionary/unflattened(_:)-4p8bn``
-    /// - ``NestedDictionary/unflattened(_:)-7xuiv``
+    /// - ``NestedDictionary/unflattened(_:)-([String:Element])``
     public static func unflattened(_ tree: some Collection<(Key, Element)>) -> NestedItem<
         Key, Element
     >
@@ -699,7 +687,7 @@ public struct NestedDictionary<Key: Hashable, Element>: CustomStringConvertible 
     /// Initialize an empty `NestedDictionary`.
     ///
     /// ### See Also
-    /// - ``NestedDictionary/subscript(_:)-7bphj``
+    /// - ``NestedDictionary/subscript(_:)-(Key)``
     public init() {
     }
 
@@ -947,7 +935,7 @@ public struct NestedDictionary<Key: Hashable, Element>: CustomStringConvertible 
     ///
     /// ### See Also
     /// - ``unflattened(_:)-4p8bn``
-    /// - ``unflattened(_:)-7xuiv``
+    /// - ``unflattened(_:)-([String:Element])``
     public func flattened(prefix: String? = nil) -> [(String, Element)] {
         asItem().flattened(prefix: prefix)
     }
@@ -956,7 +944,7 @@ public struct NestedDictionary<Key: Hashable, Element>: CustomStringConvertible 
     ///
     /// ### See Also
     /// - ``flattened(prefix:)``
-    /// - ``unflattened(_:)-7xuiv``
+    /// - ``unflattened(_:)-([String:Element])``
     static public func unflattened(_ flat: some Collection<(String, Element)>) -> Self
     where Key == String {
         switch NestedItem.unflattened(flat) {

--- a/Source/MLX/Ops+Array.swift
+++ b/Source/MLX/Ops+Array.swift
@@ -349,7 +349,7 @@ public func argMin(_ array: MLXArray, keepDims: Bool = false, stream: StreamOrDe
 /// - <doc:logical>
 /// - ``allClose(_:_:rtol:atol:equalNaN:stream:)``
 /// - ``isClose(_:_:rtol:atol:equalNaN:stream:)``
-/// - ``MLXArray/.==(_:_:)-56m0a``
+/// - ``MLXArray/.==(_:_:)-(MLXArray,MLXArray)``
 /// - ``MLXArray/arrayEqual(_:equalNAN:stream:)``
 public func arrayEqual(
     _ array: MLXArray, _ other: some ScalarOrArray, equalNAN: Bool = false,
@@ -1252,13 +1252,14 @@ public func movedAxis(
 /// let b = MLXArray([4, 5, 6])
 ///
 /// // same as a ** b
-/// let r = a.pow(b)
+/// let r = pow(a, b)
 /// ```
 ///
 /// ### See Also
 /// - <doc:arithmetic>
-/// - <doc:arithmetic>
 /// - ``MLXArray/pow(_:stream:)``
+/// - ``pow(_:_:stream:)-(_,ScalarOrArray,_)``
+/// - ``pow(_:_:stream:)-(ScalarOrArray,_,_)``
 public func pow(_ array: MLXArray, _ other: MLXArray, stream: StreamOrDevice = .default) -> MLXArray
 {
     var result = mlx_array_new()
@@ -1266,6 +1267,24 @@ public func pow(_ array: MLXArray, _ other: MLXArray, stream: StreamOrDevice = .
     return MLXArray(result)
 }
 
+/// Element-wise power operation.
+///
+/// Raise the elements of `self` to the powers in elements of `other` with <doc:broadcasting>.
+///
+/// For example:
+///
+/// ```swift
+/// let a = MLXArray(0 ..< 12, [4, 3])
+///
+/// // same as a ** 3
+/// let r = pow(a, 3)
+/// ```
+///
+/// ### See Also
+/// - <doc:arithmetic>
+/// - ``MLXArray/pow(_:stream:)``
+/// - ``pow(_:_:stream:)-(MLXArray,MLXArray,_)``
+/// - ``pow(_:_:stream:)-(ScalarOrArray,_,_)``
 public func pow(_ array: MLXArray, _ other: some ScalarOrArray, stream: StreamOrDevice = .default)
     -> MLXArray
 {
@@ -1273,6 +1292,24 @@ public func pow(_ array: MLXArray, _ other: some ScalarOrArray, stream: StreamOr
     return pow(array, other, stream: stream)
 }
 
+/// Element-wise power operation.
+///
+/// Raise the elements of `self` to the powers in elements of `other` with <doc:broadcasting>.
+///
+/// For example:
+///
+/// ```swift
+/// let b = MLXArray([4, 5, 6])
+///
+/// // same as 3 ** b
+/// let r = pow(3, b)
+/// ```
+///
+/// ### See Also
+/// - <doc:arithmetic>
+/// - ``MLXArray/pow(_:stream:)``
+/// - ``pow(_:_:stream:)-(MLXArray,MLXArray,_)``
+/// - ``pow(_:_:stream:)-(_,ScalarOrArray,_)``
 public func pow(_ array: some ScalarOrArray, _ other: MLXArray, stream: StreamOrDevice = .default)
     -> MLXArray
 {
@@ -1385,8 +1422,8 @@ public func reciprocal(_ array: MLXArray, stream: StreamOrDevice = .default) -> 
 ///
 /// ### See Also
 /// - <doc:shapes>
-/// - ``MLXArray/reshaped(_:stream:)-19x5z``
-/// - ``reshaped(_:_:stream:)-96lgr``
+/// - ``MLXArray/reshaped(_:stream:)-(Collection<Int>,StreamOrDevice)``
+/// - ``reshaped(_:_:stream:)-(MLXArray,Collection<Int>,StreamOrDevice)``
 public func reshaped(
     _ array: MLXArray, _ newShape: some Collection<Int>, stream: StreamOrDevice = .default
 )
@@ -1407,8 +1444,8 @@ public func reshaped(
 ///
 /// ### See Also
 /// - <doc:shapes>
-/// - ``MLXArray/reshaped(_:stream:)-67a89``
-/// - ``reshaped(_:_:stream:)-5x3y0``
+/// - ``MLXArray/reshaped(_:stream:)-(Int...,StreamOrDevice)``
+/// - ``reshaped(_:_:stream:)-(MLXArray,Int...,StreamOrDevice)``
 public func reshaped(_ array: MLXArray, _ newShape: Int..., stream: StreamOrDevice = .default)
     -> MLXArray
 {
@@ -1499,6 +1536,7 @@ public func sin(_ array: MLXArray, stream: StreamOrDevice = .default) -> MLXArra
 ///     - array: input array
 ///     - parts: array is split into that many sections of equal size. It is a fatal error if this is not possible
 ///     - axis: axis to split along
+///     - stream: stream or device to evaluate on
 ///
 /// ### See Also
 /// - <doc:shapes>
@@ -1526,8 +1564,8 @@ public func split(_ array: MLXArray, parts: Int, axis: Int = 0, stream: StreamOr
 ///
 /// - Parameters:
 ///     - array: input array
-///     - parts: array is split into that many sections of equal size. It is a fatal error if this is not possible
 ///     - axis: axis to split along
+///     - stream: stream or device to evaluate on
 ///
 /// ### See Also
 /// - <doc:shapes>
@@ -1550,6 +1588,7 @@ public func split(_ array: MLXArray, axis: Int = 0, stream: StreamOrDevice = .de
 ///     - array: input array
 ///     - indices: the indices of the start of each subarray along the given axis
 ///     - axis: axis to split along
+///     - stream: stream or device to evaluate on
 ///
 /// ### See Also
 /// - <doc:shapes>
@@ -1592,6 +1631,7 @@ public func square(_ array: MLXArray, stream: StreamOrDevice = .default) -> MLXA
 /// - Parameters:
 ///     - array: input array
 ///     - axes: axes to remove
+///     - stream: stream or device to evaluate on
 ///
 /// ### See Also
 /// - <doc:shapes>
@@ -1611,6 +1651,7 @@ public func squeezed(
 /// - Parameters:
 ///     - array: input array
 ///     - axis: axis to remove
+///     - stream: stream or device to evaluate on
 ///
 /// ### See Also
 /// - <doc:shapes>
@@ -1777,6 +1818,7 @@ public func take(_ array: MLXArray, _ indices: MLXArray, stream: StreamOrDevice 
 /// - Parameters:
 ///     - array: input array
 ///     - axes: Specifies the source axis for each axis in the new array
+///     - stream: stream or device to evaluate on
 ///
 /// ### See Also
 /// - <doc:shapes>
@@ -1846,6 +1888,7 @@ public func T(_ array: MLXArray, stream: StreamOrDevice = .default) -> MLXArray 
 ///     - axes: axes to reduce over
 ///     - keepDims: if `true` keep the reduces axes as singleton dimensions
 ///     - ddof: the divisor to compute the variance is `N - ddof`
+///     - stream: stream or device to evaluate on
 ///
 /// ### See Also
 /// - <doc:reduction>
@@ -1868,6 +1911,7 @@ public func variance(
 ///     - axis: axes to reduce over
 ///     - keepDims: if `true` keep the reduces axis as singleton dimensions
 ///     - ddof: the divisor to compute the variance is `N - ddof`
+///     - stream: stream or device to evaluate on
 ///
 /// ### See Also
 /// - <doc:reduction>
@@ -1889,6 +1933,7 @@ public func variance(
 ///     - array: input array
 ///     - keepDims: if `true` keep the reduces axes as singleton dimensions
 ///     - ddof: the divisor to compute the variance is `N - ddof`
+///     - stream: stream or device to evaluate on
 ///
 /// ### See Also
 /// - <doc:reduction>
@@ -1913,6 +1958,7 @@ public func variance(
 /// representation of each element (or group of elements) is the same.
 ///
 /// - Parameters:
+///     - array: input array
 ///   - dtype: type to change to
 ///   - stream: stream or device to evaluate on
 ///

--- a/Source/MLX/Ops.swift
+++ b/Source/MLX/Ops.swift
@@ -38,7 +38,7 @@ func broadcast(arrays: some Collection<MLXArray>, stream: StreamOrDevice = .defa
 ///
 /// ### See Also
 /// - <doc:arithmetic>
-/// - ``MLXArray/+(_:_:)-1rv98``
+/// - ``MLXArray/+(_:_:)-(MLXArray,MLXArray)``
 public func add(
     _ a: some ScalarOrArray, _ b: some ScalarOrArray, stream: StreamOrDevice = .default
 ) -> MLXArray {
@@ -328,7 +328,7 @@ public func argSort(_ array: MLXArray, stream: StreamOrDevice = .default) -> MLX
 /// The resulting array will always be as if the provided array was row
 /// contiguous regardless of the provided arrays storage order and current strides.
 ///
-/// > Caution! This function should be used with caution as it changes
+/// > Note: This function should be used with caution as it changes
 /// the shape and strides of the array directly. This can lead to the
 /// resulting array pointing to invalid memory locations which can
 /// result into crashes.
@@ -354,8 +354,13 @@ public func argSort(_ array: MLXArray, stream: StreamOrDevice = .default) -> MLX
 ///
 /// - Parameters:
 ///     - array: input array
-///     - shape: shape of the resulting array.  If not specified it will keep the same shape
+///     - shape: The shape of the resulting array. If not specified it defaults to `array.shape`
+///     - strides: The strides of the resulting array. If not specified it defaults to the reverse
+///                exclusive cumulative product of `array.shape`
+///     - offset: Skip that many elements from the beginning of the input array
 ///     - stream: stream or device to evaluate on
+///
+/// - Returns: The output array which is the strided view of the input
 ///
 /// ### See Also
 /// - <doc:shapes>
@@ -617,7 +622,7 @@ public func conv1d(
 /// - ``conv1d(_:_:stride:padding:dilation:groups:stream:)``
 /// - ``conv3d(_:_:stride:padding:dilation:groups:stream:)``
 /// - ``convolve(_:_:mode:stream:)``
-/// - ``convGeneral(_:_:strides:padding:kernelDilation:inputDilation:groups:flip:stream:)-9t1sj``
+/// - ``convGeneral(_:_:strides:padding:kernelDilation:inputDilation:groups:flip:stream:)-(MLXArray,MLXArray,IntOrArray,IntOrArray,IntOrArray,IntOrArray,Int,Bool,StreamOrDevice)``
 public func conv2d(
     _ array: MLXArray, _ weight: MLXArray, stride: IntOrPair = 1, padding: IntOrPair = 0,
     dilation: IntOrPair = 1, groups: Int = 1, stream: StreamOrDevice = .default
@@ -664,7 +669,7 @@ public func conv2d(
 /// - ``conv1d(_:_:stride:padding:dilation:groups:stream:)``
 /// - ``conv2d(_:_:stride:padding:dilation:groups:stream:)``
 /// - ``convolve(_:_:mode:stream:)``
-/// - ``convGeneral(_:_:strides:padding:kernelDilation:inputDilation:groups:flip:stream:)-9t1sj``
+/// - ``convGeneral(_:_:strides:padding:kernelDilation:inputDilation:groups:flip:stream:)-(MLXArray,MLXArray,IntOrArray,IntOrArray,IntOrArray,IntOrArray,Int,Bool,StreamOrDevice)``
 public func conv3d(
     _ array: MLXArray, _ weight: MLXArray, stride: IntOrTriple = 1, padding: IntOrTriple = 0,
     dilation: IntOrTriple = 1, groups: Int = 1, stream: StreamOrDevice = .default
@@ -707,7 +712,7 @@ public func conv3d(
 /// - <doc:convolution>
 /// - ``IntOrArray``
 /// - ``conv2d(_:_:stride:padding:dilation:groups:stream:)``
-/// - ``convGeneral(_:_:strides:padding:kernelDilation:inputDilation:groups:flip:stream:)-6j1nr``
+/// - ``convGeneral(_:_:strides:padding:kernelDilation:inputDilation:groups:flip:stream:)-(MLXArray,MLXArray,IntOrArray,(Int,Int),IntOrArray,IntOrArray,Int,Bool,StreamOrDevice)``
 public func convGeneral(
     _ array: MLXArray, _ weight: MLXArray, strides: IntOrArray = 1, padding: IntOrArray = 0,
     kernelDilation: IntOrArray = 1, inputDilation: IntOrArray = 1, groups: Int = 1,
@@ -753,7 +758,7 @@ public func convGeneral(
 /// - <doc:convolution>
 /// - ``IntOrArray``
 /// - ``conv2d(_:_:stride:padding:dilation:groups:stream:)``
-/// - ``convGeneral(_:_:strides:padding:kernelDilation:inputDilation:groups:flip:stream:)-6j1nr``
+/// - ``convGeneral(_:_:strides:padding:kernelDilation:inputDilation:groups:flip:stream:)-(MLXArray,MLXArray,IntOrArray,(Int,Int),IntOrArray,IntOrArray,Int,Bool,StreamOrDevice)``
 public func convGeneral(
     _ array: MLXArray, _ weight: MLXArray, strides: IntOrArray = 1, padding: (Int, Int),
     kernelDilation: IntOrArray = 1, inputDilation: IntOrArray = 1, groups: Int = 1,
@@ -842,7 +847,7 @@ public func convTransposed1d(
 /// - ``convTransposed1d(_:_:stride:padding:dilation:outputPadding:groups:stream:)``
 /// - ``convTransposed3d(_:_:stride:padding:dilation:outputPadding:groups:stream:)``
 /// - ``convolve(_:_:mode:stream:)``
-/// - ``convGeneral(_:_:strides:padding:kernelDilation:inputDilation:groups:flip:stream:)-9t1sj``
+/// - ``convGeneral(_:_:strides:padding:kernelDilation:inputDilation:groups:flip:stream:)-(MLXArray,MLXArray,IntOrArray,IntOrArray,IntOrArray,IntOrArray,Int,Bool,StreamOrDevice)``
 public func convTransposed2d(
     _ array: MLXArray, _ weight: MLXArray, stride: IntOrPair = 1, padding: IntOrPair = 0,
     dilation: IntOrPair = 1, outputPadding: IntOrPair = 0, groups: Int = 1,
@@ -893,7 +898,7 @@ public func convTransposed2d(
 /// - ``convTransposed1d(_:_:stride:padding:dilation:outputPadding:groups:stream:)``
 /// - ``convTransposed3d(_:_:stride:padding:dilation:outputPadding:groups:stream:)``
 /// - ``convolve(_:_:mode:stream:)``
-/// - ``convGeneral(_:_:strides:padding:kernelDilation:inputDilation:groups:flip:stream:)-9t1sj``
+/// - ``convGeneral(_:_:strides:padding:kernelDilation:inputDilation:groups:flip:stream:)-(MLXArray,MLXArray,IntOrArray,IntOrArray,IntOrArray,IntOrArray,Int,Bool,StreamOrDevice)``
 public func convTransposed3d(
     _ array: MLXArray, _ weight: MLXArray, stride: IntOrTriple = 1, padding: IntOrTriple = 0,
     dilation: IntOrTriple = 1, outputPadding: IntOrTriple = 0, groups: Int = 1,
@@ -1097,6 +1102,7 @@ public enum QuantizationMode: String, Codable, Sendable {
 ///   - groupSize: The size of each quantization group. Elements are quantized in groups of this size. Default is 64
 ///   - bits: The number of bits used per quantized element. Default is 4
 ///   - mode: The quantization mode used. Either `.affine` for standard affine quantization or `.mxfp4` for MXFP4 format. Default is `.affine`
+///   - dtype: data type of the output.  If not specified it will be inferred from the scales and biases.
 ///   - stream: Stream or device to evaluate on
 ///
 /// ### See Also
@@ -1319,7 +1325,7 @@ public func expandedDimensions(_ array: MLXArray, axis: Int, stream: StreamOrDev
 ///
 /// - Parameters:
 ///   - array: input array
-///     - stream: stream or device to evaluate on
+///   - stream: stream or device to evaluate on
 ///
 /// ### See Also
 /// - <doc:arithmetic>
@@ -2269,7 +2275,7 @@ public func putAlong(
 /// [this documentation](https://ml-explore.github.io/mlx/build/html/python/_autosummary/mlx.core.quantize.html)
 ///
 /// ### See Also
-/// - ``dequantized(_:scales:biases:groupSize:bits:mode:stream:)``
+/// - ``dequantized(_:scales:biases:groupSize:bits:mode:dtype:stream:)``
 /// - ``quantizedMM(_:_:scales:biases:transpose:groupSize:bits:mode:stream:)``
 public func quantized(
     _ w: MLXArray, groupSize: Int? = nil, bits: Int? = nil,
@@ -2325,7 +2331,7 @@ public func quantizedMatmul(
 ///   - stream: Stream or device to evaluate on
 ///
 /// ### See Also
-/// - ``dequantized(_:scales:biases:groupSize:bits:mode:stream:)``
+/// - ``dequantized(_:scales:biases:groupSize:bits:mode:dtype:stream:)``
 /// - ``quantized(_:groupSize:bits:mode:stream:)``
 public func quantizedMM(
     _ x: MLXArray, _ w: MLXArray, scales: MLXArray, biases: MLXArray?,
@@ -2555,6 +2561,7 @@ public func softMax(
 ///
 /// - Parameters:
 ///     - array: input array
+///     - axes: axes to compute the softmax over
 ///     - stream: stream or device to evaluate on
 ///
 /// ### See Also
@@ -2588,6 +2595,7 @@ public func softMax(
 ///
 /// - Parameters:
 ///     - array: input array
+///     - axis: axis to compute the softmax over
 ///     - stream: stream or device to evaluate on
 ///
 /// ### See Also
@@ -2866,7 +2874,7 @@ public func tanh(_ array: MLXArray, stream: StreamOrDevice = .default) -> MLXArr
 ///
 /// ### See Also
 /// - <doc:arithmetic>
-/// - ``tensordot(_:_:axes:stream:)-8yqyi``
+/// - ``tensordot(_:_:axes:stream:)-(MLXArray,MLXArray,Int,StreamOrDevice)``
 public func tensordot(
     _ a: MLXArray, _ b: MLXArray, axes: Int = 1, stream: StreamOrDevice = .default
 ) -> MLXArray {
@@ -2886,7 +2894,7 @@ public func tensordot(
 ///
 /// ### See Also
 /// - <doc:arithmetic>
-/// - ``tensordot(_:_:axes:stream:)-3qkgq``
+/// - ``tensordot(_:_:axes:stream:)-(MLXArray,MLXArray,((Int,Int),(Int,Int)),StreamOrDevice)``
 public func tensordot(
     _ a: MLXArray, _ b: MLXArray, axes: ((Int, Int), (Int, Int)), stream: StreamOrDevice = .default
 ) -> MLXArray {
@@ -2953,7 +2961,7 @@ public func tiled(
 ///
 /// ### See Also
 /// - <doc:shapes>
-/// - ``tiled(_:repetitions:stream:)-72ntc``
+/// - ``tiled(_:repetitions:stream:)-(MLXArray,Int,StreamOrDevice)``
 public func tiled(_ array: MLXArray, repetitions: Int, stream: StreamOrDevice = .default)
     -> MLXArray
 {
@@ -3129,8 +3137,8 @@ public func kron(
 ///
 /// - Parameters:
 ///     - a: input array
-///     - start_axis: first dim to flatten
-///     - end_axis: last dim to flatten
+///     - startAxis: first dim to flatten
+///     - endAxis: last dim to flatten
 ///     - stream: stream or device to evaluate on
 public func flatten(
     _ a: MLXArray, startAxis: Int, endAxis: Int = -1, stream: StreamOrDevice = .default

--- a/Source/MLX/Protocols.swift
+++ b/Source/MLX/Protocols.swift
@@ -9,12 +9,12 @@ import Foundation
 /// implemention detail for MLX and should not be depended on by outside callers.
 ///
 /// ### See Also
-/// - ``compile(inputs:outputs:shapeless:_:)-8wq3u``
+/// - ``compile(inputs:outputs:shapeless:_:)-([Updatable],[Updatable],Bool,([MLXArray])->[MLXArray])``
 public protocol Updatable {
     func innerState() -> [MLXArray]
 }
 
-/// An object that can be passed to ``eval(_:)-3b2g9`` and can produce a list
+/// An object that can be passed to ``eval(_:)-(Collection<MLXArray>)`` and can produce a list
 /// of interior ``MLXArray`` to be evaluated.
 ///
 /// Types such as:

--- a/Source/MLX/Random.swift
+++ b/Source/MLX/Random.swift
@@ -60,7 +60,7 @@ import Foundation
 /// ```
 ///
 /// Finally, if you need to control random state in deeply nested calls to `MLXRandom` or you need
-/// thread-safe random state for multi-threaded evaluation you can use ``withRandomState(_:body:)-6i2p1``:
+/// thread-safe random state for multi-threaded evaluation you can use ``withRandomState(_:body:)-18ob4``.
 ///
 /// ```swift
 /// await withTaskGroup { group in
@@ -274,6 +274,7 @@ public enum MLXRandom {
     ///   - loc: mean of the distribution
     ///   - scale: standard deviation of the distribution
     ///   - key: PRNG key
+    ///   - stream: stream or device to evaluate on
     public static func normal(
         _ shape: some Collection<Int> = [],
         type: (some HasDType & BinaryFloatingPoint).Type = Float.self, loc: Float = 0,
@@ -311,6 +312,7 @@ public enum MLXRandom {
     ///   - loc: mean of the distribution
     ///   - scale: standard deviation of the distribution
     ///   - key: PRNG key
+    ///   - stream: stream or device to evaluate on
     public static func normal(
         _ shape: some Collection<Int> = [], dtype: DType, loc: Float = 0, scale: Float = 1,
         key: (some RandomStateOrKey)? = MLXArray?.none, stream: StreamOrDevice = .default
@@ -340,6 +342,7 @@ public enum MLXRandom {
     /// shapes of `mean` and `covariance`.
     ///   - dtype: DType of the result
     ///   - key: PRNG key
+    ///   - stream: stream or device to evaluate on
     public static func multivariateNormal(
         mean: MLXArray, covariance: MLXArray, shape: some Collection<Int> = [], dtype: DType,
         key: (some RandomStateOrKey)? = MLXArray?.none, stream: StreamOrDevice = .default
@@ -698,7 +701,11 @@ public enum MLXRandom {
     /// ```
     ///
     /// - Parameters:
-    ///     - logits: The *unnormalized* categorical distribution(s).
+    ///   - logits: The *unnormalized* categorical distribution(s).
+    ///   - axis: axis that specifies the distribution
+    ///   - shape: optional shape of the output -- this must be broadcast compatible with the shape of logits
+    ///   - key: optional PRNG key
+    ///   - stream: stream or device to evaluate on
     public static func categorical(
         _ logits: MLXArray, axis: Int = -1, shape: (some Collection<Int>)? = [Int]?.none,
         key: (some RandomStateOrKey)? = MLXArray?.none, stream: StreamOrDevice = .default
@@ -734,7 +741,11 @@ public enum MLXRandom {
     /// ```
     ///
     /// - Parameters:
-    ///     - logits: The *unnormalized* categorical distribution(s).
+    ///   - logits: The *unnormalized* categorical distribution(s).
+    ///   - axis: axis that specifies the distribution
+    ///   - count: number of samples to draw from logits
+    ///   - key: optional PRNG key
+    ///   - stream: stream or device to evaluate on
     public static func categorical(
         _ logits: MLXArray, axis: Int = -1, count: Int,
         key: (some RandomStateOrKey)? = MLXArray?.none, stream: StreamOrDevice = .default
@@ -909,6 +920,7 @@ public func uniform(
 ///   - loc: mean of the distribution
 ///   - scale: standard deviation of the distribution
 ///   - key: PRNG key
+///   - stream: stream or device to evaluate on
 public func normal(
     _ shape: some Collection<Int> = [],
     type: (some HasDType & BinaryFloatingPoint).Type = Float.self, loc: Float = 0, scale: Float = 1,
@@ -938,6 +950,7 @@ public func normal(
 ///   - loc: mean of the distribution
 ///   - scale: standard deviation of the distribution
 ///   - key: PRNG key
+///   - stream: stream or device to evaluate on
 public func normal(
     _ shape: some Collection<Int> = [], dtype: DType, loc: Float = 0, scale: Float = 1,
     key: (some RandomStateOrKey)? = MLXArray?.none, stream: StreamOrDevice = .default
@@ -961,6 +974,7 @@ public func normal(
 /// shapes of `mean` and `covariance`.
 ///   - dtype: DType of the result
 ///   - key: PRNG key
+///   - stream: stream or device to evaluate on
 public func multivariateNormal(
     mean: MLXArray, covariance: MLXArray, shape: some Collection<Int> = [], dtype: DType,
     key: (some RandomStateOrKey)? = MLXArray?.none, stream: StreamOrDevice = .default
@@ -1227,7 +1241,11 @@ public func gumbel(
 /// ```
 ///
 /// - Parameters:
-///     - logits: The *unnormalized* categorical distribution(s).
+///   - logits: The *unnormalized* categorical distribution(s).
+///   - axis: axis that specifies the distribution
+///   - shape: optional shape of the output -- this must be broadcast compatible with the shape of logits
+///   - key: optional PRNG key
+///   - stream: stream or device to evaluate on
 public func categorical(
     _ logits: MLXArray, axis: Int = -1, shape: (some Collection<Int>)? = [Int]?.none,
     key: (some RandomStateOrKey)? = MLXArray?.none, stream: StreamOrDevice = .default
@@ -1250,7 +1268,11 @@ public func categorical(
 /// ```
 ///
 /// - Parameters:
-///     - logits: The *unnormalized* categorical distribution(s).
+///   - logits: The *unnormalized* categorical distribution(s).
+///   - axis: axis that specifies the distribution
+///   - count: number of samples to draw from logits
+///   - key: optional PRNG key
+///   - stream: stream or device to evaluate on
 public func categorical(
     _ logits: MLXArray, axis: Int = -1, count: Int, key: (some RandomStateOrKey)? = MLXArray?.none,
     stream: StreamOrDevice = .default
@@ -1265,6 +1287,8 @@ public func categorical(
 ///   - dtype: type of the output
 ///   - loc: mean of the distribution
 ///   - scale: scale "b" of the distribution
+///   - key: optional PRNG key
+///   - stream: stream or device to evaluate on
 public func laplace(
     _ shape: some Collection<Int> = [], dtype: DType, loc: Float = 0, scale: Float = 1,
     key: (some RandomStateOrKey)? = MLXArray?.none, stream: StreamOrDevice = .default

--- a/Source/MLX/State.swift
+++ b/Source/MLX/State.swift
@@ -25,7 +25,7 @@ extension MLXRandom {
     ///
     /// ### See Also
     /// - ``globalState``
-    /// - ``withRandomState(_:body:)-6i2p1``
+    /// - ``withRandomState(_:body:)-18ob4``
     public class RandomState: RandomStateOrKey, Updatable, Evaluatable, @unchecked (Sendable) {
         private var state: MLXArray
         private let lock = NSLock()
@@ -88,7 +88,7 @@ extension MLXRandom {
 /// random key:
 ///
 /// - the passed key, either an ``MLXArray`` or ``MLXRandom/RandomState``
-/// - the task-local ``MLXRandom/RandomState``, see ``withRandomState(_:body:)-6i2p1``
+/// - the task-local ``MLXRandom/RandomState``, see ``withRandomState(_:body:)-18ob4``
 /// - the global RandomState, ``MLXRandom/globalState``
 public func resolve(key: (some RandomStateOrKey)? = MLXArray?.none) -> MLXArray {
     key?.asRandomKey() ?? MLXRandom.taskLocalRandomState?.asRandomKey()

--- a/Source/MLX/Stream.swift
+++ b/Source/MLX/Stream.swift
@@ -125,7 +125,7 @@ public final class Stream: @unchecked Sendable, Equatable {
 
     /// New stream on the given device.
     ///
-    /// See also ``withNewDefaultStream(device:_:)``
+    /// See also ``withNewDefaultStream(device:_:)-5bwc3``
     public init(_ device: Device) {
         self.ctx = evalLock.withLock {
             mlx_stream_new_device(device.ctx)

--- a/Source/MLX/Transforms+Compile.swift
+++ b/Source/MLX/Transforms+Compile.swift
@@ -145,12 +145,12 @@ public func compile(
     }
 }
 
-/// Overload of ``compile(inputs:outputs:shapeless:_:)-8wq3u`` that takes a single ``MLXArray`` and
+/// Overload of ``compile(inputs:outputs:shapeless:_:)-([Updatable],[Updatable],Bool,([MLXArray])->[MLXArray])`` that takes a single ``MLXArray`` and
 /// produces a single ``MLXArray``.
 ///
 /// ### See Also
 /// - <doc:compilation>
-/// - ``compile(inputs:outputs:shapeless:_:)-8wq3u``
+/// - ``compile(inputs:outputs:shapeless:_:)-([Updatable],[Updatable],Bool,([MLXArray])->[MLXArray])``
 public func compile(
     inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f: @escaping (MLXArray) -> MLXArray
@@ -164,12 +164,12 @@ public func compile(
     }
 }
 
-/// Overload of ``compile(inputs:outputs:shapeless:_:)-8wq3u`` that takes two ``MLXArray`` and
+/// Overload of ``compile(inputs:outputs:shapeless:_:)-([Updatable],[Updatable],Bool,([MLXArray])->[MLXArray])`` that takes two ``MLXArray`` and
 /// produces a single ``MLXArray``.
 ///
 /// ### See Also
 /// - <doc:compilation>
-/// - ``compile(inputs:outputs:shapeless:_:)-8wq3u``
+/// - ``compile(inputs:outputs:shapeless:_:)-([Updatable],[Updatable],Bool,([MLXArray])->[MLXArray])``
 public func compile(
     inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f: @escaping (MLXArray, MLXArray) -> MLXArray
@@ -185,12 +185,12 @@ public func compile(
     }
 }
 
-/// Overload of ``compile(inputs:outputs:shapeless:_:)-8wq3u`` that takes three ``MLXArray`` and
+/// Overload of ``compile(inputs:outputs:shapeless:_:)-([Updatable],[Updatable],Bool,([MLXArray])->[MLXArray])`` that takes three ``MLXArray`` and
 /// produces a single ``MLXArray``.
 ///
 /// ### See Also
 /// - <doc:compilation>
-/// - ``compile(inputs:outputs:shapeless:_:)-8wq3u``
+/// - ``compile(inputs:outputs:shapeless:_:)-([Updatable],[Updatable],Bool,([MLXArray])->[MLXArray])``
 public func compile(
     inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f: @Sendable @escaping (MLXArray, MLXArray, MLXArray) -> MLXArray
@@ -206,7 +206,7 @@ public func compile(
     }
 }
 
-/// Globally enable or disable ``compile(inputs:outputs:shapeless:_:)-8wq3u``.
+/// Globally enable or disable ``compile(inputs:outputs:shapeless:_:)-([Updatable],[Updatable],Bool,([MLXArray])->[MLXArray])``.
 ///
 /// Default is enabled.
 public func compile(enable: Bool = true) {

--- a/Source/MLX/Transforms+Eval.swift
+++ b/Source/MLX/Transforms+Eval.swift
@@ -36,7 +36,7 @@ public func eval(_ arrays: some Collection<MLXArray>) {
 ///
 /// ### See Also
 /// - <doc:lazy-evaluation>
-/// - ``asyncEval(_:)-6j4zg``
+/// - ``asyncEval(_:)-(Collection<MLXArray>)``
 public func asyncEval(_ arrays: some Collection<MLXArray>) {
     let vector_array = new_mlx_vector_array(arrays)
     _ = evalLock.withLock {
@@ -65,7 +65,7 @@ public func asyncEval(_ arrays: some Collection<MLXArray>) {
 ///
 /// ### See Also
 /// - <doc:lazy-evaluation>
-/// - ``asyncEval(_:)-6j4zg``
+/// - ``asyncEval(_:)-(Collection<MLXArray>)``
 public func eval(_ values: Any...) {
     var arrays = [MLXArray]()
 
@@ -89,7 +89,7 @@ public func eval(_ values: some Sequence<Any>) {
     eval(arrays)
 }
 
-/// Variant of ``eval(_:)-3b2g9`` that checks for errors in MLX and throws.
+/// Variant of ``eval(_:)-(Collection<MLXArray>)`` that checks for errors in MLX and throws.
 ///
 /// ### See Also
 /// - <doc:lazy-evaluation>
@@ -105,7 +105,7 @@ public func checkedEval(_ values: Any...) throws {
     }
 }
 
-/// Variant of ``eval(_:)-190w1`` that checks for errors in MLX and throws.
+/// Variant of ``eval(_:)-(MLXArray...)`` that checks for errors in MLX and throws.
 ///
 /// ### See Also
 /// - <doc:lazy-evaluation>
@@ -153,7 +153,7 @@ public func asyncEval(_ values: Any...) {
 
 /// Evaluate one or more `MLXArray` asynchronously.
 ///
-/// See ``asyncEval(_:)-6j4zg``
+/// See ``asyncEval(_:)-(Collection<MLXArray>)``
 public func asyncEval(_ values: some Sequence<Any>) {
     var arrays = [MLXArray]()
 

--- a/Source/MLXNN/Quantized.swift
+++ b/Source/MLXNN/Quantized.swift
@@ -49,10 +49,11 @@ public func quantizeSingle(
 ///   - model: model to quantize
 ///   - groupSize: quantization group size
 ///   - bits: bits per parameter
+///   - mode: quantization mode
 ///   - filter: filter receiving path and module -- return `false` to skip a layer
 ///   - apply: function to attempt the quantization -- the default implementation will quantize ``Linear`` and ``Embedding``
 /// ### See Also
-/// - ``quantize(model:filter:apply:)``
+/// - ``quantize(model:filter:apply:)-(_,_,(Module,Int,Int,QuantizationMode)->Module?)``
 public func quantize(
     model: Module,
     groupSize: Int = 64, bits: Int = 4, mode: QuantizationMode = .affine,
@@ -233,7 +234,7 @@ open class QuantizedEmbedding: Embedding, Quantized {
 /// Please see the discussion in ``Linear`` for considerations when replacing layers.
 ///
 /// ### See Also
-/// - ``init(weight:bias:groupSize:bits:)``
+/// - ``QuantizedLinear/init(_:_:bias:groupSize:bits:mode:)``
 open class QuantizedLinear: Linear, Quantized {
 
     public let groupSize: Int
@@ -258,6 +259,7 @@ open class QuantizedLinear: Linear, Quantized {
     ///   - bias: if `true` this layer will apply a bias
     ///   - groupSize: The group size to use for the quantized weight
     ///   - bits: The bit width to use for the quantized weight
+    ///   - mode: quantization mode
     public convenience init(
         _ inputDimensions: Int, _ outputDimensions: Int,
         bias: Bool = true, groupSize: Int = 64, bits: Int = 4,
@@ -278,6 +280,7 @@ open class QuantizedLinear: Linear, Quantized {
     ///   - other: a `Linear` layer
     ///   - groupSize: The group size to use for the quantized weight
     ///   - bits: The bit width to use for the quantized weight
+    ///   - mode: quantization mode
     public convenience init(
         _ other: Linear, groupSize: Int = 64, bits: Int = 4,
         mode: QuantizationMode = .affine


### PR DESCRIPTION
- fix #327 as much as possible
- changes from the opaque hash to the new typed style:

-/// - ``MLXArray/asType(_:stream:)-6d44y``
+/// - ``MLXArray/asType(_:stream:)-(DType,StreamOrDevice)``

- where possible!
- I found that xcode and docc were not able to handle all of the links like this

- added missing docs (primarily parameters) where found
- this doesn't fix _everything_ as some references are still ambiguous

## Proposed changes

Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
