### PR TITLE
Use CXX 20, since MLX-C uses C++ 20 code

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -336,7 +336,7 @@ let package = Package(
             sources: ["CustomFunctionExampleSimple.swift"]
         ),
     ],
-    cxxLanguageStandard: .gnucxx17
+    cxxLanguageStandard: .gnucxx20
 )
 
 if Context.environment["MLX_SWIFT_BUILD_DOC"] == "1"


### PR DESCRIPTION
`line.starts_with("model name")` fails to compile in C++ 17

## Proposed changes

The new MLX-C amalgamation fails to compile under C++ 17

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
