### PR TITLE
deprecate factory methods that have an implicit Float/.float32 type

### DIFF
--- a/Source/MLX/Documentation.docc/Articles/converting-python.md
+++ b/Source/MLX/Documentation.docc/Articles/converting-python.md
@@ -147,7 +147,7 @@ This is a mapping of `mx` free functions to their ``MLX`` counterparts.
 `all` | ``MLX/all(_:axes:keepDims:stream:)``
 `allclose` | ``MLX/allClose(_:_:rtol:atol:equalNaN:stream:)``
 `any` | ``MLX/any(_:axes:keepDims:stream:)``
-`arange` | ``MLX/arange(_:_:step:stream:)``
+`arange` | ``MLX/arange(_:stream:)-9st56``
 `arccos` | ``MLX/acos(_:stream:)``
 `arccosh` | ``MLX/acosh(_:stream:)``
 `arcsin` | ``MLX/asin(_:stream:)``

--- a/Source/MLX/Factory.swift
+++ b/Source/MLX/Factory.swift
@@ -465,7 +465,7 @@ extension MLXArray {
     ///
     /// ### See Also
     /// - <doc:initialization>
-    /// - ``arange(_:_:step:stream:)``
+    /// - ``arange(_:_:step:stream:)-3wme1``
     static public func arange(_ stop: Int, stream: StreamOrDevice = .default) -> MLXArray {
         MLX.arange(0, stop, stream: stream)
     }
@@ -535,7 +535,7 @@ extension MLXArray {
     ///
     /// ### See Also
     /// - <doc:initialization>
-    /// - ``arange(_:_:step:stream:)``
+    /// - ``arange(_:_:step:stream:)-3wme1``
     static public func arange(
         _ start: Int, _ stop: Int, step: Int = 1, dtype: DType, stream: StreamOrDevice = .default
     ) -> MLXArray {
@@ -1295,7 +1295,7 @@ public func linspace<T: HasDType>(
 ///
 /// ### See Also
 /// - <doc:initialization>
-/// - ``arange(_:_:step:stream:)``
+/// - ``arange(_:_:step:stream:)-563go``
 public func arange(_ stop: Int, stream: StreamOrDevice = .default) -> MLXArray {
     var result = mlx_array_new()
     mlx_arange(&result, 0, Double(stop), 1, DType.int32.cmlxDtype, stream.ctx)
@@ -1370,7 +1370,7 @@ public func arange(_ stop: Int, dtype: DType, stream: StreamOrDevice = .default)
 ///
 /// ### See Also
 /// - <doc:initialization>
-/// - ``arange(_:_:step:stream:)``
+/// - ``arange(_:_:step:stream:)-563go``
 public func arange(
     _ start: Int, _ stop: Int, step: Int = 1, dtype: DType, stream: StreamOrDevice = .default
 ) -> MLXArray {

--- a/Source/MLX/Factory.swift
+++ b/Source/MLX/Factory.swift
@@ -23,10 +23,29 @@ extension MLXArray {
     /// - ``zeros(like:stream:)``
     /// - ``ones(_:type:stream:)``
     static public func zeros(
-        _ shape: some Collection<Int>, type: (some HasDType).Type = Float.self,
+        _ shape: some Collection<Int>, type: (some HasDType).Type,
         stream: StreamOrDevice = .default
     ) -> MLXArray {
         MLX.zeros(shape, type: type, stream: stream)
+    }
+
+    /// Construct an array of zeros with default `Float` type.
+    ///
+    /// - Parameters:
+    ///     - shape: desired shape
+    ///     - stream: stream or device to evaluate on
+    ///
+    /// ### See Also
+    /// - <doc:initialization>
+    /// - ``zeros(_:type:stream:)``
+    @available(
+        *, deprecated, message: "specify the type explicitly, e.g. zeros([...], type: Float.self)"
+    )
+    static public func zeros(
+        _ shape: some Collection<Int>,
+        stream: StreamOrDevice = .default
+    ) -> MLXArray {
+        MLX.zeros(shape, type: Float.self, stream: stream)
     }
 
     /// Construct an array of zeros with a given ``DType``
@@ -91,10 +110,29 @@ extension MLXArray {
     /// - ``ones(like:stream:)``
     /// - ``zeros(_:type:stream:)``
     static public func ones(
-        _ shape: some Collection<Int>, type: (some HasDType).Type = Float.self,
+        _ shape: some Collection<Int>, type: (some HasDType).Type,
         stream: StreamOrDevice = .default
     ) -> MLXArray {
         MLX.ones(shape, type: type, stream: stream)
+    }
+
+    /// Construct an array of ones with default `Float` type.
+    ///
+    /// - Parameters:
+    ///     - shape: desired shape
+    ///     - stream: stream or device to evaluate on
+    ///
+    /// ### See Also
+    /// - <doc:initialization>
+    /// - ``ones(_:type:stream:)``
+    @available(
+        *, deprecated, message: "specify the type explicitly, e.g. ones([...], type: Float.self)"
+    )
+    static public func ones(
+        _ shape: some Collection<Int>,
+        stream: StreamOrDevice = .default
+    ) -> MLXArray {
+        MLX.ones(shape, type: Float.self, stream: stream)
     }
 
     /// Construct an array of ones with a given ``DType``
@@ -161,10 +199,31 @@ extension MLXArray {
     /// - <doc:initialization>
     /// - ``identity(_:type:stream:)``
     static public func eye(
-        _ n: Int, m: Int? = nil, k: Int = 0, type: (some HasDType).Type = Float.self,
+        _ n: Int, m: Int? = nil, k: Int = 0, type: (some HasDType).Type,
         stream: StreamOrDevice = .default
     ) -> MLXArray {
         MLX.eye(n, m: m, k: k, type: type, stream: stream)
+    }
+
+    /// Create an identity matrix or a general diagonal matrix with default `Float` type.
+    ///
+    /// - Parameters:
+    ///     - n: number of rows in the output
+    ///     - m: number of columns in the output -- equal to `n` if not specified
+    ///     - k: index of the diagonal
+    ///     - stream: stream or device to evaluate on
+    ///
+    /// ### See Also
+    /// - <doc:initialization>
+    /// - ``eye(_:m:k:type:stream:)``
+    @available(
+        *, deprecated, message: "specify the type explicitly, e.g. eye(..., type: Float.self)"
+    )
+    static public func eye(
+        _ n: Int, m: Int? = nil, k: Int = 0,
+        stream: StreamOrDevice = .default
+    ) -> MLXArray {
+        MLX.eye(n, m: m, k: k, type: Float.self, stream: stream)
     }
 
     /// Create an identity matrix or a general diagonal matrix given a ``DType``.
@@ -215,7 +274,7 @@ extension MLXArray {
     /// - ``full(_:values:stream:)``
     /// - ``repeated(_:count:axis:stream:)``
     static public func full(
-        _ shape: some Collection<Int>, values: MLXArray, type: (some HasDType).Type = Float.self,
+        _ shape: some Collection<Int>, values: MLXArray, type: (some HasDType).Type,
         stream: StreamOrDevice = .default
     ) -> MLXArray {
         MLX.full(shape, values: values, type: type, stream: stream)
@@ -297,9 +356,27 @@ extension MLXArray {
     /// - <doc:initialization>
     /// - ``eye(_:m:k:type:stream:)``
     static public func identity(
-        _ n: Int, type: (some HasDType).Type = Float.self, stream: StreamOrDevice = .default
+        _ n: Int, type: (some HasDType).Type, stream: StreamOrDevice = .default
     ) -> MLXArray {
         MLX.identity(n, type: type, stream: stream)
+    }
+
+    /// Create a square identity matrix with default `Float` type.
+    ///
+    /// - Parameters:
+    ///     - n: number of rows and columns in the output
+    ///     - stream: stream or device to evaluate on
+    ///
+    /// ### See Also
+    /// - <doc:initialization>
+    /// - ``identity(_:type:stream:)``
+    @available(
+        *, deprecated, message: "specify the type explicitly, e.g. identity(..., type: Float.self)"
+    )
+    static public func identity(
+        _ n: Int, stream: StreamOrDevice = .default
+    ) -> MLXArray {
+        MLX.identity(n, type: Float.self, stream: stream)
     }
 
     /// Create a square identity matrix with a given ``DType``.
@@ -514,6 +591,74 @@ extension MLXArray {
         MLX.arange(start, stop, step: step, dtype: dtype, stream: stream)
     }
 
+    /// Generate values in the half-open interval `[0, stop)` inferring the dtype from the input type.
+    ///
+    /// This generic overload infers the output dtype from the Swift type of `stop`.
+    /// For example, `arange(Int16(10))` produces an `.int16` array.
+    ///
+    /// - Parameters:
+    ///     - stop: stop value
+    ///     - stream: stream or device to evaluate on
+    ///
+    /// ### See Also
+    /// - <doc:initialization>
+    /// - ``arange(_:stream:)-(Int,_)``
+    static public func arange<T: HasDType & BinaryInteger>(
+        _ stop: T, stream: StreamOrDevice = .default
+    ) -> MLXArray {
+        MLX.arange(stop, stream: stream)
+    }
+
+    /// Generate values in the half-open interval `[start, stop)` spaced by `step`, inferring the dtype from the input type.
+    ///
+    /// - Parameters:
+    ///     - start: start value
+    ///     - stop: stop value
+    ///     - step: step size (default: 1)
+    ///     - stream: stream or device to evaluate on
+    ///
+    /// ### See Also
+    /// - <doc:initialization>
+    static public func arange<T: HasDType & BinaryInteger>(
+        _ start: T, _ stop: T, step: T = 1, stream: StreamOrDevice = .default
+    ) -> MLXArray {
+        MLX.arange(start, stop, step: step, stream: stream)
+    }
+
+    /// Generate values in the half-open interval `[0, stop)` inferring the dtype from the input type (floating point version).
+    ///
+    /// This generic overload infers the output dtype from the Swift type of `stop`.
+    /// For example, `arange(Float16(5.0))` produces a `.float16` array.
+    ///
+    /// - Parameters:
+    ///     - stop: stop value
+    ///     - stream: stream or device to evaluate on
+    ///
+    /// ### See Also
+    /// - <doc:initialization>
+    /// - ``arange(_:dtype:stream:)-(Double,_,_)``
+    static public func arange<T: HasDType & BinaryFloatingPoint>(
+        _ stop: T, stream: StreamOrDevice = .default
+    ) -> MLXArray {
+        MLX.arange(stop, stream: stream)
+    }
+
+    /// Generate values in the half-open interval `[start, stop)` spaced by `step`, inferring the dtype from the input type (floating point version).
+    ///
+    /// - Parameters:
+    ///     - start: start value
+    ///     - stop: stop value
+    ///     - step: step size
+    ///     - stream: stream or device to evaluate on
+    ///
+    /// ### See Also
+    /// - <doc:initialization>
+    static public func arange<T: HasDType & BinaryFloatingPoint>(
+        _ start: T, _ stop: T, step: T, stream: StreamOrDevice = .default
+    ) -> MLXArray {
+        MLX.arange(start, stop, step: step, stream: stream)
+    }
+
     /// Repeat an array along a specified axis.
     ///
     /// > Deprected in favor of the more consistently named ``repeated(_:count:axis:stream:)``
@@ -612,10 +757,31 @@ extension MLXArray {
     /// ### See Also
     /// - <doc:initialization>
     static public func tri(
-        _ n: Int, m: Int? = nil, k: Int = 0, type: (some HasDType).Type = Float.self,
+        _ n: Int, m: Int? = nil, k: Int = 0, type: (some HasDType).Type,
         stream: StreamOrDevice = .default
     ) -> MLXArray {
         MLX.tri(n, m: m, k: k, type: type, stream: stream)
+    }
+
+    /// An array with ones at and below the given diagonal and zeros elsewhere, with default `Float` type.
+    ///
+    /// - Parameters:
+    ///     - n: number of rows in the output
+    ///     - m: number of columns in the output -- equal to `n` if not specified
+    ///     - k: index of the diagonal
+    ///     - stream: stream or device to evaluate on
+    ///
+    /// ### See Also
+    /// - <doc:initialization>
+    /// - ``tri(_:m:k:type:stream:)``
+    @available(
+        *, deprecated, message: "specify the type explicitly, e.g. tri(..., type: Float.self)"
+    )
+    static public func tri(
+        _ n: Int, m: Int? = nil, k: Int = 0,
+        stream: StreamOrDevice = .default
+    ) -> MLXArray {
+        MLX.tri(n, m: m, k: k, type: Float.self, stream: stream)
     }
 
     /// An array with ones at and below the given diagonal and zeros elsewhere and a given ``DType``.
@@ -662,12 +828,31 @@ extension MLXArray {
 /// - ``zeros(like:stream:)``
 /// - ``ones(_:type:stream:)``
 public func zeros(
-    _ shape: some Collection<Int>, type: (some HasDType).Type = Float.self,
+    _ shape: some Collection<Int>, type: (some HasDType).Type,
     stream: StreamOrDevice = .default
 ) -> MLXArray {
     var result = mlx_array_new()
     mlx_zeros(&result, shape.map { Int32($0) }, shape.count, type.dtype.cmlxDtype, stream.ctx)
     return MLXArray(result)
+}
+
+/// Construct an array of zeros with default `Float` type.
+///
+/// - Parameters:
+///     - shape: desired shape
+///     - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - <doc:initialization>
+/// - ``zeros(_:type:stream:)``
+@available(
+    *, deprecated, message: "specify the type explicitly, e.g. zeros([...], type: Float.self)"
+)
+public func zeros(
+    _ shape: some Collection<Int>,
+    stream: StreamOrDevice = .default
+) -> MLXArray {
+    zeros(shape, type: Float.self, stream: stream)
 }
 
 /// Construct an array of zeros with a given ``DType``
@@ -736,12 +921,31 @@ public func zeros(like array: MLXArray, stream: StreamOrDevice = .default) -> ML
 /// - ``ones(like:stream:)``
 /// - ``zeros(_:type:stream:)``
 public func ones(
-    _ shape: some Collection<Int>, type: (some HasDType).Type = Float.self,
+    _ shape: some Collection<Int>, type: (some HasDType).Type,
     stream: StreamOrDevice = .default
 ) -> MLXArray {
     var result = mlx_array_new()
     mlx_ones(&result, shape.map { Int32($0) }, shape.count, type.dtype.cmlxDtype, stream.ctx)
     return MLXArray(result)
+}
+
+/// Construct an array of ones with default `Float` type.
+///
+/// - Parameters:
+///     - shape: desired shape
+///     - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - <doc:initialization>
+/// - ``ones(_:type:stream:)``
+@available(
+    *, deprecated, message: "specify the type explicitly, e.g. ones([...], type: Float.self)"
+)
+public func ones(
+    _ shape: some Collection<Int>,
+    stream: StreamOrDevice = .default
+) -> MLXArray {
+    ones(shape, type: Float.self, stream: stream)
 }
 
 /// Construct an array of ones with a given ``DType``
@@ -812,12 +1016,31 @@ public func ones(like array: MLXArray, stream: StreamOrDevice = .default) -> MLX
 /// - <doc:initialization>
 /// - ``identity(_:type:stream:)``
 public func eye(
-    _ n: Int, m: Int? = nil, k: Int = 0, type: (some HasDType).Type = Float.self,
+    _ n: Int, m: Int? = nil, k: Int = 0, type: (some HasDType).Type,
     stream: StreamOrDevice = .default
 ) -> MLXArray {
     var result = mlx_array_new()
     mlx_eye(&result, n.int32, (m ?? n).int32, k.int32, type.dtype.cmlxDtype, stream.ctx)
     return MLXArray(result)
+}
+
+/// Create an identity matrix or a general diagonal matrix with default `Float` type.
+///
+/// - Parameters:
+///     - n: number of rows in the output
+///     - m: number of columns in the output -- equal to `n` if not specified
+///     - k: index of the diagonal
+///     - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - <doc:initialization>
+/// - ``eye(_:m:k:type:stream:)``
+@available(*, deprecated, message: "specify the type explicitly, e.g. eye(..., type: Float.self)")
+public func eye(
+    _ n: Int, m: Int? = nil, k: Int = 0,
+    stream: StreamOrDevice = .default
+) -> MLXArray {
+    eye(n, m: m, k: k, type: Float.self, stream: stream)
 }
 
 /// Create an identity matrix or a general diagonal matrix given a ``DType``.
@@ -957,11 +1180,29 @@ public func full(
 /// - <doc:initialization>
 /// - ``eye(_:m:k:type:stream:)``
 public func identity(
-    _ n: Int, type: (some HasDType).Type = Float.self, stream: StreamOrDevice = .default
+    _ n: Int, type: (some HasDType).Type, stream: StreamOrDevice = .default
 ) -> MLXArray {
     var result = mlx_array_new()
     mlx_identity(&result, n.int32, type.dtype.cmlxDtype, stream.ctx)
     return MLXArray(result)
+}
+
+/// Create a square identity matrix with default `Float` type.
+///
+/// - Parameters:
+///     - n: number of rows and columns in the output
+///     - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - <doc:initialization>
+/// - ``identity(_:type:stream:)``
+@available(
+    *, deprecated, message: "specify the type explicitly, e.g. identity(..., type: Float.self)"
+)
+public func identity(
+    _ n: Int, stream: StreamOrDevice = .default
+) -> MLXArray {
+    identity(n, type: Float.self, stream: stream)
 }
 
 /// Create a square identity matrix with a given ``DType``.
@@ -1191,6 +1432,82 @@ public func arange(
     return MLXArray(result)
 }
 
+/// Generate values in the half-open interval `[0, stop)` inferring the dtype from the input type.
+///
+/// This generic overload infers the output dtype from the Swift type of `stop`.
+/// For example, `arange(Int16(10))` produces an `.int16` array.
+///
+/// - Parameters:
+///     - stop: stop value
+///     - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - <doc:initialization>
+/// - ``arange(_:stream:)-(Int,_)``
+public func arange<T: HasDType & BinaryInteger>(
+    _ stop: T, stream: StreamOrDevice = .default
+) -> MLXArray {
+    var result = mlx_array_new()
+    mlx_arange(&result, 0, Double(stop), 1, T.dtype.cmlxDtype, stream.ctx)
+    return MLXArray(result)
+}
+
+/// Generate values in the half-open interval `[start, stop)` spaced by `step`, inferring the dtype from the input type.
+///
+/// - Parameters:
+///     - start: start value
+///     - stop: stop value
+///     - step: step size (default: 1)
+///     - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - <doc:initialization>
+public func arange<T: HasDType & BinaryInteger>(
+    _ start: T, _ stop: T, step: T = 1, stream: StreamOrDevice = .default
+) -> MLXArray {
+    var result = mlx_array_new()
+    mlx_arange(&result, Double(start), Double(stop), Double(step), T.dtype.cmlxDtype, stream.ctx)
+    return MLXArray(result)
+}
+
+/// Generate values in the half-open interval `[0, stop)` inferring the dtype from the input type (floating point version).
+///
+/// This generic overload infers the output dtype from the Swift type of `stop`.
+/// For example, `arange(Float16(5.0))` produces a `.float16` array.
+///
+/// - Parameters:
+///     - stop: stop value
+///     - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - <doc:initialization>
+/// - ``arange(_:dtype:stream:)-(Double,_,_)``
+public func arange<T: HasDType & BinaryFloatingPoint>(
+    _ stop: T, stream: StreamOrDevice = .default
+) -> MLXArray {
+    var result = mlx_array_new()
+    mlx_arange(&result, 0, Double(stop), 1, T.dtype.cmlxDtype, stream.ctx)
+    return MLXArray(result)
+}
+
+/// Generate values in the half-open interval `[start, stop)` spaced by `step`, inferring the dtype from the input type (floating point version).
+///
+/// - Parameters:
+///     - start: start value
+///     - stop: stop value
+///     - step: step size
+///     - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - <doc:initialization>
+public func arange<T: HasDType & BinaryFloatingPoint>(
+    _ start: T, _ stop: T, step: T, stream: StreamOrDevice = .default
+) -> MLXArray {
+    var result = mlx_array_new()
+    mlx_arange(&result, Double(start), Double(stop), Double(step), T.dtype.cmlxDtype, stream.ctx)
+    return MLXArray(result)
+}
+
 /// Repeat an array along a specified axis.
 ///
 /// > Deprected in favor of the more consistently named ``repeated(_:count:axis:stream:)``
@@ -1293,12 +1610,31 @@ public func repeated(_ array: MLXArray, count: Int, stream: StreamOrDevice = .de
 /// ### See Also
 /// - <doc:initialization>
 public func tri(
-    _ n: Int, m: Int? = nil, k: Int = 0, type: (some HasDType).Type = Float.self,
+    _ n: Int, m: Int? = nil, k: Int = 0, type: (some HasDType).Type,
     stream: StreamOrDevice = .default
 ) -> MLXArray {
     var result = mlx_array_new()
     mlx_tri(&result, n.int32, (m ?? n).int32, k.int32, type.dtype.cmlxDtype, stream.ctx)
     return MLXArray(result)
+}
+
+/// An array with ones at and below the given diagonal and zeros elsewhere, with default `Float` type.
+///
+/// - Parameters:
+///     - n: number of rows in the output
+///     - m: number of columns in the output -- equal to `n` if not specified
+///     - k: index of the diagonal
+///     - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - <doc:initialization>
+/// - ``tri(_:m:k:type:stream:)``
+@available(*, deprecated, message: "specify the type explicitly, e.g. tri(..., type: Float.self)")
+public func tri(
+    _ n: Int, m: Int? = nil, k: Int = 0,
+    stream: StreamOrDevice = .default
+) -> MLXArray {
+    tri(n, m: m, k: k, type: Float.self, stream: stream)
 }
 
 /// An array with ones at and below the given diagonal and zeros elsewhere and a given ``DType``.

--- a/Tests/MLXTests/MLXArray+IndexingTests.swift
+++ b/Tests/MLXTests/MLXArray+IndexingTests.swift
@@ -643,8 +643,8 @@ class MLXArrayIndexingTests: XCTestCase {
     public func testSliceWithBroadcast() {
         // https://github.com/ml-explore/mlx-swift/issues/76
 
-        let a = MLXArray.ones([2, 6, 6, 6])
-        let b = MLXArray.zeros([3, 4, 4, 4])
+        let a = MLXArray.ones([2, 6, 6, 6], type: Float.self)
+        let b = MLXArray.zeros([3, 4, 4, 4], type: Float.self)
 
         b[0, 0 ..< 4, 3, 0 ..< 4] = a[0, 1 ..< 5, 5, 1 ..< 5]
 

--- a/Tests/MLXTests/MLXArray+InitTests.swift
+++ b/Tests/MLXTests/MLXArray+InitTests.swift
@@ -201,6 +201,32 @@ class MLXArrayInitTests: XCTestCase {
         XCTAssertEqual(c.shape, [0])
     }
 
+    func testArangeDTypeInference() {
+        // Generic integer overloads infer dtype from Swift type
+        XCTAssertEqual(arange(Int16(10)).dtype, .int16)
+        XCTAssertEqual(arange(UInt8(5)).dtype, .uint8)
+        XCTAssertEqual(arange(Int8(0), Int8(10), step: Int8(2)).dtype, .int8)
+        XCTAssertEqual(arange(Int64(10)).dtype, .int64)
+        XCTAssertEqual(arange(UInt32(8)).dtype, .uint32)
+
+        // Generic floating point overload
+        XCTAssertEqual(arange(Float(5.0)).dtype, .float32)
+
+        // Existing concrete overloads remain unchanged
+        XCTAssertEqual(arange(10).dtype, .int32)
+        XCTAssertEqual(arange(5.0).dtype, .float32)
+
+        // Static method versions
+        XCTAssertEqual(MLXArray.arange(Int16(10)).dtype, .int16)
+        XCTAssertEqual(MLXArray.arange(UInt8(5)).dtype, .uint8)
+
+        #if !arch(x86_64)
+            // Float16 test (not available on x86_64)
+            XCTAssertEqual(arange(Float16(5.0)).dtype, .float16)
+            XCTAssertEqual(MLXArray.arange(Float16(3.0)).dtype, .float16)
+        #endif
+    }
+
     func testData() {
         let data = Data([1, 2, 3, 4])
         let a = MLXArray(data, [2, 2], type: UInt8.self)

--- a/Tests/MLXTests/MLXRandomTests.swift
+++ b/Tests/MLXTests/MLXRandomTests.swift
@@ -136,7 +136,7 @@ class MLXRandomTests: XCTestCase {
     func testLogits() {
         let key = MLXRandom.key(0)
 
-        let logits = MLXArray.zeros([5, 20])
+        let logits = MLXArray.zeros([5, 20], type: Float.self)
         let result = MLXRandom.categorical(logits, key: key)
 
         XCTAssertEqual(result.shape, [5])
@@ -149,7 +149,7 @@ class MLXRandomTests: XCTestCase {
     func testLogitsCount() {
         let key = MLXRandom.key(0)
 
-        let logits = MLXArray.zeros([5, 20])
+        let logits = MLXArray.zeros([5, 20], type: Float.self)
         let result = MLXRandom.categorical(logits, count: 2, key: key)
 
         XCTAssertEqual(result.shape, [5, 2])

--- a/Tests/MLXTests/ModuleTests.swift
+++ b/Tests/MLXTests/ModuleTests.swift
@@ -357,8 +357,8 @@ class ModuleTests: XCTestCase {
             @ModuleInfo var d: Linear?
 
             override init() {
-                _a.wrappedValue = MLXArray.zeros([10])
-                _b.wrappedValue = MLXArray.zeros([10])
+                _a.wrappedValue = MLXArray.zeros([10], type: Float.self)
+                _b.wrappedValue = MLXArray.zeros([10], type: Float.self)
                 _c.wrappedValue = Linear(10, 10)
                 _d.wrappedValue = Linear(10, 10)
             }
@@ -836,7 +836,8 @@ class ModuleTests: XCTestCase {
                 let loraScale = 1 / sqrt(Float(inputDimensions))
                 self._loraA.wrappedValue = MLXRandom.uniform(
                     low: -loraScale, high: loraScale, [inputDimensions, rank])
-                self._loraB.wrappedValue = MLXArray.zeros([rank, outputDimensions])
+                self._loraB.wrappedValue = MLXArray.zeros(
+                    [rank, outputDimensions], type: Float.self)
 
                 super.init()
 

--- a/Tests/MLXTests/OpsTests.swift
+++ b/Tests/MLXTests/OpsTests.swift
@@ -87,7 +87,7 @@ class OpsTests: XCTestCase {
     }
 
     func testFlatten() {
-        let a = zeros([4, 5, 6, 7])
+        let a = zeros([4, 5, 6, 7], type: Float.self)
         let b = flatten(a, startAxis: 1, endAxis: 2)
         let c = unflatten(b, axis: 1, shape: [5, 6])
         assertEqual(a, c)

--- a/Tests/MLXTests/OptimizerTests.swift
+++ b/Tests/MLXTests/OptimizerTests.swift
@@ -14,8 +14,8 @@ class OptimizerTests: XCTestCase {
     }
 
     class ShapeModule: Module {
-        let first = [MLXArray.zeros([10]), MLXArray.zeros([1])]
-        let second = MLXArray.zeros([1])
+        let first = [MLXArray.zeros([10], type: Float.self), MLXArray.zeros([1], type: Float.self)]
+        let second = MLXArray.zeros([1], type: Float.self)
     }
 
     func checkShape<T>(optimizer: OptimizerBase<T>) {

--- a/Tests/MLXTests/SaveTests.swift
+++ b/Tests/MLXTests/SaveTests.swift
@@ -34,8 +34,8 @@ final class SaveTests: XCTestCase {
         )
 
         let arrays: [String: MLXArray] = [
-            "foo": MLX.ones([1, 2]),
-            "bar": MLX.zeros([2, 1]),
+            "foo": MLX.ones([1, 2], type: Float.self),
+            "bar": MLX.zeros([2, 1], type: Float.self),
         ]
 
         try MLX.save(arrays: arrays, url: safetensorsPath)
@@ -54,7 +54,7 @@ final class SaveTests: XCTestCase {
             directoryHint: .notDirectory
         )
 
-        let array = MLX.ones([2, 4])
+        let array = MLX.ones([2, 4], type: Float.self)
 
         try MLX.save(array: array, url: path)
 
@@ -65,8 +65,8 @@ final class SaveTests: XCTestCase {
 
     public func testSaveArraysData() throws {
         let arrays: [String: MLXArray] = [
-            "foo": MLX.ones([1, 2]),
-            "bar": MLX.zeros([2, 1]),
+            "foo": MLX.ones([1, 2], type: Float.self),
+            "bar": MLX.zeros([2, 1], type: Float.self),
         ]
 
         let data = try saveToData(arrays: arrays)
@@ -79,8 +79,8 @@ final class SaveTests: XCTestCase {
 
     public func testSaveArraysMetadataData() throws {
         let arrays: [String: MLXArray] = [
-            "foo": MLX.ones([1, 2]),
-            "bar": MLX.zeros([2, 1]),
+            "foo": MLX.ones([1, 2], type: Float.self),
+            "bar": MLX.zeros([2, 1], type: Float.self),
         ]
         let metadata = [
             "key": "value",


### PR DESCRIPTION
# wait just a sec... not sure we want this

- fix #390

specifically this logically deprecates functions like this:

    static public func ones(
        _ shape: some Collection<Int>, type: (some HasDType).Type = Float.self,
        stream: StreamOrDevice = .default
    ) -> MLXArray {
        MLX.ones(shape, type: type, stream: stream)
    }

calling with no type will get a deprecation warning

## Proposed changes

Please include a description of the problem or feature this PR is addressing. If there is a corresponding issue, include the issue #.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
