### PR TITLE
Mlx Array Convenience Initializer Macro

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,7 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 // Copyright © 2024 Apple Inc.
 
+import CompilerPluginSupport
 import PackageDescription
 
 #if os(Linux)
@@ -232,7 +233,8 @@ let package = Package(
     ],
     dependencies: [
         // for Complex type
-        .package(url: "https://github.com/apple/swift-numerics", from: "1.0.0")
+        .package(url: "https://github.com/apple/swift-numerics", from: "1.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "602.0.0"),
     ],
     targets: [
         cmlx,
@@ -246,10 +248,21 @@ let package = Package(
             dependencies: [
                 "Cmlx",
                 .product(name: "Numerics", package: "swift-numerics"),
+                "MLXMacrosPlugin",
             ],
             exclude: mlxSwiftExcludes,
             swiftSettings: [
                 .enableExperimentalFeature("StrictConcurrency")
+            ]
+        ),
+        .macro(
+            name: "MLXMacrosPlugin",
+            dependencies: [
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+                .product(name: "SwiftSyntax", package: "swift-syntax"),
+                .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftDiagnostics", package: "swift-syntax"),
             ]
         ),
         .target(
@@ -299,6 +312,13 @@ let package = Package(
             name: "MLXTests",
             dependencies: [
                 "MLX", "MLXNN", "MLXOptimizers",
+            ]
+        ),
+        .testTarget(
+            name: "MLXMacrosTests",
+            dependencies: [
+                "MLXMacrosPlugin",
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
             ]
         ),
 

--- a/Source/MLX/Documentation.docc/Organization/initialization.md
+++ b/Source/MLX/Documentation.docc/Organization/initialization.md
@@ -141,6 +141,27 @@ When creating using an array or sequence you can also control the shape:
 let v1 = MLXArray(0 ..< 12, [3, 4])
 ```
 
+### Macro Literals
+
+You can also create arrays from nested literals with the `#mlx` expression macro:
+
+```swift
+import MLX
+
+let a = #mlx([[1, 2], [3, 4]])
+let b = #mlx([[1, 2], [3, 4]], dtype: .int16)
+let c = #mlx([[[0.1, 0.2], [0.3, 0.4]]], dtype: .float16)
+```
+
+This is especially convenient for small constants in model code and tests.
+The macro requires rectangular nested arrays and numeric literals.
+
+When `dtype` is a known integer dtype (for example `.int16`, `.int64`, `.uint8`) or `.float32`,
+the expansion emits typed Swift literals directly and avoids a trailing `.asType(...)` cast.
+For dynamic dtype expressions, or dtypes that do not map cleanly to a Swift literal type
+(for example `.float16`, `.bfloat16`, `.complex64`), the macro emits a base array and applies
+`.asType(...)`.
+
 ### Random Value Arrays
 
 See also `MLXRandom` for creating arrays with random data.

--- a/Source/MLX/Documentation.docc/Organization/initialization.md
+++ b/Source/MLX/Documentation.docc/Organization/initialization.md
@@ -155,12 +155,19 @@ let c = #mlx([[[0.1, 0.2], [0.3, 0.4]]], dtype: .float16)
 
 This is especially convenient for small constants in model code and tests.
 The macro requires rectangular nested arrays and numeric literals.
+Mixed numeric literals are promoted to floating-point behavior: if any element is a
+floating-point literal, the entire literal is treated as floating-point.
 
 When `dtype` is a known integer dtype (for example `.int16`, `.int64`, `.uint8`) or `.float32`,
 the expansion emits typed Swift literals directly and avoids a trailing `.asType(...)` cast.
 For dynamic dtype expressions, or dtypes that do not map cleanly to a Swift literal type
 (for example `.float16`, `.bfloat16`, `.complex64`), the macro emits a base array and applies
 `.asType(...)`.
+
+```swift
+// promoted to floating-point because of 2.5
+let mixed = #mlx([[1, 2.5], [3, 4]])
+```
 
 ### Random Value Arrays
 

--- a/Source/MLX/Documentation.docc/Organization/initialization.md
+++ b/Source/MLX/Documentation.docc/Organization/initialization.md
@@ -151,6 +151,8 @@ import MLX
 let a = #mlx([[1, 2], [3, 4]])
 let b = #mlx([[1, 2], [3, 4]], dtype: .int16)
 let c = #mlx([[[0.1, 0.2], [0.3, 0.4]]], dtype: .float16)
+let d = #mlx([[true, false], [false, true]])
+let e = #mlx([[0, 1], [1, 0]], dtype: .bool)
 ```
 
 This is especially convenient for small constants in model code and tests.
@@ -168,6 +170,9 @@ For dynamic dtype expressions, or dtypes that do not map cleanly to a Swift lite
 // promoted to floating-point because of 2.5
 let mixed = #mlx([[1, 2.5], [3, 4]])
 ```
+
+Boolean literals are supported directly (`true` / `false`). For `dtype: .bool`,
+integer literals are accepted only when each element is `0` or `1`.
 
 ### Random Value Arrays
 

--- a/Source/MLX/Documentation.docc/Organization/initialization.md
+++ b/Source/MLX/Documentation.docc/Organization/initialization.md
@@ -143,20 +143,21 @@ let v1 = MLXArray(0 ..< 12, [3, 4])
 
 ### Macro Literals
 
-You can also create arrays from nested literals with the `#mlx` expression macro:
+You can also create arrays from nested literals with the `#MLXArray` expression macro:
 
 ```swift
 import MLX
 
-let a = #mlx([[1, 2], [3, 4]])
-let b = #mlx([[1, 2], [3, 4]], dtype: .int16)
-let c = #mlx([[[0.1, 0.2], [0.3, 0.4]]], dtype: .float16)
-let d = #mlx([[true, false], [false, true]])
-let e = #mlx([[0, 1], [1, 0]], dtype: .bool)
+let a = #MLXArray([[1, 2], [3, 4]])
+let b = #MLXArray([[1, 2], [3, 4]], dtype: .int16)
+let c = #MLXArray([[[0.1, 0.2], [0.3, 0.4]]], dtype: .float16)
+let d = #MLXArray([[true, false], [false, true]])
+let e = #MLXArray([[0, 1], [1, 0]], dtype: .bool)
 ```
 
 This is especially convenient for small constants in model code and tests.
-The macro requires rectangular nested arrays and numeric literals.
+The macro requires rectangular nested arrays with boolean, integer, or floating-point literals.
+Mixing boolean and numeric literals in the same nested literal is not supported.
 Mixed numeric literals are promoted to floating-point behavior: if any element is a
 floating-point literal, the entire literal is treated as floating-point.
 
@@ -166,9 +167,12 @@ For dynamic dtype expressions, or dtypes that do not map cleanly to a Swift lite
 (for example `.float16`, `.bfloat16`, `.complex64`), the macro emits a base array and applies
 `.asType(...)`.
 
+If `dtype` is an integer type and the literal contains floating-point values,
+the macro still allows expansion but emits a warning because conversion may truncate.
+
 ```swift
 // promoted to floating-point because of 2.5
-let mixed = #mlx([[1, 2.5], [3, 4]])
+let mixed = #MLXArray([[1, 2.5], [3, 4]])
 ```
 
 Boolean literals are supported directly (`true` / `false`). For `dtype: .bool`,

--- a/Source/MLX/MLXMacros.swift
+++ b/Source/MLX/MLXMacros.swift
@@ -1,21 +1,21 @@
 // Copyright © 2026 Apple Inc.
 
-/// Construct an ``MLXArray`` from a nested numeric literal.
+/// Construct an ``MLXArray`` from a nested literal.
 ///
 /// Examples:
 ///
 /// ```swift
-/// let a = #mlx([[1, 2, 3], [4, 5, 6]])
-/// let b = #mlx([[1, 2, 3], [4, 5, 6]], dtype: .int16)
-/// let c = #mlx([[0.1, 0.2], [0.3, 0.4]], dtype: .float16)
+/// let a = #MLXArray([[1, 2, 3], [4, 5, 6]])
+/// let b = #MLXArray([[1, 2, 3], [4, 5, 6]], dtype: .int16)
+/// let c = #MLXArray([[0.1, 0.2], [0.3, 0.4]], dtype: .float16)
 /// ```
 @freestanding(expression)
-public macro mlx(_ literal: Any) -> MLXArray =
+public macro MLXArray(_ literal: Any) -> MLXArray =
     #externalMacro(
         module: "MLXMacrosPlugin", type: "MLXLiteralMacro")
 
-/// Construct an ``MLXArray`` from a nested numeric literal and cast to `dtype`.
+/// Construct an ``MLXArray`` from a nested literal and cast to `dtype`.
 @freestanding(expression)
-public macro mlx(_ literal: Any, dtype: DType) -> MLXArray =
+public macro MLXArray(_ literal: Any, dtype: DType) -> MLXArray =
     #externalMacro(
         module: "MLXMacrosPlugin", type: "MLXLiteralMacro")

--- a/Source/MLX/MLXMacros.swift
+++ b/Source/MLX/MLXMacros.swift
@@ -1,0 +1,21 @@
+// Copyright © 2026 Apple Inc.
+
+/// Construct an ``MLXArray`` from a nested numeric literal.
+///
+/// Examples:
+///
+/// ```swift
+/// let a = #mlx([[1, 2, 3], [4, 5, 6]])
+/// let b = #mlx([[1, 2, 3], [4, 5, 6]], dtype: .int16)
+/// let c = #mlx([[0.1, 0.2], [0.3, 0.4]], dtype: .float16)
+/// ```
+@freestanding(expression)
+public macro mlx(_ literal: Any) -> MLXArray =
+    #externalMacro(
+        module: "MLXMacrosPlugin", type: "MLXLiteralMacro")
+
+/// Construct an ``MLXArray`` from a nested numeric literal and cast to `dtype`.
+@freestanding(expression)
+public macro mlx(_ literal: Any, dtype: DType) -> MLXArray =
+    #externalMacro(
+        module: "MLXMacrosPlugin", type: "MLXLiteralMacro")

