### PR TITLE
package: exclude mlx/build cmake artifacts from Cmlx target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -146,6 +146,7 @@ let cmlx = Target.target(
         "mlx/python",
         "mlx/setup.py",
         "mlx/tests",
+        "mlx/build",
 
         // special handling for cuda -- we need to keep one file:
         // mlx/mlx/backend/cuda/no_cuda.cpp

--- a/Package.swift
+++ b/Package.swift
@@ -285,6 +285,7 @@ let cmlx = Target.target(
         "mlx/python",
         "mlx/setup.py",
         "mlx/tests",
+        "mlx/build",
 
         // build variants (we are opting _out_ of these)
         "mlx/mlx/io/no_safetensors.cpp",


### PR DESCRIPTION
## Problem

Running `cmake -B build` (standard cmake workflow) creates
`mlx/build/_deps/doctest-src/scripts/hello_world.cpp`, which contains
`main()`. SwiftPM scans the full Cmlx source tree and finds this file,
classifying the target as an executable instead of a library:

    error: module 'Cmlx' is the main module of an executable

## Fix

Add `"mlx/build"` to the `excludedSources` list of the Cmlx target.

## Impact

One line added to Package.swift. No API change, no behaviour change.
Lets contributors build mlx with `cmake -B build` alongside a Swift
consumer of the package without errors.
