### PR TITLE
Fix dictionary key lookup in Module.update(parameters:)

### DIFF
--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -493,7 +493,7 @@ open class Module {
                 for (dictionaryKey, dictionaryItem) in dictionary {
                     let newKey = "\(key).\(dictionaryKey)"
                     let path = path + [dictionaryKey]
-                    if let valueItem = values[key] {
+                    if let valueItem = values[dictionaryKey] {
                         try apply(key: newKey, path: path, dictionaryItem, valueItem)
                     } else if verify.contains(.allModelKeysSet) {
                         try apply(key: newKey, path: path, dictionaryItem, .none)

--- a/Tests/MLXTests/ModuleTests.swift
+++ b/Tests/MLXTests/ModuleTests.swift
@@ -619,6 +619,21 @@ class ModuleTests: XCTestCase {
             "In verify none mode, parameters can be updated with a different shape")
     }
 
+    func testDictionaryParameterUpdate() {
+        class Model: Module {
+            var layers: [String: Linear] = ["a": Linear(2, 2)]
+        }
+
+        let m = Model()
+        eval(m)
+
+        m.update(parameters: m.mapParameters { MLXArray.ones(like: $0) })
+
+        let weight = m.layers["a"]!.weight
+        eval(weight)
+        XCTAssertEqual(weight[0, 0].item(Float.self), 1.0)
+    }
+
     func testQuantize() throws {
         class C: Module {
             @ModuleInfo


### PR DESCRIPTION
## Proposed changes

Fix incorrect dictionary key lookup in Module.update(parameters:verify:).
In the .dictionary, .dictionary case of the recursive apply function, values[key] uses the parent path component instead of values[dictionaryKey] (the current child key). This causes all parameters in [String: Module] or [String: MLXArray] dictionary properties to be silently skipped during updates.
```diff
-        if let valueItem = values[key] {
+        if let valueItem = values[dictionaryKey] {
```
Added testDictionaryParameters regression test in ModuleTests.swift.
Fixes #362 

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes (swift-formatter instead)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
