### PR TITLE
break init order dependency

### DIFF
--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -111,7 +111,6 @@ open class Module {
 
     /// Initializes the module.
     public init() {
-        buildCaches()
     }
 
     private func buildCaches() {


### PR DESCRIPTION
## Proposed changes

- fix #224
- lazily build _items and _setters after init is complete

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
