### PR TITLE
fix: check mlx_detail_compile and mlx_closure_apply return values in CompiledFunction

### DIFF
--- a/Source/MLX/Transforms+Compile.swift
+++ b/Source/MLX/Transforms+Compile.swift
@@ -88,10 +88,18 @@ final class CompiledFunction: @unchecked (Sendable) {
         // but will be able to re-evaluate with fresh state if needed
         evalLock.lock()
         var compiled = mlx_closure_new()
-        mlx_detail_compile(&compiled, innerClosure, id, shapeless, [], 0)
+        let compileStatus = mlx_detail_compile(&compiled, innerClosure, id, shapeless, [], 0)
         defer {
             mlx_closure_free(compiled)
             evalLock.unlock()
+        }
+
+        // mlx_error was already dispatched on failure:
+        //   • outside withError — fatalError was called; we won't reach here
+        //   • inside withError  — error is stored in the ErrorBox; return [] so
+        //                         withError can throw instead of crashing downstream
+        guard compileStatus == 0 else {
+            return []
         }
 
         let innerInputs = arguments + stateInputs
@@ -101,8 +109,12 @@ final class CompiledFunction: @unchecked (Sendable) {
         // will compile the function (if needed) and evaluate the
         // compiled graph
         var resultVector = mlx_vector_array_new()
-        mlx_closure_apply(&resultVector, compiled, innerInputsVector)
+        let applyStatus = mlx_closure_apply(&resultVector, compiled, innerInputsVector)
         defer { mlx_vector_array_free(resultVector) }
+
+        guard applyStatus == 0 else {
+            return []
+        }
 
         let resultsPlusStateOutput = mlx_vector_array_values(resultVector)
 
@@ -164,7 +176,11 @@ public func compile(
     }
 
     return { a in
-        compileState.call([a])[0]
+        let r = compileState.call([a])
+        // r is empty only when an MLX error fired inside a withError scope — the
+        // error is already stored in the ErrorBox.  Return a placeholder so that
+        // withError can throw instead of crashing with "Index out of range".
+        return r.isEmpty ? MLXArray(0) : r[0]
     }
 }
 
@@ -185,7 +201,8 @@ public func compile(
     }
 
     return { a, b in
-        compileState.call([a, b])[0]
+        let r = compileState.call([a, b])
+        return r.isEmpty ? MLXArray(0) : r[0]
     }
 }
 
@@ -206,7 +223,8 @@ public func compile(
     }
 
     return { a, b, c in
-        compileState.call([a, b, c])[0]
+        let r = compileState.call([a, b, c])
+        return r.isEmpty ? MLXArray(0) : r[0]
     }
 }
 

--- a/Tests/MLXTests/TransformTests.swift
+++ b/Tests/MLXTests/TransformTests.swift
@@ -412,4 +412,65 @@ class TransformTests: XCTestCase {
 
     // Note: OptimizerTests contains additional integration tests of compile()
 
+    func testCompileSingleArrayErrorPropagatesViaWithError() throws {
+        // A compiled function that produces a broadcast shape mismatch at evaluation time.
+        // The constant has shape [3]; passing an input with shape [2] triggers an MLX error
+        // inside mlx_closure_apply.
+        //
+        // Before fix: mlx_closure_apply's non-zero return value was silently ignored,
+        // causing innerCall to return [], and the single-array overload to crash with
+        // "Fatal error: Index out of range" — a Swift trap that bypasses withError.
+        //
+        // After fix: innerCall returns [] early on error, the overload returns a placeholder,
+        // and withError properly surfaces the MLXError.
+        let compiled = compile { (x: MLXArray) -> MLXArray in
+            let constant = MLXArray([Float](repeating: 1, count: 3))
+            return x + constant
+        }
+        let x = MLXArray([Float](repeating: 0, count: 2))
+
+        XCTAssertThrowsError(
+            try withError {
+                eval(compiled(x))
+            }
+        ) { error in
+            XCTAssertTrue(error is MLXError, "expected MLXError, got \(error)")
+        }
+    }
+
+    func testCompileMultiArrayErrorPropagatesViaWithError() throws {
+        // Same scenario with the [MLXArray] -> [MLXArray] overload.
+        let compiled = compile { (inputs: [MLXArray]) -> [MLXArray] in
+            let constant = MLXArray([Float](repeating: 1, count: 3))
+            return [inputs[0] + constant]
+        }
+        let x = MLXArray([Float](repeating: 0, count: 2))
+
+        XCTAssertThrowsError(
+            try withError {
+                eval(compiled([x]))
+            }
+        ) { error in
+            XCTAssertTrue(error is MLXError, "expected MLXError, got \(error)")
+        }
+    }
+
+    func testCompileTwoArrayErrorPropagatesViaWithError() throws {
+        // Same scenario with the (MLXArray, MLXArray) -> MLXArray overload.
+        let compiled = compile { (a: MLXArray, _: MLXArray) -> MLXArray in
+            let constant = MLXArray([Float](repeating: 1, count: 3))
+            return a + constant
+        }
+        let x = MLXArray([Float](repeating: 0, count: 2))
+        let y = MLXArray([Float](repeating: 0, count: 2))
+
+        XCTAssertThrowsError(
+            try withError {
+                eval(compiled(x, y))
+            }
+        ) { error in
+            XCTAssertTrue(error is MLXError, "expected MLXError, got \(error)")
+        }
+    }
+
 }


### PR DESCRIPTION
## Proposed changes

Fixes #397.

`CompiledFunction.innerCall()` (`Source/MLX/Transforms+Compile.swift`) silently ignored the `int` return values of `mlx_detail_compile` and `mlx_closure_apply`. Both return `1` on failure and call `mlx_error()`. When called inside a `withError` scope the Swift error handler stores the error in an `ErrorBox` and execution continues — leaving `resultVector` empty. The single/two/three-array `compile` overloads then subscript into an empty array (`result[0]`), triggering a Swift trap that kills the process before `withError` can throw.

**Fix:**
- Capture the return value of `mlx_detail_compile`; `return []` from `innerCall` if it fails.
- Capture the return value of `mlx_closure_apply`; `return []` from `innerCall` if it fails.
- Guard against the empty-result crash in the three convenience overloads by replacing `compileState.call(...)[0]` with a safe `let r = ...; return r.isEmpty ? MLXArray(0) : r[0]`.

The placeholder `MLXArray(0)` returned by the overloads on the error path is never observed by the caller — `withError` throws `MLXError` before the value is used.

`MLXCustomFunction.swift:112` already uses the same pattern (`precondition(status == 0, ...)`) for its own `mlx_closure_apply` call; this PR makes `Transforms+Compile.swift` consistent.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)