### PR TITLE
feat: Add AdamW bias correction parameter.

### DIFF
--- a/Source/MLXOptimizers/Optimizers.swift
+++ b/Source/MLXOptimizers/Optimizers.swift
@@ -107,6 +107,32 @@ public struct TupleState: Updatable {
     }
 }
 
+/// State container for Adam-style optimizers that need first and second moments
+/// plus an update step for optional bias correction.
+public struct AdamState: Updatable {
+    let values: (MLXArray, MLXArray)
+    var step: MLXArray
+
+    init(_ values: (MLXArray, MLXArray), step: MLXArray) {
+        self.values = values
+        self.step = step
+    }
+
+    init(_ a: MLXArray, _ b: MLXArray, step: MLXArray) {
+        self.values = (a, b)
+        self.step = step
+    }
+
+    init(zeros array: MLXArray) {
+        self.values = (MLXArray.zeros(like: array), MLXArray.zeros(like: array))
+        self.step = MLXArray(0)
+    }
+
+    public func innerState() -> [MLXArray] {
+        [values.0, values.1, step]
+    }
+}
+
 /// Stochastic gradient descent optimizer.
 ///
 /// ### See Also
@@ -302,14 +328,14 @@ open class AdaDelta: OptimizerBase<TupleState> {
 
 /// The Adam optimizer [1].
 ///
-/// Our Adam implementation follows the original paper and omits the bias
-/// correction in the first and second moment estimates. In detail,
+/// By default our Adam implementation omits bias correction in the first and
+/// second moment estimates. Set `biasCorrection` to `true` to apply it. In detail,
 ///
 /// [1]: Kingma, D.P. and Ba, J., 2015. Adam: A method for stochastic optimization. ICLR 2015.
 ///
 /// ### See Also
 /// - <doc:MLXOptimizers>
-open class Adam: OptimizerBase<TupleState> {
+open class Adam: OptimizerBase<AdamState> {
 
     /// The learning rate
     public var learningRate: Float
@@ -317,41 +343,60 @@ open class Adam: OptimizerBase<TupleState> {
     public var betas: (Float, Float) = (0.9, 0.999)
     /// The epsilon added to the denominator to improve numerical stability
     public var eps: Float = 1e-8
+    /// If `true`, apply bias correction to the first and second moments
+    public var biasCorrection = false
 
     /// Initialize the optimizer.
     /// - Parameters:
     ///   - learningRate: the learning rate
     ///   - betas: coefficients used for computing running averages of the gradient and its square
     ///   - eps: the epsilon added to the denominator to improve numerical stability
-    public init(learningRate: Float, betas: (Float, Float) = (0.9, 0.999), eps: Float = 1e-8) {
+    ///   - biasCorrection: if `true`, apply bias correction to the first and second moments
+    public init(
+        learningRate: Float, betas: (Float, Float) = (0.9, 0.999), eps: Float = 1e-8,
+        biasCorrection: Bool = false
+    ) {
         self.learningRate = learningRate
         self.betas = betas
         self.eps = eps
+        self.biasCorrection = biasCorrection
     }
 
-    override open func newState(parameter: MLXArray) -> TupleState {
-        TupleState(zeros: parameter)
+    override open func newState(parameter: MLXArray) -> AdamState {
+        AdamState(zeros: parameter)
     }
 
-    override open func applySingle(gradient: MLXArray, parameter: MLXArray, state: TupleState) -> (
-        MLXArray, TupleState
+    override open func applySingle(gradient: MLXArray, parameter: MLXArray, state: AdamState) -> (
+        MLXArray, AdamState
     ) {
         let (b1, b2) = betas
 
+        var state = state
         var (m, v) = state.values
+        state.step = state.step + 1
 
         m = b1 * m + (1 - b1) * gradient
         v = b2 * v + (1 - b2) * square(gradient)
 
-        return (parameter - learningRate * m / (sqrt(v) + eps), TupleState(m, v))
+        let update: MLXArray
+        if biasCorrection {
+            let step = state.step
+            let c1 = learningRate / (1 - pow(b1, step))
+            let c2 = rsqrt(1 - pow(b2, step))
+            update = (c1 * m) / (sqrt(v) * c2 + eps)
+        } else {
+            update = learningRate * m / (sqrt(v) + eps)
+        }
+
+        return (parameter - update, AdamState(m, v, step: state.step))
     }
 }
 
 /// The AdamW optimizer [1].
 ///
-/// Following the above convention, in contrast with [1], we do not use bias
-/// correction in the first and second moments for AdamW. We update the weights
-/// with a `weightDecay` lambda value:
+/// By default AdamW omits bias correction in the first and second moments, to
+/// match the longstanding MLX Swift behavior. Set `biasCorrection` to `true`
+/// to apply it. We update the weights with a `weightDecay` lambda value:
 ///
 /// [1]: Loshchilov, I. and Hutter, F., 2019. Decoupled weight decay regularization. ICLR 2019.
 ///
@@ -368,16 +413,19 @@ open class AdamW: Adam {
     ///   - betas: coefficients used for computing running averages of the gradient and its square
     ///   - eps: the epsilon added to the denominator to improve numerical stability
     ///   - weightDecay:the weight decay
+    ///   - biasCorrection: if `true`, apply bias correction to the first and second moments
     public init(
         learningRate: Float, betas: (Float, Float) = (0.9, 0.999), eps: Float = 1e-8,
-        weightDecay: Float = 0.01
+        weightDecay: Float = 0.01, biasCorrection: Bool = false
     ) {
         self.weightDecay = weightDecay
-        super.init(learningRate: learningRate, betas: betas, eps: eps)
+        super.init(
+            learningRate: learningRate, betas: betas, eps: eps,
+            biasCorrection: biasCorrection)
     }
 
-    override open func applySingle(gradient: MLXArray, parameter: MLXArray, state: TupleState) -> (
-        MLXArray, TupleState
+    override open func applySingle(gradient: MLXArray, parameter: MLXArray, state: AdamState) -> (
+        MLXArray, AdamState
     ) {
         return super.applySingle(
             gradient: gradient, parameter: parameter * (1 - learningRate * weightDecay),

--- a/Tests/MLXTests/OptimizerTests.swift
+++ b/Tests/MLXTests/OptimizerTests.swift
@@ -151,10 +151,48 @@ class OptimizerTests: XCTestCase {
         checkTrain(optimizer: Adam(learningRate: 0.1), compile: true)
     }
 
+    func testAdamBiasCorrection() {
+        let parameter = MLXArray([1.0 as Float, -2.0, 3.0])
+        let gradient = MLXArray([0.5 as Float, -0.25, 2.0])
+        let optimizer = Adam(learningRate: 0.1 as Float, biasCorrection: true)
+
+        let result = optimizer.applySingle(
+            gradient: gradient, parameter: parameter,
+            state: optimizer.newState(parameter: parameter))
+
+        let step = MLXArray(1.0 as Float)
+        let c1 = Float(0.1) / (1 - pow(Float(0.9), step))
+        let c2 = rsqrt(1 - pow(Float(0.999), step))
+        let m = (1 - Float(0.9)) * gradient
+        let v = (1 - Float(0.999)) * square(gradient)
+        let expected = parameter - (c1 * m) / (sqrt(v) * c2 + Float(1e-8))
+        assertEqual(result.0, expected, atol: 1e-6)
+    }
+
     func testAdamW() {
         checkShape(optimizer: AdamW(learningRate: 0.1))
         checkTrain(optimizer: AdamW(learningRate: 0.1))
         checkTrain(optimizer: AdamW(learningRate: 0.1), compile: true)
+    }
+
+    func testAdamWBiasCorrection() {
+        let parameter = MLXArray([1.0 as Float, -2.0, 3.0])
+        let gradient = MLXArray([0.5 as Float, -0.25, 2.0])
+        let optimizer = AdamW(
+            learningRate: 0.1 as Float, weightDecay: 0.01 as Float, biasCorrection: true)
+
+        let result = optimizer.applySingle(
+            gradient: gradient, parameter: parameter,
+            state: optimizer.newState(parameter: parameter))
+
+        let decayed = parameter * (1 - Float(0.1) * Float(0.01))
+        let step = MLXArray(1.0 as Float)
+        let c1 = Float(0.1) / (1 - pow(Float(0.9), step))
+        let c2 = rsqrt(1 - pow(Float(0.999), step))
+        let m = (1 - Float(0.9)) * gradient
+        let v = (1 - Float(0.999)) * square(gradient)
+        let expected = decayed - (c1 * m) / (sqrt(v) * c2 + Float(1e-8))
+        assertEqual(result.0, expected, atol: 1e-6)
     }
 
     func testAdamax() {

--- a/skills/mlx-swift/references/optimizers.md
+++ b/skills/mlx-swift/references/optimizers.md
@@ -80,7 +80,8 @@ Adaptive Moment Estimation:
 let optimizer = Adam(
     learningRate: 0.001,
     betas: (0.9, 0.999),    // (β1, β2) for moment estimates
-    eps: 1e-8               // Numerical stability
+    eps: 1e-8,              // Numerical stability
+    biasCorrection: false   // Optional bias correction
 )
 ```
 
@@ -101,7 +102,8 @@ let optimizer = AdamW(
     learningRate: 0.001,
     betas: (0.9, 0.999),
     eps: 1e-8,
-    weightDecay: 0.01       // Weight decay factor
+    weightDecay: 0.01,      // Weight decay factor
+    biasCorrection: false   // Optional bias correction
 )
 ```
 


### PR DESCRIPTION
## Proposed changes

This PR adds a `biasCorrection` parameter to the Swift `Adam` and `AdamW` optimizers, matching the Python API and bias-corrected update rule used in MLX Python.

The main motivation is consistency with the Python implementation and easier comparison against PyTorch and other common optimizer implementations. I don't know if this falls within the goals of the mlx-swift project but I definitely encountered a situation where this was preventing close comparison with an MPSGraph implementation which was itself written to behave like PyTorch.

Internally, this requires tracking the optimizer step so the bias-correction factors can be applied:
- `1 - beta1^t`
- `1 - beta2^t`

To support that, this change replaces `TupleState` with an `AdamState` for `Adam`/`AdamW`, so the first moment, second moment, and step can be stored together.

This PR also adds tests for the bias-corrected `Adam` and `AdamW` paths and updates the relevant optimizer documentation.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
