### PR TITLE
Weakly link error domains to allow building non-Metal-supporting targets

### DIFF
--- a/Source/Cmlx/metal-cpp/Metal/MTLIOCommandQueue.hpp
+++ b/Source/Cmlx/metal-cpp/Metal/MTLIOCommandQueue.hpp
@@ -104,7 +104,7 @@ public:
 };
 
 }
-_MTL_PRIVATE_DEF_CONST(NS::ErrorDomain, IOErrorDomain);
+_MTL_PRIVATE_DEF_WEAK_CONST(NS::ErrorDomain, IOErrorDomain);
 _MTL_INLINE MTL::IOCommandBuffer* MTL::IOCommandQueue::commandBuffer()
 {
     return Object::sendMessage<MTL::IOCommandBuffer*>(this, _MTL_PRIVATE_SEL(commandBuffer));

--- a/Source/Cmlx/metal-cpp/Metal/MTLTensor.hpp
+++ b/Source/Cmlx/metal-cpp/Metal/MTLTensor.hpp
@@ -134,7 +134,7 @@ public:
 
 }
 
-_MTL_PRIVATE_DEF_CONST(NS::ErrorDomain, TensorDomain);
+_MTL_PRIVATE_DEF_WEAK_CONST(NS::ErrorDomain, TensorDomain);
 
 _MTL_INLINE MTL::TensorExtents* MTL::TensorExtents::alloc()
 {


### PR DESCRIPTION
## Proposed changes

Addresses #341 by using`_MTL_PRIVATE_DEF_WEAK_CONST` to weakly link `MTLIOErrorDomain` and `MTLTensorDomain`, which allows Simulator builds for libraries that include MLX Swift.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] ~I have added tests that prove my fix is effective or that my feature works~
- [x] I have updated the necessary documentation (if needed)