--- a/Source/MLXMacrosPlugin/MLXLiteralMacro.swift
+++ b/Source/MLXMacrosPlugin/MLXLiteralMacro.swift
@@ -1,0 +1,236 @@
+// Copyright © 2026 Apple Inc.
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+private enum ScalarKind {
+    case int
+    case float
+
+    static func merge(_ lhs: ScalarKind, _ rhs: ScalarKind) -> ScalarKind {
+        if lhs == .float || rhs == .float {
+            return .float
+        }
+        return .int
+    }
+}
+
+private struct ParsedLiteral {
+    var flat: [ExprSyntax]
+    var shape: [Int]
+    var kind: ScalarKind
+}
+
+private struct MacroError: Error {}
+
+private struct MacroMessage: DiagnosticMessage {
+    let message: String
+    let diagnosticID: MessageID
+    let severity: DiagnosticSeverity = .error
+
+    init(_ message: String) {
+        self.message = message
+        self.diagnosticID = MessageID(domain: "MLXMacros", id: "mlx_literal")
+    }
+}
+
+private enum KnownDType: String {
+    case bool
+    case uint8
+    case uint16
+    case uint32
+    case uint64
+    case int8
+    case int16
+    case int32
+    case int64
+    case float16
+    case float32
+    case bfloat16
+    case complex64
+    case float64
+}
+
+public struct MLXLiteralMacro: ExpressionMacro {
+    public static func expansion(
+        of node: some FreestandingMacroExpansionSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> ExprSyntax {
+        let args = Array(node.arguments)
+        guard let literalArg = args.first else {
+            diagnose("#mlx requires a nested numeric array literal.", at: Syntax(node), in: context)
+            return "MLXArray([])"
+        }
+
+        let dtypeExpr: ExprSyntax?
+        if args.count == 1 {
+            dtypeExpr = nil
+        } else if args.count == 2 {
+            guard args[1].label?.text == "dtype" else {
+                diagnose(
+                    "#mlx second argument must be labeled 'dtype:'.",
+                    at: Syntax(args[1]), in: context)
+                return "MLXArray([])"
+            }
+            dtypeExpr = args[1].expression
+        } else {
+            diagnose(
+                "#mlx accepts one literal argument and optional dtype:.", at: Syntax(node),
+                in: context)
+            return "MLXArray([])"
+        }
+
+        let parsed: ParsedLiteral
+        do {
+            parsed = try parseLiteral(literalArg.expression, context: context)
+        } catch {
+            return "MLXArray([])"
+        }
+
+        let flatSource = parsed.flat.map { $0.description }.joined(separator: ", ")
+        let shapeSource = parsed.shape.map(String.init).joined(separator: ", ")
+        let baseExpr: ExprSyntax =
+            switch parsed.kind {
+            case .int:
+                "MLXArray([\(raw: flatSource)], [\(raw: shapeSource)])"
+            case .float:
+                "MLXArray(converting: [\(raw: flatSource)], [\(raw: shapeSource)])"
+            }
+
+        if let dtypeExpr {
+            if let knownDType = parseKnownDType(dtypeExpr),
+                let typedExpr = makeTypedExpression(parsed: parsed, dtype: knownDType)
+            {
+                return typedExpr
+            }
+            return "\(baseExpr).asType(\(dtypeExpr))"
+        } else {
+            return baseExpr
+        }
+    }
+
+    private static func parseKnownDType(_ expr: ExprSyntax) -> KnownDType? {
+        guard let member = expr.as(MemberAccessExprSyntax.self) else {
+            return nil
+        }
+        return KnownDType(rawValue: member.declName.baseName.text)
+    }
+
+    private static func makeTypedExpression(parsed: ParsedLiteral, dtype: KnownDType) -> ExprSyntax?
+    {
+        let shapeSource = parsed.shape.map(String.init).joined(separator: ", ")
+        let typedFlat: String
+
+        switch dtype {
+        case .int8:
+            guard parsed.kind == .int else { return nil }
+            typedFlat = wrap(parsed.flat, with: "Int8")
+        case .int16:
+            guard parsed.kind == .int else { return nil }
+            typedFlat = wrap(parsed.flat, with: "Int16")
+        case .int32:
+            guard parsed.kind == .int else { return nil }
+            typedFlat = wrap(parsed.flat, with: "Int32")
+        case .int64:
+            guard parsed.kind == .int else { return nil }
+            typedFlat = wrap(parsed.flat, with: "Int64")
+        case .uint8:
+            guard parsed.kind == .int else { return nil }
+            typedFlat = wrap(parsed.flat, with: "UInt8")
+        case .uint16:
+            guard parsed.kind == .int else { return nil }
+            typedFlat = wrap(parsed.flat, with: "UInt16")
+        case .uint32:
+            guard parsed.kind == .int else { return nil }
+            typedFlat = wrap(parsed.flat, with: "UInt32")
+        case .uint64:
+            guard parsed.kind == .int else { return nil }
+            typedFlat = wrap(parsed.flat, with: "UInt64")
+        case .float32:
+            if parsed.kind == .int {
+                typedFlat = wrap(parsed.flat, with: "Float")
+            } else {
+                typedFlat = wrap(parsed.flat, with: "Float")
+            }
+        case .bool, .float16, .bfloat16, .complex64, .float64:
+            return nil
+        }
+
+        return "MLXArray([\(raw: typedFlat)], [\(raw: shapeSource)])"
+    }
+
+    private static func wrap(_ values: [ExprSyntax], with typeName: String) -> String {
+        values.map { "\(typeName)(\($0))" }.joined(separator: ", ")
+    }
+
+    private static func parseLiteral(
+        _ expr: ExprSyntax, context: some MacroExpansionContext
+    ) throws -> ParsedLiteral {
+        if let arrayExpr = expr.as(ArrayExprSyntax.self) {
+            if arrayExpr.elements.isEmpty {
+                return ParsedLiteral(flat: [], shape: [0], kind: .int)
+            }
+
+            var children: [ParsedLiteral] = []
+            children.reserveCapacity(arrayExpr.elements.count)
+
+            for element in arrayExpr.elements {
+                children.append(try parseLiteral(element.expression, context: context))
+            }
+
+            let firstShape = children[0].shape
+            if children.dropFirst().contains(where: { $0.shape != firstShape }) {
+                diagnose(
+                    "#mlx does not support ragged nested arrays.", at: Syntax(expr), in: context)
+                throw MacroError()
+            }
+
+            let kind = children.dropFirst().reduce(children[0].kind) {
+                ScalarKind.merge($0, $1.kind)
+            }
+
+            return ParsedLiteral(
+                flat: children.flatMap(\.flat), shape: [children.count] + firstShape, kind: kind)
+        }
+
+        if isInteger(expr) {
+            return ParsedLiteral(flat: [expr], shape: [], kind: .int)
+        }
+        if isFloat(expr) {
+            return ParsedLiteral(flat: [expr], shape: [], kind: .float)
+        }
+
+        diagnose(
+            "#mlx only supports integer and floating-point literals.", at: Syntax(expr), in: context
+        )
+        throw MacroError()
+    }
+
+    private static func isInteger(_ expr: ExprSyntax) -> Bool {
+        if expr.as(IntegerLiteralExprSyntax.self) != nil {
+            return true
+        }
+        if let prefix = expr.as(PrefixOperatorExprSyntax.self) {
+            return isInteger(prefix.expression)
+        }
+        return false
+    }
+
+    private static func isFloat(_ expr: ExprSyntax) -> Bool {
+        if expr.as(FloatLiteralExprSyntax.self) != nil {
+            return true
+        }
+        if let prefix = expr.as(PrefixOperatorExprSyntax.self) {
+            return isFloat(prefix.expression)
+        }
+        return false
+    }
+
+    private static func diagnose(
+        _ message: String, at node: Syntax, in context: some MacroExpansionContext
+    ) {
+        context.diagnose(Diagnostic(node: node, message: MacroMessage(message)))
+    }
+}

--- a/Source/MLXMacrosPlugin/MLXLiteralMacro.swift
+++ b/Source/MLXMacrosPlugin/MLXLiteralMacro.swift
@@ -70,7 +70,7 @@ public struct MLXLiteralMacro: ExpressionMacro {
     ) throws -> ExprSyntax {
         let args = Array(node.arguments)
         guard let literalArg = args.first else {
-            diagnose("#mlx requires a nested numeric array literal.", at: Syntax(node), in: context)
+            diagnose("#MLXArray requires a nested numeric array literal.", at: Syntax(node), in: context)
             return "MLXArray([])"
         }
 
@@ -80,14 +80,14 @@ public struct MLXLiteralMacro: ExpressionMacro {
         } else if args.count == 2 {
             guard args[1].label?.text == "dtype" else {
                 diagnose(
-                    "#mlx second argument must be labeled 'dtype:'.",
+                    "#MLXArray second argument must be labeled 'dtype:'.",
                     at: Syntax(args[1]), in: context)
                 return "MLXArray([])"
             }
             dtypeExpr = args[1].expression
         } else {
             diagnose(
-                "#mlx accepts one literal argument and optional dtype:.", at: Syntax(node),
+                "#MLXArray accepts one literal argument and optional dtype:.", at: Syntax(node),
                 in: context)
             return "MLXArray([])"
         }
@@ -127,7 +127,7 @@ public struct MLXLiteralMacro: ExpressionMacro {
                             guard let value = integerLiteralValue(element), value == 0 || value == 1
                             else {
                                 diagnose(
-                                    "#mlx dtype .bool only supports integer literals 0 or 1.",
+                                    "#MLXArray dtype .bool only supports integer literals 0 or 1.",
                                     at: Syntax(element),
                                     in: context)
                                 return "MLXArray([])"
@@ -138,7 +138,7 @@ public struct MLXLiteralMacro: ExpressionMacro {
                         return "MLXArray([\(raw: boolSource)], [\(raw: shapeSource)])"
                     case .float:
                         diagnose(
-                            "#mlx dtype .bool only supports true/false literals or integer 0/1.",
+                            "#MLXArray dtype .bool only supports true/false literals or integer 0/1.",
                             at: Syntax(dtypeExpr),
                             in: context)
                         return "MLXArray([])"
@@ -149,7 +149,7 @@ public struct MLXLiteralMacro: ExpressionMacro {
                 // since runtime conversion may truncate.
                 if isIntegerDType(knownDType), let floatExpr = parsed.flat.first(where: isFloat) {
                     diagnose(
-                        "#mlx integer dtype with floating-point literal(s) may truncate values during conversion.",
+                        "#MLXArray integer dtype with floating-point literal(s) may truncate values during conversion.",
                         at: Syntax(floatExpr),
                         severity: .warning,
                         in: context)
@@ -254,7 +254,7 @@ public struct MLXLiteralMacro: ExpressionMacro {
                 // MLXArray construction here assumes rectangular nested literals.
                 // Ragged arrays are rejected early with a macro diagnostic.
                 diagnose(
-                    "#mlx does not support ragged nested arrays.", at: Syntax(expr), in: context)
+                    "#MLXArray does not support ragged nested arrays.", at: Syntax(expr), in: context)
                 throw MacroError()
             }
 
@@ -268,7 +268,7 @@ public struct MLXLiteralMacro: ExpressionMacro {
                     })
             else {
                 diagnose(
-                    "#mlx does not support mixing boolean and numeric literals in the same array.",
+                    "#MLXArray does not support mixing boolean and numeric literals in the same array.",
                     at: Syntax(expr),
                     in: context)
                 throw MacroError()
@@ -289,7 +289,7 @@ public struct MLXLiteralMacro: ExpressionMacro {
         }
 
         diagnose(
-            "#mlx only supports boolean, integer, and floating-point literals.", at: Syntax(expr),
+            "#MLXArray only supports boolean, integer, and floating-point literals.", at: Syntax(expr),
             in: context
         )
         throw MacroError()

--- a/Source/MLXMacrosPlugin/MLXLiteralMacro.swift
+++ b/Source/MLXMacrosPlugin/MLXLiteralMacro.swift
@@ -70,7 +70,8 @@ public struct MLXLiteralMacro: ExpressionMacro {
     ) throws -> ExprSyntax {
         let args = Array(node.arguments)
         guard let literalArg = args.first else {
-            diagnose("#MLXArray requires a nested numeric array literal.", at: Syntax(node), in: context)
+            diagnose(
+                "#MLXArray requires a nested numeric array literal.", at: Syntax(node), in: context)
             return "MLXArray([])"
         }
 
@@ -254,7 +255,8 @@ public struct MLXLiteralMacro: ExpressionMacro {
                 // MLXArray construction here assumes rectangular nested literals.
                 // Ragged arrays are rejected early with a macro diagnostic.
                 diagnose(
-                    "#MLXArray does not support ragged nested arrays.", at: Syntax(expr), in: context)
+                    "#MLXArray does not support ragged nested arrays.", at: Syntax(expr),
+                    in: context)
                 throw MacroError()
             }
 
@@ -289,7 +291,8 @@ public struct MLXLiteralMacro: ExpressionMacro {
         }
 
         diagnose(
-            "#MLXArray only supports boolean, integer, and floating-point literals.", at: Syntax(expr),
+            "#MLXArray only supports boolean, integer, and floating-point literals.",
+            at: Syntax(expr),
             in: context
         )
         throw MacroError()

--- a/Source/MLXMacrosPlugin/MLXMacrosPlugin.swift
+++ b/Source/MLXMacrosPlugin/MLXMacrosPlugin.swift
@@ -1,0 +1,11 @@
+// Copyright © 2026 Apple Inc.
+
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct MLXMacrosPlugin: CompilerPlugin {
+    let providingMacros: [Macro.Type] = [
+        MLXLiteralMacro.self
+    ]
+}

--- a/Tests/MLXMacrosTests/MLXLiteralMacroTests.swift
+++ b/Tests/MLXMacrosTests/MLXLiteralMacroTests.swift
@@ -100,6 +100,14 @@ final class MLXLiteralMacroTests: XCTestCase {
         )
     }
 
+    func testExpandsSingleFloatElementAsFloatLiteral() {
+        assertMacroExpansion(
+            "#mlx([[1, 2], [3, 4.5]])",
+            expandedSource: "MLXArray(converting: [1, 2, 3, 4.5], [2, 2])",
+            macros: testMacros
+        )
+    }
+
     func testExpandsDeepLiteralWithFloat16Dtype() {
         assertMacroExpansion(
             "#mlx([[[1, 2], [3, 4]]], dtype: .float16)",

--- a/Tests/MLXMacrosTests/MLXLiteralMacroTests.swift
+++ b/Tests/MLXMacrosTests/MLXLiteralMacroTests.swift
@@ -1,0 +1,130 @@
+// Copyright © 2026 Apple Inc.
+
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+@testable import MLXMacrosPlugin
+
+private let testMacros: [String: Macro.Type] = [
+    "mlx": MLXLiteralMacro.self
+]
+
+final class MLXLiteralMacroTests: XCTestCase {
+    func testExpandsIntegerLiteral() {
+        assertMacroExpansion(
+            "#mlx([[1, 2], [3, 4]])",
+            expandedSource: "MLXArray([1, 2, 3, 4], [2, 2])",
+            macros: testMacros
+        )
+    }
+
+    func testExpandsFloatLiteral() {
+        assertMacroExpansion(
+            "#mlx([[0.1, 0.2], [0.3, 0.4]])",
+            expandedSource: "MLXArray(converting: [0.1, 0.2, 0.3, 0.4], [2, 2])",
+            macros: testMacros
+        )
+    }
+
+    func testExpandsWithDtypeCast() {
+        assertMacroExpansion(
+            "#mlx([[1, 2], [3, 4]], dtype: .int16)",
+            expandedSource: "MLXArray([Int16(1), Int16(2), Int16(3), Int16(4)], [2, 2])",
+            macros: testMacros
+        )
+    }
+
+    func testExpandsIntegerLiteralWithInt64Dtype() {
+        assertMacroExpansion(
+            "#mlx([[1, 2], [3, 4]], dtype: .int64)",
+            expandedSource: "MLXArray([Int64(1), Int64(2), Int64(3), Int64(4)], [2, 2])",
+            macros: testMacros
+        )
+    }
+
+    func testExpandsIntegerLiteralWithUInt8Dtype() {
+        assertMacroExpansion(
+            "#mlx([[1, 2], [3, 4]], dtype: .uint8)",
+            expandedSource: "MLXArray([UInt8(1), UInt8(2), UInt8(3), UInt8(4)], [2, 2])",
+            macros: testMacros
+        )
+    }
+
+    func testExpandsIntegerLiteralWithFloat32Dtype() {
+        assertMacroExpansion(
+            "#mlx([[1, 2], [3, 4]], dtype: .float32)",
+            expandedSource: "MLXArray([Float(1), Float(2), Float(3), Float(4)], [2, 2])",
+            macros: testMacros
+        )
+    }
+
+    func testFallsBackToAsTypeForFloat64Dtype() {
+        assertMacroExpansion(
+            "#mlx([[1.0, 2.0], [3.0, 4.0]], dtype: .float64)",
+            expandedSource: "MLXArray(converting: [1.0, 2.0, 3.0, 4.0], [2, 2]).asType(.float64)",
+            macros: testMacros
+        )
+    }
+
+    func testFallsBackToAsTypeForDynamicDtypeExpression() {
+        assertMacroExpansion(
+            "#mlx([[1, 2], [3, 4]], dtype: dtypeValue)",
+            expandedSource: "MLXArray([1, 2, 3, 4], [2, 2]).asType(dtypeValue)",
+            macros: testMacros
+        )
+    }
+
+    func testExpandsThreeDimensionalIntegerLiteral() {
+        assertMacroExpansion(
+            "#mlx([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])",
+            expandedSource: "MLXArray([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2])",
+            macros: testMacros
+        )
+    }
+
+    func testExpandsFourDimensionalFloatLiteral() {
+        assertMacroExpansion(
+            "#mlx([[[[0.1, 0.2]], [[0.3, 0.4]]], [[[0.5, 0.6]], [[0.7, 0.8]]]])",
+            expandedSource:
+                "MLXArray(converting: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8], [2, 2, 1, 2])",
+            macros: testMacros
+        )
+    }
+
+    func testExpandsMixedIntegerFloatLiteralAsFloat() {
+        assertMacroExpansion(
+            "#mlx([[1, 2.5], [3, 4.5]])",
+            expandedSource: "MLXArray(converting: [1, 2.5, 3, 4.5], [2, 2])",
+            macros: testMacros
+        )
+    }
+
+    func testExpandsDeepLiteralWithFloat16Dtype() {
+        assertMacroExpansion(
+            "#mlx([[[1, 2], [3, 4]]], dtype: .float16)",
+            expandedSource: "MLXArray([1, 2, 3, 4], [1, 2, 2]).asType(.float16)",
+            macros: testMacros
+        )
+    }
+
+    func testExpandsMixedLiteralWithInt8Dtype() {
+        assertMacroExpansion(
+            "#mlx([[1.25, 2], [3.5, 4]], dtype: .int8)",
+            expandedSource: "MLXArray(converting: [1.25, 2, 3.5, 4], [2, 2]).asType(.int8)",
+            macros: testMacros
+        )
+    }
+
+    func testRaggedLiteralDiagnostics() {
+        assertMacroExpansion(
+            "#mlx([[1, 2], [3]])",
+            expandedSource: "MLXArray([])",
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "#mlx does not support ragged nested arrays.", line: 1, column: 6)
+            ],
+            macros: testMacros
+        )
+    }
+}

--- a/Tests/MLXMacrosTests/MLXLiteralMacroTests.swift
+++ b/Tests/MLXMacrosTests/MLXLiteralMacroTests.swift
@@ -120,6 +120,30 @@ final class MLXLiteralMacroTests: XCTestCase {
         assertMacroExpansion(
             "#mlx([[1.25, 2], [3.5, 4]], dtype: .int8)",
             expandedSource: "MLXArray(converting: [1.25, 2, 3.5, 4], [2, 2]).asType(.int8)",
+            diagnostics: [
+                DiagnosticSpec(
+                    message:
+                        "#mlx integer dtype with floating-point literal(s) may truncate values during conversion.",
+                    line: 1,
+                    column: 8,
+                    severity: .warning)
+            ],
+            macros: testMacros
+        )
+    }
+
+    func testWarnsOnIntegerDtypeWithFloatLiteral() {
+        assertMacroExpansion(
+            "#mlx([[1, 2.5], [3, 4]], dtype: .int16)",
+            expandedSource: "MLXArray(converting: [1, 2.5, 3, 4], [2, 2]).asType(.int16)",
+            diagnostics: [
+                DiagnosticSpec(
+                    message:
+                        "#mlx integer dtype with floating-point literal(s) may truncate values during conversion.",
+                    line: 1,
+                    column: 11,
+                    severity: .warning)
+            ],
             macros: testMacros
         )
     }

--- a/Tests/MLXMacrosTests/MLXLiteralMacroTests.swift
+++ b/Tests/MLXMacrosTests/MLXLiteralMacroTests.swift
@@ -27,6 +27,14 @@ final class MLXLiteralMacroTests: XCTestCase {
         )
     }
 
+    func testExpandsBooleanLiteral() {
+        assertMacroExpansion(
+            "#mlx([[true, false], [false, true]])",
+            expandedSource: "MLXArray([true, false, false, true], [2, 2])",
+            macros: testMacros
+        )
+    }
+
     func testExpandsWithDtypeCast() {
         assertMacroExpansion(
             "#mlx([[1, 2], [3, 4]], dtype: .int16)",
@@ -63,6 +71,14 @@ final class MLXLiteralMacroTests: XCTestCase {
         assertMacroExpansion(
             "#mlx([[1.0, 2.0], [3.0, 4.0]], dtype: .float64)",
             expandedSource: "MLXArray(converting: [1.0, 2.0, 3.0, 4.0], [2, 2]).asType(.float64)",
+            macros: testMacros
+        )
+    }
+
+    func testExpandsBoolDtypeFromZeroOneLiterals() {
+        assertMacroExpansion(
+            "#mlx([[0, 1], [1, 0]], dtype: .bool)",
+            expandedSource: "MLXArray([false, true, true, false], [2, 2])",
             macros: testMacros
         )
     }
@@ -143,6 +159,34 @@ final class MLXLiteralMacroTests: XCTestCase {
                     line: 1,
                     column: 11,
                     severity: .warning)
+            ],
+            macros: testMacros
+        )
+    }
+
+    func testRejectsBoolDtypeWithOutOfRangeIntegerLiterals() {
+        assertMacroExpansion(
+            "#mlx([[0, 2], [1, 0]], dtype: .bool)",
+            expandedSource: "MLXArray([])",
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "#mlx dtype .bool only supports integer literals 0 or 1.",
+                    line: 1,
+                    column: 11)
+            ],
+            macros: testMacros
+        )
+    }
+
+    func testRejectsBoolDtypeWithFloatLiterals() {
+        assertMacroExpansion(
+            "#mlx([[0.0, 1.0]], dtype: .bool)",
+            expandedSource: "MLXArray([])",
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "#mlx dtype .bool only supports true/false literals or integer 0/1.",
+                    line: 1,
+                    column: 27)
             ],
             macros: testMacros
         )

