### PR TITLE
ci: catch broken markdown links

### DIFF
--- a/.check-links-ignore
+++ b/.check-links-ignore
@@ -1,0 +1,15 @@
+# Paths that tools/check_links.py should skip: markdown files matching
+# a pattern are not scanned, and link targets matching a pattern are not
+# flagged as broken. One fnmatch glob per line, relative to the repository
+# root. Lines starting with # are comments.
+
+# Third-party sources -- we don't build docs for these:
+Source/Cmlx/fmt/*
+Source/Cmlx/json/*
+Source/Cmlx/metal-cpp/*
+
+# DocC cross-doc-package links; these resolve in the built documentation
+# (https://swiftpackageindex.com/ml-explore/mlx-swift/main/documentation/mlx):
+Source/*/Documentation.docc/mlx
+Source/*/Documentation.docc/mlxnn
+Source/*/Documentation.docc/mlxoptimizers

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -64,10 +64,10 @@ jobs:
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: Run style checks
+      - name: Run style and markdown link checks
         shell: sh
         run: |
-          pre-commit run --all || (echo "Style checks failed, please install pre-commit and run pre-commit run --all and push the change"; echo ""; git --no-pager diff; exit 1)
+          pre-commit run --all || (echo "Style or markdown link checks failed, please install pre-commit and run pre-commit run --all and push the change"; echo ""; git --no-pager diff; exit 1)
 
   docs:
     needs: lint

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,4 +1,0 @@
-^file://.*/Source/Cmlx/fmt/.*
-^file://.*/Source/Cmlx/json/.*
-^file://.*/Source/Cmlx/metal-cpp/.*
-^file://.*/Source/(MLX|MLXNN|MLXOptimizers)/Documentation\.docc/(mlx|mlxnn|mlxoptimizers)$

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,4 @@
+^file://.*/Source/Cmlx/fmt/.*
+^file://.*/Source/Cmlx/json/.*
+^file://.*/Source/Cmlx/metal-cpp/.*
+^file://.*/Source/(MLX|MLXNN|MLXOptimizers)/Documentation\.docc/(mlx|mlxnn|mlxoptimizers)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,12 @@ repos:
   rev: v0.6.10
   hooks:
     - id: cmake-format
+
+- repo: https://github.com/lycheeverse/lychee.git
+  rev: lychee-v0.24.2
+  hooks:
+    - id: lychee
+      args:
+        - --no-progress
+        - --offline
+      types: [markdown]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,16 +9,14 @@ repos:
       require_serial: true
       types: [swift]
 
+    - id: check-markdown-links
+      name: check markdown links
+      language: system
+      entry: python3 tools/check_links.py
+      require_serial: true
+      types: [markdown]
+
 - repo: https://github.com/cheshirekow/cmake-format-precommit
   rev: v0.6.10
   hooks:
     - id: cmake-format
-
-- repo: https://github.com/lycheeverse/lychee.git
-  rev: lychee-v0.24.2
-  hooks:
-    - id: lychee
-      args:
-        - --no-progress
-        - --offline
-      types: [markdown]

--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -7,6 +7,8 @@ with a short description of your contribution(s) below. For example:
 
 MLX Swift was developed with contributions from the following individuals:
 
