### PR TITLE
fix #364 -- x[.ellipsis] returns self instead of a "copy"

### DIFF
--- a/Source/MLX/MLXArray+Indexing.swift
+++ b/Source/MLX/MLXArray+Indexing.swift
@@ -532,7 +532,9 @@ func getItem(src: MLXArray, operation: MLXArrayIndexOperation, stream: StreamOrD
 {
     switch operation {
     case .ellipsis:
-        return src
+        // let y = x[.elllipsis] -- this should be a "copy", e.g. a full range
+        // slice.  getItemND() handles that, so fall back to it
+        return getItemND(src: src, operations: [operation], stream: stream)
 
     case .newAxis:
         return src.expandedDimensions(axis: 0, stream: stream)

--- a/Tests/MLXTests/MLXArray+IndexingTests.swift
+++ b/Tests/MLXTests/MLXArray+IndexingTests.swift
@@ -662,4 +662,18 @@ class MLXArrayIndexingTests: XCTestCase {
         assertEqual(b, expected)
     }
 
+    public func testCopyEllipsis() {
+        // https://github.com/ml-explore/mlx-swift/issues/364
+        let x = arange(0, 12).reshaped([3, 4])
+
+        // this should produce an independent copy of x -- they share the same backing
+        // but if y is mutated then x should have reference to the original values
+        let y = x[.ellipsis]
+
+        y[.ellipsis, 1] *= 10
+
+        // x and y should be different
+        XCTAssertFalse(x.allClose(y).all().item())
+    }
+
 }


### PR DESCRIPTION
## Proposed changes

Remove special case for `x[...]` that just returns self.  Test added.

Note: CI will fail until #366 is merged and this is rebased.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