--- a/Tests/MLXMacrosTests/MLXLiteralMacroTests.swift
+++ b/Tests/MLXMacrosTests/MLXLiteralMacroTests.swift
@@ -7,13 +7,13 @@ import XCTest
 @testable import MLXMacrosPlugin
 
 private let testMacros: [String: Macro.Type] = [
-    "mlx": MLXLiteralMacro.self
+    "MLXArray": MLXLiteralMacro.self,
 ]
 
 final class MLXLiteralMacroTests: XCTestCase {
     func testExpandsIntegerLiteral() {
         assertMacroExpansion(
-            "#mlx([[1, 2], [3, 4]])",
+            "#MLXArray([[1, 2], [3, 4]])",
             expandedSource: "MLXArray([1, 2, 3, 4], [2, 2])",
             macros: testMacros
         )
@@ -21,7 +21,7 @@ final class MLXLiteralMacroTests: XCTestCase {
 
     func testExpandsFloatLiteral() {
         assertMacroExpansion(
-            "#mlx([[0.1, 0.2], [0.3, 0.4]])",
+            "#MLXArray([[0.1, 0.2], [0.3, 0.4]])",
             expandedSource: "MLXArray(converting: [0.1, 0.2, 0.3, 0.4], [2, 2])",
             macros: testMacros
         )
@@ -29,7 +29,7 @@ final class MLXLiteralMacroTests: XCTestCase {
 
     func testExpandsBooleanLiteral() {
         assertMacroExpansion(
-            "#mlx([[true, false], [false, true]])",
+            "#MLXArray([[true, false], [false, true]])",
             expandedSource: "MLXArray([true, false, false, true], [2, 2])",
             macros: testMacros
         )
@@ -37,7 +37,7 @@ final class MLXLiteralMacroTests: XCTestCase {
 
     func testExpandsWithDtypeCast() {
         assertMacroExpansion(
-            "#mlx([[1, 2], [3, 4]], dtype: .int16)",
+            "#MLXArray([[1, 2], [3, 4]], dtype: .int16)",
             expandedSource: "MLXArray([Int16(1), Int16(2), Int16(3), Int16(4)], [2, 2])",
             macros: testMacros
         )
@@ -45,7 +45,7 @@ final class MLXLiteralMacroTests: XCTestCase {
 
     func testExpandsIntegerLiteralWithInt64Dtype() {
         assertMacroExpansion(
-            "#mlx([[1, 2], [3, 4]], dtype: .int64)",
+            "#MLXArray([[1, 2], [3, 4]], dtype: .int64)",
             expandedSource: "MLXArray([Int64(1), Int64(2), Int64(3), Int64(4)], [2, 2])",
             macros: testMacros
         )
@@ -53,7 +53,7 @@ final class MLXLiteralMacroTests: XCTestCase {
 
     func testExpandsIntegerLiteralWithUInt8Dtype() {
         assertMacroExpansion(
-            "#mlx([[1, 2], [3, 4]], dtype: .uint8)",
+            "#MLXArray([[1, 2], [3, 4]], dtype: .uint8)",
             expandedSource: "MLXArray([UInt8(1), UInt8(2), UInt8(3), UInt8(4)], [2, 2])",
             macros: testMacros
         )
@@ -61,7 +61,7 @@ final class MLXLiteralMacroTests: XCTestCase {
 
     func testExpandsIntegerLiteralWithFloat32Dtype() {
         assertMacroExpansion(
-            "#mlx([[1, 2], [3, 4]], dtype: .float32)",
+            "#MLXArray([[1, 2], [3, 4]], dtype: .float32)",
             expandedSource: "MLXArray([Float(1), Float(2), Float(3), Float(4)], [2, 2])",
             macros: testMacros
         )
@@ -69,7 +69,7 @@ final class MLXLiteralMacroTests: XCTestCase {
 
     func testFallsBackToAsTypeForFloat64Dtype() {
         assertMacroExpansion(
-            "#mlx([[1.0, 2.0], [3.0, 4.0]], dtype: .float64)",
+            "#MLXArray([[1.0, 2.0], [3.0, 4.0]], dtype: .float64)",
             expandedSource: "MLXArray(converting: [1.0, 2.0, 3.0, 4.0], [2, 2]).asType(.float64)",
             macros: testMacros
         )
@@ -77,7 +77,7 @@ final class MLXLiteralMacroTests: XCTestCase {
 
     func testExpandsBoolDtypeFromZeroOneLiterals() {
         assertMacroExpansion(
-            "#mlx([[0, 1], [1, 0]], dtype: .bool)",
+            "#MLXArray([[0, 1], [1, 0]], dtype: .bool)",
             expandedSource: "MLXArray([false, true, true, false], [2, 2])",
             macros: testMacros
         )
@@ -85,7 +85,7 @@ final class MLXLiteralMacroTests: XCTestCase {
 
     func testFallsBackToAsTypeForDynamicDtypeExpression() {
         assertMacroExpansion(
-            "#mlx([[1, 2], [3, 4]], dtype: dtypeValue)",
+            "#MLXArray([[1, 2], [3, 4]], dtype: dtypeValue)",
             expandedSource: "MLXArray([1, 2, 3, 4], [2, 2]).asType(dtypeValue)",
             macros: testMacros
         )
@@ -93,7 +93,7 @@ final class MLXLiteralMacroTests: XCTestCase {
 
     func testExpandsThreeDimensionalIntegerLiteral() {
         assertMacroExpansion(
-            "#mlx([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])",
+            "#MLXArray([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])",
             expandedSource: "MLXArray([1, 2, 3, 4, 5, 6, 7, 8], [2, 2, 2])",
             macros: testMacros
         )
@@ -101,7 +101,7 @@ final class MLXLiteralMacroTests: XCTestCase {
 
     func testExpandsFourDimensionalFloatLiteral() {
         assertMacroExpansion(
-            "#mlx([[[[0.1, 0.2]], [[0.3, 0.4]]], [[[0.5, 0.6]], [[0.7, 0.8]]]])",
+            "#MLXArray([[[[0.1, 0.2]], [[0.3, 0.4]]], [[[0.5, 0.6]], [[0.7, 0.8]]]])",
             expandedSource:
                 "MLXArray(converting: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8], [2, 2, 1, 2])",
             macros: testMacros
@@ -110,7 +110,7 @@ final class MLXLiteralMacroTests: XCTestCase {
 
     func testExpandsMixedIntegerFloatLiteralAsFloat() {
         assertMacroExpansion(
-            "#mlx([[1, 2.5], [3, 4.5]])",
+            "#MLXArray([[1, 2.5], [3, 4.5]])",
             expandedSource: "MLXArray(converting: [1, 2.5, 3, 4.5], [2, 2])",
             macros: testMacros
         )
@@ -118,7 +118,7 @@ final class MLXLiteralMacroTests: XCTestCase {
 
     func testExpandsSingleFloatElementAsFloatLiteral() {
         assertMacroExpansion(
-            "#mlx([[1, 2], [3, 4.5]])",
+            "#MLXArray([[1, 2], [3, 4.5]])",
             expandedSource: "MLXArray(converting: [1, 2, 3, 4.5], [2, 2])",
             macros: testMacros
         )
@@ -126,7 +126,7 @@ final class MLXLiteralMacroTests: XCTestCase {
 
     func testExpandsDeepLiteralWithFloat16Dtype() {
         assertMacroExpansion(
-            "#mlx([[[1, 2], [3, 4]]], dtype: .float16)",
+            "#MLXArray([[[1, 2], [3, 4]]], dtype: .float16)",
             expandedSource: "MLXArray([1, 2, 3, 4], [1, 2, 2]).asType(.float16)",
             macros: testMacros
         )
@@ -134,14 +134,14 @@ final class MLXLiteralMacroTests: XCTestCase {
 
     func testExpandsMixedLiteralWithInt8Dtype() {
         assertMacroExpansion(
-            "#mlx([[1.25, 2], [3.5, 4]], dtype: .int8)",
+            "#MLXArray([[1.25, 2], [3.5, 4]], dtype: .int8)",
             expandedSource: "MLXArray(converting: [1.25, 2, 3.5, 4], [2, 2]).asType(.int8)",
             diagnostics: [
                 DiagnosticSpec(
                     message:
-                        "#mlx integer dtype with floating-point literal(s) may truncate values during conversion.",
+                        "#MLXArray integer dtype with floating-point literal(s) may truncate values during conversion.",
                     line: 1,
-                    column: 8,
+                    column: 13,
                     severity: .warning)
             ],
             macros: testMacros
@@ -150,14 +150,14 @@ final class MLXLiteralMacroTests: XCTestCase {
 
     func testWarnsOnIntegerDtypeWithFloatLiteral() {
         assertMacroExpansion(
-            "#mlx([[1, 2.5], [3, 4]], dtype: .int16)",
+            "#MLXArray([[1, 2.5], [3, 4]], dtype: .int16)",
             expandedSource: "MLXArray(converting: [1, 2.5, 3, 4], [2, 2]).asType(.int16)",
             diagnostics: [
                 DiagnosticSpec(
                     message:
-                        "#mlx integer dtype with floating-point literal(s) may truncate values during conversion.",
+                        "#MLXArray integer dtype with floating-point literal(s) may truncate values during conversion.",
                     line: 1,
-                    column: 11,
+                    column: 16,
                     severity: .warning)
             ],
             macros: testMacros
@@ -166,13 +166,13 @@ final class MLXLiteralMacroTests: XCTestCase {
 
     func testRejectsBoolDtypeWithOutOfRangeIntegerLiterals() {
         assertMacroExpansion(
-            "#mlx([[0, 2], [1, 0]], dtype: .bool)",
+            "#MLXArray([[0, 2], [1, 0]], dtype: .bool)",
             expandedSource: "MLXArray([])",
             diagnostics: [
                 DiagnosticSpec(
-                    message: "#mlx dtype .bool only supports integer literals 0 or 1.",
+                    message: "#MLXArray dtype .bool only supports integer literals 0 or 1.",
                     line: 1,
-                    column: 11)
+                    column: 16)
             ],
             macros: testMacros
         )
@@ -180,13 +180,13 @@ final class MLXLiteralMacroTests: XCTestCase {
 
     func testRejectsBoolDtypeWithFloatLiterals() {
         assertMacroExpansion(
-            "#mlx([[0.0, 1.0]], dtype: .bool)",
+            "#MLXArray([[0.0, 1.0]], dtype: .bool)",
             expandedSource: "MLXArray([])",
             diagnostics: [
                 DiagnosticSpec(
-                    message: "#mlx dtype .bool only supports true/false literals or integer 0/1.",
+                    message: "#MLXArray dtype .bool only supports true/false literals or integer 0/1.",
                     line: 1,
-                    column: 27)
+                    column: 32)
             ],
             macros: testMacros
         )
@@ -194,11 +194,11 @@ final class MLXLiteralMacroTests: XCTestCase {
 
     func testRaggedLiteralDiagnostics() {
         assertMacroExpansion(
-            "#mlx([[1, 2], [3]])",
+            "#MLXArray([[1, 2], [3]])",
             expandedSource: "MLXArray([])",
             diagnostics: [
                 DiagnosticSpec(
-                    message: "#mlx does not support ragged nested arrays.", line: 1, column: 6)
+                    message: "#MLXArray does not support ragged nested arrays.", line: 1, column: 11)
             ],
             macros: testMacros
         )

--- a/Tests/MLXMacrosTests/MLXLiteralMacroTests.swift
+++ b/Tests/MLXMacrosTests/MLXLiteralMacroTests.swift
@@ -7,7 +7,7 @@ import XCTest
 @testable import MLXMacrosPlugin
 
 private let testMacros: [String: Macro.Type] = [
-    "MLXArray": MLXLiteralMacro.self,
+    "MLXArray": MLXLiteralMacro.self
 ]
 
 final class MLXLiteralMacroTests: XCTestCase {
@@ -184,7 +184,8 @@ final class MLXLiteralMacroTests: XCTestCase {
             expandedSource: "MLXArray([])",
             diagnostics: [
                 DiagnosticSpec(
-                    message: "#MLXArray dtype .bool only supports true/false literals or integer 0/1.",
+                    message:
+                        "#MLXArray dtype .bool only supports true/false literals or integer 0/1.",
                     line: 1,
                     column: 32)
             ],
@@ -198,7 +199,8 @@ final class MLXLiteralMacroTests: XCTestCase {
             expandedSource: "MLXArray([])",
             diagnostics: [
                 DiagnosticSpec(
-                    message: "#MLXArray does not support ragged nested arrays.", line: 1, column: 11)
+                    message: "#MLXArray does not support ragged nested arrays.", line: 1, column: 11
+                )
             ],
             macros: testMacros
         )


### PR DESCRIPTION
## Proposed changes

Potential solution for #161.

This change introduces a new `#mlx(...)` expression macro to improve array literal ergonomics for `MLXArray` initialization while keeping expansion behavior explicit and testable:

- Adds `#mlx` as a public macro surface in `MLX`, so users can write:
  - `#mlx([[1, 2], [3, 4]])`
  - `#mlx([[1, 2], [3, 4]], dtype: .int16)`
- Validates nested literals are rectangular and numeric, and emits diagnostics for ragged/invalid input.
- Supports deep nested literals and shape inference during expansion.
- Implements dtype-aware expansion optimization:
  - Emits typed literal initialization directly for known integer dtypes and `.float32` (avoids a trailing `.asType(...)` cast).
  - Falls back to `.asType(...)` for dynamic dtype expressions and dtypes that do not cleanly map to Swift literal typing (`.float16`, `.bfloat16`, `.complex64`, `.float64`, `.bool`).
- Defines mixed literal promotion semantics:
  - If any literal element is floating-point, expansion uses floating-point construction for the full array.
  - Provides warning when float is used and explicit integer dtype is specified

Tests and docs:

- Adds macro unit tests covering:
  - integer, float, mixed, deep-nested literals
  - dtype-specific expansion behavior
  - fallback behavior for dynamic/non-native dtypes
  - ragged-literal diagnostics
  - compiler warning when mixing float literals with integer dtypes
- Updates DocC initialization docs with a macro section, examples, and mixed-literal promotion notes.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
