### PR TITLE
Fix race condition during the tracing phase of automatic differentiation (vjp, value_and_grad)

### DIFF
--- a/Source/MLX/Transforms.swift
+++ b/Source/MLX/Transforms.swift
@@ -28,9 +28,9 @@ public func jvp(
 
     let closure = new_mlx_closure(f)
 
-    transformMutex.lock()
-    mlx_jvp(&r0, &r1, closure, primals_mlx, tangents_mlx)
-    transformMutex.unlock()
+    _ = evalLock.withLock {
+        mlx_jvp(&r0, &r1, closure, primals_mlx, tangents_mlx)
+    }
 
     mlx_closure_free(closure)
 
@@ -65,9 +65,9 @@ public func vjp(
 
     let closure = new_mlx_closure(f)
 
-    transformMutex.lock()
-    mlx_vjp(&r0, &r1, closure, primals_mlx, cotangents_mlx)
-    transformMutex.unlock()
+    _ = evalLock.withLock {
+        mlx_vjp(&r0, &r1, closure, primals_mlx, cotangents_mlx)
+    }
 
     mlx_closure_free(closure)
 


### PR DESCRIPTION
This PR introduces thread safety to the graph construction phase of the function transformations (vjp, jvp, and valueAndGrad).When multiple threads attempt to compute gradients or vector-Jacobian products simultaneously, data races occur within the C++ layer, leading to std::bad_access crashes and heap corruption.

## Proposed changes

The lock is only held during the graph tracing/construction phase. It does not block the actual evaluation or computation of the arrays (which remains lazy).

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
