### PR TITLE
Add release workflow that builds and attaches XCFramework assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release XCFrameworks
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to upload assets to (leave empty for dry run)'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build_xcframeworks:
+    if: github.repository == 'ml-explore/mlx-swift'
+    runs-on: [self-hosted, macos]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Verify MetalToolchain installed
+        shell: bash
+        run: xcodebuild -showComponent MetalToolchain
+
+      - name: Build XCFrameworks
+        shell: bash
+        env:
+          DEVELOPER_DIR: /Applications/Xcode-latest.app
+        working-directory: xcode
+        run: |
+          xcodebuild -version
+          ../tools/create-xcframework.sh
+
+      - name: Create archives
+        shell: bash
+        working-directory: xcode/build/output
+        run: |
+          for framework in MLX Cmlx MLXNN MLXOptimizers; do
+            zip -r -y "${framework}.xcframework.zip" "${framework}.xcframework"
+          done
+
+      - name: Upload XCFrameworks to release
+        if: github.event.release.tag_name || inputs.tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name || inputs.tag }}" \
+            xcode/build/output/MLX.xcframework.zip \
+            xcode/build/output/Cmlx.xcframework.zip \
+            xcode/build/output/MLXNN.xcframework.zip \
+            xcode/build/output/MLXOptimizers.xcframework.zip


### PR DESCRIPTION
## Proposed changes

This PR adds a GitHub Actions workflow to automatically build and attach XCFramework artifacts to releases.

This enables API consumers to download prebuilt binaries directly from GitHub releases, significantly reducing build times (as noted in https://github.com/mattt/AnyLanguageModel/issues/9, MLX-related builds can take 75% of total build time).

The workflow:

- Triggers on published releases (or manually via workflow_dispatch for testing)
- Builds XCFrameworks for all platforms (iOS, macOS, Mac Catalyst, tvOS, visionOS) using the existing `tools/create-xcframework.sh` script (added by https://github.com/ml-explore/mlx-swift/pull/289)
- Creates zip archives
- Uploads them to the release

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
