### PR TITLE
guard compile and vmap tracing calls

### DIFF
--- a/Source/MLX/Transforms+Compile.swift
+++ b/Source/MLX/Transforms+Compile.swift
@@ -86,9 +86,13 @@ final class CompiledFunction: @unchecked (Sendable) {
 
         // note: this will use the cached compile (via the id)
         // but will be able to re-evaluate with fresh state if needed
+        evalLock.lock()
         var compiled = mlx_closure_new()
         mlx_detail_compile(&compiled, innerClosure, id, shapeless, [], 0)
-        defer { mlx_closure_free(compiled) }
+        defer {
+            mlx_closure_free(compiled)
+            evalLock.unlock()
+        }
 
         let innerInputs = arguments + stateInputs
         let innerInputsVector = new_mlx_vector_array(innerInputs)

--- a/Source/MLX/Transforms+Vmap.swift
+++ b/Source/MLX/Transforms+Vmap.swift
@@ -29,13 +29,16 @@ public func vmap(
         var traceInputs = mlx_vector_array_new()
         var traceOutputs = mlx_vector_array_new()
 
-        let closure = new_mlx_closure(f)
-        _ = inAxes32.withUnsafeBufferPointer { inAxesBuf in
-            mlx_detail_vmap_trace(
-                &traceInputs, &traceOutputs, closure, inputs, inAxesBuf.baseAddress, inAxesBuf.count
-            )
+        evalLock.withLock {
+            let closure = new_mlx_closure(f)
+            _ = inAxes32.withUnsafeBufferPointer { inAxesBuf in
+                mlx_detail_vmap_trace(
+                    &traceInputs, &traceOutputs, closure, inputs, inAxesBuf.baseAddress,
+                    inAxesBuf.count
+                )
+            }
+            mlx_closure_free(closure)
         }
-        mlx_closure_free(closure)
 
         defer {
             mlx_vector_array_free(traceInputs)


### PR DESCRIPTION
- these mutate global state and are not thread safe
- fix #337

## Proposed changes

Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
