### PR TITLE
remove CI workaround -- no longer what we want

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -89,9 +89,6 @@ jobs:
 
       - name: Build SwiftPM (Xcode, macOS)
         shell: sh
-        env:
-          # workaround for CI failure
-          DEVELOPER_DIR: /Applications/Xcode-latest.app
         run: |
           xcodebuild -version
           xcrun --show-sdk-build-version
@@ -101,27 +98,18 @@ jobs:
 
       - name: Run Tests SwiftPM (Xcode, macOS)
         shell: sh
-        env:
-          # workaround for CI failure
-          DEVELOPER_DIR: /Applications/Xcode-latest.app
         run: |
           xcrun xctest ~/Library/Developer/Xcode/DerivedData/mlx-swift-*/Build/Products/Debug/CmlxTests.xctest
           xcrun xctest ~/Library/Developer/Xcode/DerivedData/mlx-swift-*/Build/Products/Debug/MLXTests.xctest
 
       - name: Build xcodeproj (Xcode, macOS)
         shell: sh
-        env:
-          # workaround for CI failure
-          DEVELOPER_DIR: /Applications/Xcode-latest.app
         run: |
           rm -rf ~/Library/Developer/Xcode/DerivedData/*
           cd xcode
           xcodebuild build-for-testing -scheme MLX -destination 'platform=macOS'
 
       - name: Run Tests xcodeproj (Xcode, macOS)
-        env:
-          # workaround for CI failure
-          DEVELOPER_DIR: /Applications/Xcode-latest.app
         working-directory: xcode
         run: ../.github/scripts/run-xcode-tests.sh
 


### PR DESCRIPTION
## Proposed changes

Remove `DEVELOPER_DIR` for CI as that workaround no longer works.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
