### PR TITLE
Deprecate Float-defaulted Factory functions (zeros/ones/eye/identity/tri)

### DIFF
--- a/Source/Examples/Tutorial.swift
+++ b/Source/Examples/Tutorial.swift
@@ -53,7 +53,7 @@ struct Tutorial {
         print(x[1])
 
         // make an array of shape [2, 2] filled with ones
-        let y = MLXArray.ones([2, 2])
+        let y = MLXArray.ones([2, 2], dtype: .float32)
 
         // pointwise add x and y
         let z = x + y

--- a/Source/MLX/Factory.swift
+++ b/Source/MLX/Factory.swift
@@ -23,10 +23,27 @@ extension MLXArray {
     /// - ``zeros(like:stream:)``
     /// - ``ones(_:type:stream:)``
     static public func zeros(
-        _ shape: some Collection<Int>, type: (some HasDType).Type = Float.self,
+        _ shape: some Collection<Int>, type: (some HasDType).Type,
         stream: StreamOrDevice = .default
     ) -> MLXArray {
         MLX.zeros(shape, type: type, stream: stream)
+    }
+
+    /// Construct an array of zeros, defaulting to `Float` (float32).
+    ///
+    /// > Deprecated: pass the dtype explicitly via ``zeros(_:dtype:stream:)``
+    /// or ``zeros(_:type:stream:)``. Allowing the dtype to default silently
+    /// promotes computations to float32, which can mask precision issues in
+    /// half-precision (bfloat16 / float16) pipelines. See
+    /// [ml-explore/mlx-swift#390](https://github.com/ml-explore/mlx-swift/issues/390).
+    @available(
+        *, deprecated,
+        message: "Pass dtype explicitly: zeros(shape, dtype: .float32) or zeros(shape, type: Float.self). See ml-explore/mlx-swift#390."
+    )
+    static public func zeros(
+        _ shape: some Collection<Int>, stream: StreamOrDevice = .default
+    ) -> MLXArray {
+        MLX.zeros(shape, dtype: .float32, stream: stream)
     }
 
     /// Construct an array of zeros with a given ``DType``
@@ -91,10 +108,25 @@ extension MLXArray {
     /// - ``ones(like:stream:)``
     /// - ``zeros(_:type:stream:)``
     static public func ones(
-        _ shape: some Collection<Int>, type: (some HasDType).Type = Float.self,
+        _ shape: some Collection<Int>, type: (some HasDType).Type,
         stream: StreamOrDevice = .default
     ) -> MLXArray {
         MLX.ones(shape, type: type, stream: stream)
+    }
+
+    /// Construct an array of ones, defaulting to `Float` (float32).
+    ///
+    /// > Deprecated: pass the dtype explicitly via ``ones(_:dtype:stream:)``
+    /// or ``ones(_:type:stream:)``. See
+    /// [ml-explore/mlx-swift#390](https://github.com/ml-explore/mlx-swift/issues/390).
+    @available(
+        *, deprecated,
+        message: "Pass dtype explicitly: ones(shape, dtype: .float32) or ones(shape, type: Float.self). See ml-explore/mlx-swift#390."
+    )
+    static public func ones(
+        _ shape: some Collection<Int>, stream: StreamOrDevice = .default
+    ) -> MLXArray {
+        MLX.ones(shape, dtype: .float32, stream: stream)
     }
 
     /// Construct an array of ones with a given ``DType``
@@ -147,7 +179,7 @@ extension MLXArray {
     ///
     /// ```swift
     /// //  create [10, 10] array with 1's on the diagonal.
-    /// let r = MLXArray.eye(10)
+    /// let r = MLXArray.eye(10, type: Int.self)
     /// ```
     ///
     /// - Parameters:
@@ -161,10 +193,25 @@ extension MLXArray {
     /// - <doc:initialization>
     /// - ``identity(_:type:stream:)``
     static public func eye(
-        _ n: Int, m: Int? = nil, k: Int = 0, type: (some HasDType).Type = Float.self,
+        _ n: Int, m: Int? = nil, k: Int = 0, type: (some HasDType).Type,
         stream: StreamOrDevice = .default
     ) -> MLXArray {
         MLX.eye(n, m: m, k: k, type: type, stream: stream)
+    }
+
+    /// Create an identity matrix or a general diagonal matrix, defaulting to `Float` (float32).
+    ///
+    /// > Deprecated: pass the dtype explicitly via ``eye(_:m:k:dtype:stream:)``
+    /// or ``eye(_:m:k:type:stream:)``. See
+    /// [ml-explore/mlx-swift#390](https://github.com/ml-explore/mlx-swift/issues/390).
+    @available(
+        *, deprecated,
+        message: "Pass dtype explicitly: eye(n, m:, k:, dtype: .float32) or eye(n, m:, k:, type: Float.self). See ml-explore/mlx-swift#390."
+    )
+    static public func eye(
+        _ n: Int, m: Int? = nil, k: Int = 0, stream: StreamOrDevice = .default
+    ) -> MLXArray {
+        MLX.eye(n, m: m, k: k, dtype: .float32, stream: stream)
     }
 
     /// Create an identity matrix or a general diagonal matrix given a ``DType``.
@@ -215,7 +262,7 @@ extension MLXArray {
     /// - ``full(_:values:stream:)``
     /// - ``repeated(_:count:axis:stream:)``
     static public func full(
-        _ shape: some Collection<Int>, values: MLXArray, type: (some HasDType).Type = Float.self,
+        _ shape: some Collection<Int>, values: MLXArray, type: (some HasDType).Type,
         stream: StreamOrDevice = .default
     ) -> MLXArray {
         MLX.full(shape, values: values, type: type, stream: stream)
@@ -285,7 +332,7 @@ extension MLXArray {
     ///
     /// ```swift
     /// //  create [10, 10] array with 1's on the diagonal.
-    /// let r = MLXArray.identity(10)
+    /// let r = MLXArray.identity(10, type: Int.self)
     /// ```
     ///
     /// - Parameters:
@@ -297,9 +344,22 @@ extension MLXArray {
     /// - <doc:initialization>
     /// - ``eye(_:m:k:type:stream:)``
     static public func identity(
-        _ n: Int, type: (some HasDType).Type = Float.self, stream: StreamOrDevice = .default
+        _ n: Int, type: (some HasDType).Type, stream: StreamOrDevice = .default
     ) -> MLXArray {
         MLX.identity(n, type: type, stream: stream)
+    }
+
+    /// Create a square identity matrix, defaulting to `Float` (float32).
+    ///
+    /// > Deprecated: pass the dtype explicitly via ``identity(_:dtype:stream:)``
+    /// or ``identity(_:type:stream:)``. See
+    /// [ml-explore/mlx-swift#390](https://github.com/ml-explore/mlx-swift/issues/390).
+    @available(
+        *, deprecated,
+        message: "Pass dtype explicitly: identity(n, dtype: .float32) or identity(n, type: Float.self). See ml-explore/mlx-swift#390."
+    )
+    static public func identity(_ n: Int, stream: StreamOrDevice = .default) -> MLXArray {
+        MLX.identity(n, dtype: .float32, stream: stream)
     }
 
     /// Create a square identity matrix with a given ``DType``.
@@ -599,7 +659,7 @@ extension MLXArray {
     ///
     /// ```swift
     /// // [5, 5] array with the lower triangle filled with 1s
-    /// let r = MLXArray.triangle(5)
+    /// let r = MLXArray.tri(5, type: Int.self)
     /// ```
     ///
     /// - Parameters:
@@ -612,10 +672,25 @@ extension MLXArray {
     /// ### See Also
     /// - <doc:initialization>
     static public func tri(
-        _ n: Int, m: Int? = nil, k: Int = 0, type: (some HasDType).Type = Float.self,
+        _ n: Int, m: Int? = nil, k: Int = 0, type: (some HasDType).Type,
         stream: StreamOrDevice = .default
     ) -> MLXArray {
         MLX.tri(n, m: m, k: k, type: type, stream: stream)
+    }
+
+    /// An array with ones at and below the given diagonal and zeros elsewhere, defaulting to `Float` (float32).
+    ///
+    /// > Deprecated: pass the dtype explicitly via ``tri(_:m:k:dtype:stream:)``
+    /// or ``tri(_:m:k:type:stream:)``. See
+    /// [ml-explore/mlx-swift#390](https://github.com/ml-explore/mlx-swift/issues/390).
+    @available(
+        *, deprecated,
+        message: "Pass dtype explicitly: tri(n, m:, k:, dtype: .float32) or tri(n, m:, k:, type: Float.self). See ml-explore/mlx-swift#390."
+    )
+    static public func tri(
+        _ n: Int, m: Int? = nil, k: Int = 0, stream: StreamOrDevice = .default
+    ) -> MLXArray {
+        MLX.tri(n, m: m, k: k, dtype: .float32, stream: stream)
     }
 
     /// An array with ones at and below the given diagonal and zeros elsewhere and a given ``DType``.
@@ -649,7 +724,7 @@ extension MLXArray {
 /// Example:
 ///
 /// ```swift
-/// let z = MLXArray.zeros([5, 10], type: Int.self)
+/// let z = zeros([5, 10], type: Int.self)
 /// ```
 ///
 /// - Parameters:
@@ -662,12 +737,27 @@ extension MLXArray {
 /// - ``zeros(like:stream:)``
 /// - ``ones(_:type:stream:)``
 public func zeros(
-    _ shape: some Collection<Int>, type: (some HasDType).Type = Float.self,
+    _ shape: some Collection<Int>, type: (some HasDType).Type,
     stream: StreamOrDevice = .default
 ) -> MLXArray {
     var result = mlx_array_new()
     mlx_zeros(&result, shape.map { Int32($0) }, shape.count, type.dtype.cmlxDtype, stream.ctx)
     return MLXArray(result)
+}
+
+/// Construct an array of zeros, defaulting to `Float` (float32).
+///
+/// > Deprecated: pass the dtype explicitly via ``zeros(_:dtype:stream:)``
+/// or ``zeros(_:type:stream:)``. See
+/// [ml-explore/mlx-swift#390](https://github.com/ml-explore/mlx-swift/issues/390).
+@available(
+    *, deprecated,
+    message: "Pass dtype explicitly: zeros(shape, dtype: .float32) or zeros(shape, type: Float.self). See ml-explore/mlx-swift#390."
+)
+public func zeros(
+    _ shape: some Collection<Int>, stream: StreamOrDevice = .default
+) -> MLXArray {
+    zeros(shape, dtype: .float32, stream: stream)
 }
 
 /// Construct an array of zeros with a given ``DType``
@@ -723,7 +813,7 @@ public func zeros(like array: MLXArray, stream: StreamOrDevice = .default) -> ML
 /// Example:
 ///
 /// ```swift
-/// let r = MLXArray.ones([5, 10], type: Int.self)
+/// let r = ones([5, 10], type: Int.self)
 /// ```
 ///
 /// - Parameters:
@@ -736,12 +826,27 @@ public func zeros(like array: MLXArray, stream: StreamOrDevice = .default) -> ML
 /// - ``ones(like:stream:)``
 /// - ``zeros(_:type:stream:)``
 public func ones(
-    _ shape: some Collection<Int>, type: (some HasDType).Type = Float.self,
+    _ shape: some Collection<Int>, type: (some HasDType).Type,
     stream: StreamOrDevice = .default
 ) -> MLXArray {
     var result = mlx_array_new()
     mlx_ones(&result, shape.map { Int32($0) }, shape.count, type.dtype.cmlxDtype, stream.ctx)
     return MLXArray(result)
+}
+
+/// Construct an array of ones, defaulting to `Float` (float32).
+///
+/// > Deprecated: pass the dtype explicitly via ``ones(_:dtype:stream:)``
+/// or ``ones(_:type:stream:)``. See
+/// [ml-explore/mlx-swift#390](https://github.com/ml-explore/mlx-swift/issues/390).
+@available(
+    *, deprecated,
+    message: "Pass dtype explicitly: ones(shape, dtype: .float32) or ones(shape, type: Float.self). See ml-explore/mlx-swift#390."
+)
+public func ones(
+    _ shape: some Collection<Int>, stream: StreamOrDevice = .default
+) -> MLXArray {
+    ones(shape, dtype: .float32, stream: stream)
 }
 
 /// Construct an array of ones with a given ``DType``
@@ -798,7 +903,7 @@ public func ones(like array: MLXArray, stream: StreamOrDevice = .default) -> MLX
 ///
 /// ```swift
 /// //  create [10, 10] array with 1's on the diagonal.
-/// let r = MLXArray.eye(10)
+/// let r = eye(10, type: Int.self)
 /// ```
 ///
 /// - Parameters:
@@ -812,12 +917,27 @@ public func ones(like array: MLXArray, stream: StreamOrDevice = .default) -> MLX
 /// - <doc:initialization>
 /// - ``identity(_:type:stream:)``
 public func eye(
-    _ n: Int, m: Int? = nil, k: Int = 0, type: (some HasDType).Type = Float.self,
+    _ n: Int, m: Int? = nil, k: Int = 0, type: (some HasDType).Type,
     stream: StreamOrDevice = .default
 ) -> MLXArray {
     var result = mlx_array_new()
     mlx_eye(&result, n.int32, (m ?? n).int32, k.int32, type.dtype.cmlxDtype, stream.ctx)
     return MLXArray(result)
+}
+
+/// Create an identity matrix or a general diagonal matrix, defaulting to `Float` (float32).
+///
+/// > Deprecated: pass the dtype explicitly via ``eye(_:m:k:dtype:stream:)``
+/// or ``eye(_:m:k:type:stream:)``. See
+/// [ml-explore/mlx-swift#390](https://github.com/ml-explore/mlx-swift/issues/390).
+@available(
+    *, deprecated,
+    message: "Pass dtype explicitly: eye(n, m:, k:, dtype: .float32) or eye(n, m:, k:, type: Float.self). See ml-explore/mlx-swift#390."
+)
+public func eye(
+    _ n: Int, m: Int? = nil, k: Int = 0, stream: StreamOrDevice = .default
+) -> MLXArray {
+    eye(n, m: m, k: k, dtype: .float32, stream: stream)
 }
 
 /// Create an identity matrix or a general diagonal matrix given a ``DType``.
@@ -945,7 +1065,7 @@ public func full(
 ///
 /// ```swift
 /// //  create [10, 10] array with 1's on the diagonal.
-/// let r = MLXArray.identity(10)
+/// let r = identity(10, type: Int.self)
 /// ```
 ///
 /// - Parameters:
@@ -957,11 +1077,24 @@ public func full(
 /// - <doc:initialization>
 /// - ``eye(_:m:k:type:stream:)``
 public func identity(
-    _ n: Int, type: (some HasDType).Type = Float.self, stream: StreamOrDevice = .default
+    _ n: Int, type: (some HasDType).Type, stream: StreamOrDevice = .default
 ) -> MLXArray {
     var result = mlx_array_new()
     mlx_identity(&result, n.int32, type.dtype.cmlxDtype, stream.ctx)
     return MLXArray(result)
+}
+
+/// Create a square identity matrix, defaulting to `Float` (float32).
+///
+/// > Deprecated: pass the dtype explicitly via ``identity(_:dtype:stream:)``
+/// or ``identity(_:type:stream:)``. See
+/// [ml-explore/mlx-swift#390](https://github.com/ml-explore/mlx-swift/issues/390).
+@available(
+    *, deprecated,
+    message: "Pass dtype explicitly: identity(n, dtype: .float32) or identity(n, type: Float.self). See ml-explore/mlx-swift#390."
+)
+public func identity(_ n: Int, stream: StreamOrDevice = .default) -> MLXArray {
+    identity(n, dtype: .float32, stream: stream)
 }
 
 /// Create a square identity matrix with a given ``DType``.
@@ -1280,7 +1413,7 @@ public func repeated(_ array: MLXArray, count: Int, stream: StreamOrDevice = .de
 ///
 /// ```swift
 /// // [5, 5] array with the lower triangle filled with 1s
-/// let r = MLXArray.triangle(5)
+/// let r = tri(5, type: Int.self)
 /// ```
 ///
 /// - Parameters:
@@ -1293,12 +1426,27 @@ public func repeated(_ array: MLXArray, count: Int, stream: StreamOrDevice = .de
 /// ### See Also
 /// - <doc:initialization>
 public func tri(
-    _ n: Int, m: Int? = nil, k: Int = 0, type: (some HasDType).Type = Float.self,
+    _ n: Int, m: Int? = nil, k: Int = 0, type: (some HasDType).Type,
     stream: StreamOrDevice = .default
 ) -> MLXArray {
     var result = mlx_array_new()
     mlx_tri(&result, n.int32, (m ?? n).int32, k.int32, type.dtype.cmlxDtype, stream.ctx)
     return MLXArray(result)
+}
+
+/// An array with ones at and below the given diagonal and zeros elsewhere, defaulting to `Float` (float32).
+///
+/// > Deprecated: pass the dtype explicitly via ``tri(_:m:k:dtype:stream:)``
+/// or ``tri(_:m:k:type:stream:)``. See
+/// [ml-explore/mlx-swift#390](https://github.com/ml-explore/mlx-swift/issues/390).
+@available(
+    *, deprecated,
+    message: "Pass dtype explicitly: tri(n, m:, k:, dtype: .float32) or tri(n, m:, k:, type: Float.self). See ml-explore/mlx-swift#390."
+)
+public func tri(
+    _ n: Int, m: Int? = nil, k: Int = 0, stream: StreamOrDevice = .default
+) -> MLXArray {
+    tri(n, m: m, k: k, dtype: .float32, stream: stream)
 }
 
 /// An array with ones at and below the given diagonal and zeros elsewhere and a given ``DType``.

--- a/Source/MLXNN/Convolution.swift
+++ b/Source/MLXNN/Convolution.swift
@@ -56,7 +56,7 @@ open class Conv1d: Module, UnaryLayer {
                 kernelSize,
                 inputChannels / groups,
             ])
-        self.bias = bias ? MLXArray.zeros([outputChannels]) : nil
+        self.bias = bias ? MLXArray.zeros([outputChannels], dtype: .float32) : nil
         self.padding = padding
         self.dilation = dilation
         self.stride = stride
@@ -127,7 +127,7 @@ open class Conv2d: Module, UnaryLayer {
                 kernelSize.first, kernelSize.second,
                 inputChannels / groups,
             ])
-        self.bias = bias ? MLXArray.zeros([outputChannels]) : nil
+        self.bias = bias ? MLXArray.zeros([outputChannels], dtype: .float32) : nil
         self.padding = padding.values
         self.dilation = dilation.values
         self.stride = stride.values
@@ -199,7 +199,7 @@ open class Conv3d: Module, UnaryLayer {
                 kernelSize.first, kernelSize.second, kernelSize.third,
                 inputChannels / groups,
             ])
-        self.bias = bias ? MLXArray.zeros([outputChannels]) : nil
+        self.bias = bias ? MLXArray.zeros([outputChannels], dtype: .float32) : nil
         self.padding = padding.values
         self.dilation = dilation.values
         self.stride = stride.values

--- a/Source/MLXNN/ConvolutionTransposed.swift
+++ b/Source/MLXNN/ConvolutionTransposed.swift
@@ -57,7 +57,7 @@ open class ConvTransposed1d: Module, UnaryLayer {
                 kernelSize,
                 inputChannels / groups,
             ])
-        self.bias = bias ? MLXArray.zeros([outputChannels]) : nil
+        self.bias = bias ? MLXArray.zeros([outputChannels], dtype: .float32) : nil
         self.padding = padding
         self.dilation = dilation
         self.outputPadding = outputPadding
@@ -133,7 +133,7 @@ open class ConvTransposed2d: Module, UnaryLayer {
                 kernelSize.first, kernelSize.second,
                 inputChannels / groups,
             ])
-        self.bias = bias ? MLXArray.zeros([outputChannels]) : nil
+        self.bias = bias ? MLXArray.zeros([outputChannels], dtype: .float32) : nil
         self.padding = padding.values
         self.dilation = dilation.values
         self.outputPadding = outputPadding.values
@@ -210,7 +210,7 @@ open class ConvTransposed3d: Module, UnaryLayer {
                 kernelSize.first, kernelSize.second, kernelSize.third,
                 inputChannels / groups,
             ])
-        self.bias = bias ? MLXArray.zeros([outputChannels]) : nil
+        self.bias = bias ? MLXArray.zeros([outputChannels], dtype: .float32) : nil
         self.padding = padding.values
         self.dilation = dilation.values
         self.outputPadding = outputPadding.values

--- a/Source/MLXNN/Normalization.swift
+++ b/Source/MLXNN/Normalization.swift
@@ -34,8 +34,8 @@ open class InstanceNorm: Module, UnaryLayer {
         self.eps = eps
 
         if affine {
-            self.weight = MLXArray.ones([dimensions])
-            self.bias = MLXArray.zeros([dimensions])
+            self.weight = MLXArray.ones([dimensions], dtype: .float32)
+            self.bias = MLXArray.zeros([dimensions], dtype: .float32)
         } else {
             self.weight = nil
             self.bias = nil
@@ -95,8 +95,8 @@ open class LayerNorm: Module, UnaryLayer {
         self.eps = eps
 
         if affine {
-            self.weight = MLXArray.ones([dimensions])
-            self.bias = bias ? MLXArray.zeros([dimensions]) : nil
+            self.weight = MLXArray.ones([dimensions], dtype: .float32)
+            self.bias = bias ? MLXArray.zeros([dimensions], dtype: .float32) : nil
         } else {
             self.weight = nil
             self.bias = nil
@@ -130,7 +130,7 @@ open class RMSNorm: Module, UnaryLayer {
     public let eps: Float
 
     public init(dimensions: Int, eps: Float = 1e-5) {
-        self.weight = MLXArray.ones([dimensions])
+        self.weight = MLXArray.ones([dimensions], dtype: .float32)
         self.eps = eps
         super.init()
     }
@@ -189,8 +189,8 @@ open class GroupNorm: Module, UnaryLayer {
         self.pytorchCompatible = pytorchCompatible
 
         if affine {
-            self.weight = MLXArray.ones([dimensions])
-            self.bias = MLXArray.zeros([dimensions])
+            self.weight = MLXArray.ones([dimensions], dtype: .float32)
+            self.bias = MLXArray.zeros([dimensions], dtype: .float32)
         } else {
             self.weight = nil
             self.bias = nil
@@ -294,16 +294,16 @@ open class BatchNorm: Module, UnaryLayer {
         self.momentum = momentum
 
         if affine {
-            self.weight = MLXArray.ones([featureCount])
-            self.bias = MLXArray.zeros([featureCount])
+            self.weight = MLXArray.ones([featureCount], dtype: .float32)
+            self.bias = MLXArray.zeros([featureCount], dtype: .float32)
         } else {
             self.weight = nil
             self.bias = nil
         }
 
         if trackRunningStats {
-            self._runningMean.wrappedValue = MLXArray.zeros([featureCount])
-            self._runningVar.wrappedValue = MLXArray.ones([featureCount])
+            self._runningMean.wrappedValue = MLXArray.zeros([featureCount], dtype: .float32)
+            self._runningVar.wrappedValue = MLXArray.ones([featureCount], dtype: .float32)
         }
 
         super.init()

--- a/Source/MLXNN/Quantized.swift
+++ b/Source/MLXNN/Quantized.swift
@@ -269,7 +269,7 @@ open class QuantizedLinear: Linear, Quantized {
         let weight = MLXRandom.uniform(
             low: -scale, high: scale, [outputDimensions, inputDimensions])
 
-        let bias = bias ? MLXArray.zeros([outputDimensions]) : nil
+        let bias = bias ? MLXArray.zeros([outputDimensions], dtype: .float32) : nil
 
         self.init(weight: weight, bias: bias, groupSize: groupSize, bits: bits, mode: mode)
     }


### PR DESCRIPTION
Closes #390.

Implements the path called out in the issue: factory functions whose dtype silently defaults to `Float.self` are now deprecated, while the existing `dtype:` / `type:` overloads are kept as the recommended replacements.

## API change

For each of `zeros`, `ones`, `eye`, `identity`, `tri` (both \`MLXArray.<func>\` and free \`MLX.<func>\` forms):

\`\`\`swift
// Already existed — keep as the recommended explicit-dtype paths:
zeros(shape, dtype: .float32)
zeros(shape, type: Float.self)

// Existed but silently returned float32 — now deprecated:
zeros(shape)              // ⚠️  #DeprecatedDeclaration
\`\`\`

The deprecated overload still returns float32, so the change is source-compatible. Callers that omitted the type argument get a Swift warning pointing them at the explicit-dtype form and at this issue.

A small mechanical cleanup also runs alongside:

- \`type: (some HasDType).Type = Float.self\` had its \`= Float.self\` default removed. The new no-type deprecated overload is more specific than the type-explicit overload under Swift overload resolution, so the default was already unreachable; the cleanup just removes dead syntax. Explicit \`type: T.self\` calls continue to compile silently.
- \`full(shape, values, type: T = Float.self)\` had its default removed for the same reason — \`full(shape, values)\` already exists and inherits \`values.dtype\`, so the default was never selected.

## In-tree callers tightened to keep the build warning-free

The deprecation surfaced silent float32 promotion at six existing internal sites in MLXNN and the tutorial example:

- \`Convolution.bias = MLXArray.zeros([outputChannels])\` (1D / 2D / 3D)
- \`ConvolutionTransposed.bias = MLXArray.zeros([outputChannels])\` (1D / 2D / 3D)
- \`LayerNorm\` / \`RMSNorm\` / \`GroupNorm\` / \`BatchNorm\` affine + running-stats parameters
- \`QuantizedLinear.bias\`
- \`Source/Examples/Tutorial.swift\`

All become \`...zeros([d], dtype: .float32)\` / \`...ones([d], dtype: .float32)\`. No behavior change — the original implicit dtype was \`.float32\` — but the dtype is now visible at the layer-construction site, which is also a stepping-stone toward the broader \"thread dtype through layer initializers\" follow-up that #390 alludes to via ml-explore/mlx-swift-lm#124.

## Intentional non-goals (separate PRs welcome)

- **\`arange(_ stop: Double, dtype: DType = .float32, ...)\`**: matches Python (\`mx.arange(3.0)\` returns float32), so the default is parity, not a footgun. Leaving in place.
- **\`MLXRandom.{uniform, normal, multivariateNormal, truncatedNormal, gumbel, laplace}\`**: these have the same \`dtype: DType = .float32\` shape. Worth tackling, but the right design depends on whether the dtype should be inferred from \`low\`/\`high\` when those are \`MLXArray\` (Python-parity behavior). I left them out so the scope of this PR stays focused and reviewable, and so the inference-vs-explicit question can be discussed independently.
- **Layer-level dtype threading** (\`Linear(dtype:)\`, \`Conv2d(dtype:)\`, \`*Norm(dtype:)\`, etc.). This is the real fix for the issue's underlying motivation (avoiding implicit float32 weights in bf16 pipelines). It's a much larger API surface — happy to follow up with a draft once the deprecation direction here is settled.

## Verification

\`\`\`
swift build       # Build complete!
                  # 0 #390-related warnings remain in-tree
\`\`\`

\`swift test\` could not be run end-to-end on this machine: the SPM test target hits the pre-existing \"Failed to load the default metallib\" issue (#349) before any of my changes get exercised. Plain library / example builds succeed without warnings, and the changes are purely additive overloads plus default-argument removals, so there is no runtime path affected by this PR that isn't already covered by the build.

I'm happy to:
- Strip the in-tree call-site updates if you'd rather see them in a separate \"clean up internal float32 callers\" PR.
- Convert the no-type overloads to a hard removal (i.e., remove \`= Float.self\` *and* skip adding the deprecated overload) if you prefer a breaking change with a clearer deprecation cycle in a release-note section.
- Extend the same pattern to \`MLXRandom.*\` once the inference-from-inputs question is decided.

Whichever direction you prefer, this PR can be reshaped to match.