+- [Ledio Berdellima](https://github.com/x-n2o): Added Markdown link checks in pre-commit/CI.
+
 <a href="https://github.com/ml-explore/mlx-swift/graphs/contributors">
   <img class="dark-light" src="https://contrib.rocks/image?repo=ml-explore/mlx-swift&anon=0&columns=20&max=100&r=true" />
 </a>

--- a/tools/check_links.py
+++ b/tools/check_links.py
@@ -2,10 +2,10 @@
 """
 Check for broken internal markdown links.
 Scans .md files for links like [text](Something.md) and reports
-any that point to files that don't exist. External links (http,
-https, mailto) and bare anchors are skipped, as are targets that
-resolve outside the repository (they cannot be validated from a
-checkout).
+any that point to files that don't exist. Links with a URL scheme
+or host (http, https, mailto, ...) and bare anchors are skipped,
+as are targets that resolve outside the repository (they cannot
+be validated from a checkout).
 
 Paths listed in .check-links-ignore at the repository root (one
 fnmatch glob per line, relative to the root) are also skipped:
@@ -18,13 +18,17 @@ Usage: python3 check_links.py <directory>
 
 The file form is used by pre-commit, which passes the tracked
 markdown files to check.
+
+Kept in sync between ml-explore/mlx-swift-examples (support/)
+and ml-explore/mlx-swift (tools/).
 """
 
 import fnmatch
+import os
 import re
 import sys
 from pathlib import Path
-from urllib.parse import unquote
+from urllib.parse import unquote, urlsplit
 
 
 # Directories to skip when scanning a directory
@@ -32,9 +36,11 @@ SKIP_DIRS = {'.git', '.build', '.swiftpm', 'vendor', 'node_modules'}
 
 IGNORE_FILE = '.check-links-ignore'
 
+LINK_PATTERN = re.compile(r'\[([^\]]*)\]\(([^)]+)\)')
+
 
 def load_ignore_patterns(base):
-    """Load link-target patterns to skip from .check-links-ignore."""
+    """Load path patterns to skip from .check-links-ignore."""
     ignore_file = base / IGNORE_FILE
     if not ignore_file.is_file():
         return []
@@ -48,72 +54,56 @@ def load_ignore_patterns(base):
 
 def is_ignored(path, base, ignore_patterns):
     """True if path (relative to base) matches an ignore pattern."""
-    try:
-        rel = path.relative_to(base)
-    except ValueError:
+    if not path.is_relative_to(base):
         return False
-    return any(fnmatch.fnmatch(str(rel), p) for p in ignore_patterns)
+    rel = str(path.relative_to(base))
+    return any(fnmatch.fnmatch(rel, p) for p in ignore_patterns)
 
 
 def find_all_md_files(directory):
     """Build a set of all .md file paths under the directory."""
     md_files = set()
-    for filepath in directory.rglob('*.md'):
-        if any(part in SKIP_DIRS for part in filepath.parts):
-            continue
-        md_files.add(filepath)
+    for dirpath, dirnames, filenames in os.walk(directory):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        md_files.update(
+            Path(dirpath) / name for name in filenames if name.endswith('.md'))
     return md_files
 
 
 def check_file(filepath, directory, ignore_patterns):
-    """Check all internal links in a file. Returns list of (source, line_num, link_text, target) tuples."""
+    """Check all internal links in a file. Returns a list of
+    (line_num, link_text, target) tuples for broken links."""
     broken = []
-    with open(filepath, 'r', encoding='utf-8') as f:
-        lines = f.readlines()
-
-    # Match [text](target) but skip external URLs
-    link_pattern = re.compile(r'\[([^\]]*)\]\(([^)]+)\)')
-
     in_code_block = False
-    for line_num, line in enumerate(lines, 1):
-        # Skip fenced code blocks -- their contents are not links
-        if line.lstrip().startswith(('```', '~~~')):
-            in_code_block = not in_code_block
-            continue
-        if in_code_block:
-            continue
-        for match in link_pattern.finditer(line):
-            display = match.group(1)
-            target = match.group(2)
-
-            # Skip external links
-            if target.startswith(('http://', 'https://', 'mailto:', '#')):
+    with open(filepath, 'r', encoding='utf-8') as f:
+        for line_num, line in enumerate(f, 1):
+            # Skip fenced code blocks -- their contents are not links
+            if line.lstrip().startswith(('```', '~~~')):
+                in_code_block = not in_code_block
                 continue
-
-            # Strip anchor fragments
-            target = target.split('#')[0]
-            if not target:
+            if in_code_block:
                 continue
+            for match in LINK_PATTERN.finditer(line):
+                display = match.group(1)
+                target = urlsplit(match.group(2))
 
-            # URL-decode (e.g. %20 -> space)
-            target = unquote(target)
+                # Skip external links and bare anchors
+                if target.scheme or target.netloc or not target.path:
+                    continue
 
-            # Resolve relative to the file's directory
-            target_path = (filepath.parent / target).resolve()
+                # URL-decode (e.g. %20 -> space) and resolve relative
+                # to the file's directory
+                target_path = (filepath.parent / unquote(target.path)).resolve()
 
-            # Targets outside the repository cannot be validated here
-            if not target_path.is_relative_to(directory):
-                continue
+                # Targets outside the repository cannot be validated here
+                if not target_path.is_relative_to(directory):
+                    continue
 
-            if is_ignored(target_path, directory, ignore_patterns):
-                continue
+                if is_ignored(target_path, directory, ignore_patterns):
+                    continue
 
-            if not target_path.exists():
-                try:
-                    rel_source = filepath.relative_to(directory)
-                except ValueError:
-                    rel_source = filepath
-                broken.append((rel_source, line_num, display, target))
+                if not target_path.exists():
+                    broken.append((line_num, display, target.path))
 
     return broken
 
@@ -132,27 +122,27 @@ def main():
 
     ignore_patterns = load_ignore_patterns(directory)
 
-    all_broken = []
+    by_file = {}
     for filepath in sorted(md_files):
         if is_ignored(filepath, directory, ignore_patterns):
             continue
-        all_broken.extend(check_file(filepath, directory, ignore_patterns))
+        broken = check_file(filepath, directory, ignore_patterns)
+        if broken:
+            rel = (filepath.relative_to(directory)
+                   if filepath.is_relative_to(directory) else filepath)
+            by_file[rel] = broken
 
-    if not all_broken:
+    if not by_file:
         print("No broken links found.")
         sys.exit(0)
 
-    # Group by source file
-    by_file = {}
-    for source, line_num, display, target in all_broken:
-        by_file.setdefault(source, []).append((line_num, display, target))
-
-    for source in sorted(by_file):
+    for source, broken in by_file.items():
         print(f"\n{source}:")
-        for line_num, display, target in by_file[source]:
+        for line_num, display, target in broken:
             print(f"  line {line_num}: [{display}]({target}) -> NOT FOUND")
 
-    print(f"\nTotal: {len(all_broken)} broken link(s) in {len(by_file)} file(s)")
+    total = sum(len(broken) for broken in by_file.values())
+    print(f"\nTotal: {total} broken link(s) in {len(by_file)} file(s)")
     sys.exit(1)
 
 

--- a/tools/check_links.py
+++ b/tools/check_links.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Check for broken internal markdown links.
+Scans .md files for links like [text](Something.md) and reports
+any that point to files that don't exist. External links (http,
+https, mailto) and bare anchors are skipped, as are targets that
+resolve outside the repository (they cannot be validated from a
+checkout).
+
+Paths listed in .check-links-ignore at the repository root (one
+fnmatch glob per line, relative to the root) are also skipped:
+markdown files matching a pattern are not scanned (e.g. vendored
+third-party docs), and link targets matching a pattern are not
+flagged as broken (e.g. targets that moved to another repository).
+
+Usage: python3 check_links.py <directory>
+       python3 check_links.py <file.md> [<file.md> ...]
+
+The file form is used by pre-commit, which passes the tracked
+markdown files to check.
+"""
+
+import fnmatch
+import re
+import sys
+from pathlib import Path
+from urllib.parse import unquote
+
+
+# Directories to skip when scanning a directory
+SKIP_DIRS = {'.git', '.build', '.swiftpm', 'vendor', 'node_modules'}
+
+IGNORE_FILE = '.check-links-ignore'
+
+
+def load_ignore_patterns(base):
+    """Load link-target patterns to skip from .check-links-ignore."""
+    ignore_file = base / IGNORE_FILE
+    if not ignore_file.is_file():
+        return []
+    patterns = []
+    for line in ignore_file.read_text(encoding='utf-8').splitlines():
+        line = line.strip()
+        if line and not line.startswith('#'):
+            patterns.append(line)
+    return patterns
+
+
+def is_ignored(path, base, ignore_patterns):
+    """True if path (relative to base) matches an ignore pattern."""
+    try:
+        rel = path.relative_to(base)
+    except ValueError:
+        return False
+    return any(fnmatch.fnmatch(str(rel), p) for p in ignore_patterns)
+
+
+def find_all_md_files(directory):
+    """Build a set of all .md file paths under the directory."""
+    md_files = set()
+    for filepath in directory.rglob('*.md'):
+        if any(part in SKIP_DIRS for part in filepath.parts):
+            continue
+        md_files.add(filepath)
+    return md_files
+
+
+def check_file(filepath, directory, ignore_patterns):
+    """Check all internal links in a file. Returns list of (source, line_num, link_text, target) tuples."""
+    broken = []
+    with open(filepath, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+
+    # Match [text](target) but skip external URLs
+    link_pattern = re.compile(r'\[([^\]]*)\]\(([^)]+)\)')
+
+    in_code_block = False
+    for line_num, line in enumerate(lines, 1):
+        # Skip fenced code blocks -- their contents are not links
+        if line.lstrip().startswith(('```', '~~~')):
+            in_code_block = not in_code_block
+            continue
+        if in_code_block:
+            continue
+        for match in link_pattern.finditer(line):
+            display = match.group(1)
+            target = match.group(2)
+
+            # Skip external links
+            if target.startswith(('http://', 'https://', 'mailto:', '#')):
+                continue
+
+            # Strip anchor fragments
+            target = target.split('#')[0]
+            if not target:
+                continue
+
+            # URL-decode (e.g. %20 -> space)
+            target = unquote(target)
+
+            # Resolve relative to the file's directory
+            target_path = (filepath.parent / target).resolve()
+
+            # Targets outside the repository cannot be validated here
+            if not target_path.is_relative_to(directory):
+                continue
+
+            if is_ignored(target_path, directory, ignore_patterns):
+                continue
+
+            if not target_path.exists():
+                try:
+                    rel_source = filepath.relative_to(directory)
+                except ValueError:
+                    rel_source = filepath
+                broken.append((rel_source, line_num, display, target))
+
+    return broken
+
+
+def main():
+    args = sys.argv[1:]
+    if len(args) == 1 and Path(args[0]).is_dir():
+        directory = Path(args[0]).resolve()
+        md_files = find_all_md_files(directory)
+    elif args:
+        directory = Path.cwd()
+        md_files = {Path(arg).resolve() for arg in args}
+    else:
+        print("Usage: python3 check_links.py <directory or markdown files>")
+        sys.exit(1)
+
+    ignore_patterns = load_ignore_patterns(directory)
+
+    all_broken = []
+    for filepath in sorted(md_files):
+        if is_ignored(filepath, directory, ignore_patterns):
+            continue
+        all_broken.extend(check_file(filepath, directory, ignore_patterns))
+
+    if not all_broken:
+        print("No broken links found.")
+        sys.exit(0)
+
+    # Group by source file
+    by_file = {}
+    for source, line_num, display, target in all_broken:
+        by_file.setdefault(source, []).append((line_num, display, target))
+
+    for source in sorted(by_file):
+        print(f"\n{source}:")
+        for line_num, display, target in by_file[source]:
+            print(f"  line {line_num}: [{display}]({target}) -> NOT FOUND")
+
+    print(f"\nTotal: {len(all_broken)} broken link(s) in {len(by_file)} file(s)")
+    sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Proposed changes

Adds a markdown link check to the existing pre-commit workflow so repository-local links are validated locally and in pull request CI. Per review feedback, this now uses a small local script (`tools/check_links.py`) instead of a third-party dependency — the same checker proposed in ml-explore/mlx-swift-examples#479; the two copies are kept in sync.

- pre-commit passes the tracked markdown files to the script; links with a URL scheme or host are skipped — matching the previous offline lychee behavior without the extra dependency. The script also supports a manual whole-tree scan: `python3 tools/check_links.py .`
- The earlier `.lycheeignore` is replaced by a `.check-links-ignore` blocklist (fnmatch globs, repo-root relative). Patterns skip both scanned files and link targets, covering the review feedback:
  - Third-party sources we don't build docs for are not scanned at all: `Source/Cmlx/fmt/*`, `Source/Cmlx/json/*`, `Source/Cmlx/metal-cpp/*` (this also silences false positives like C++ lambdas `[=](auto out)` in fmt's docs being parsed as markdown links).
  - DocC cross-doc-package links (`mlx`, `mlxnn`, `mlxoptimizers`) are not flagged — they resolve in the [built documentation](https://swiftpackageindex.com/ml-explore/mlx-swift/main/documentation/mlx), not as repository files.
- Links inside fenced code blocks are ignored, so the linkage example in `MAINTENANCE.md` is not flagged.

Unlike the examples repo (#479), no genuinely missing in-repo `.md` targets turned up: running the checker with an empty `.check-links-ignore` flags exactly the 7 links covered above — the fmt lambda and the six DocC cross-package links — all verified false positives, so there is nothing to track in issues here.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

Local run:

```
❯ pre-commit run --all
swift-format.............................................................Passed
check markdown links.....................................................Passed
cmake-format.............................................................Passed
```

False-positive audit — with an empty `.check-links-ignore`, the whole-tree scan flags only the known false positives, no real missing files:

```
❯ python3 tools/check_links.py .

Source/Cmlx/fmt/doc/api.md:
  line 173: [=](auto out) -> NOT FOUND

Source/MLX/Documentation.docc/MLX.md:
  line 69: [MLXNN](mlxnn) -> NOT FOUND
  line 70: [MLXOptimizers](mlxoptimizers) -> NOT FOUND

Source/MLXNN/Documentation.docc/MLXNN.md:
  line 46: [MLX](mlx) -> NOT FOUND
  line 47: [MLXOptimizers](mlxoptimizers) -> NOT FOUND

Source/MLXOptimizers/Documentation.docc/MLXOptimizers.md:
  line 34: [MLX](mlx) -> NOT FOUND
  line 35: [MLXNN](mlxnn) -> NOT FOUND

Total: 7 broken link(s) in 4 file(s)
```

