### PR TITLE
Add nested Swift Array initializers (and reverse) for MLXArray

### DIFF
--- a/Source/MLX/MLXArray+NestedArrayInit.swift
+++ b/Source/MLX/MLXArray+NestedArrayInit.swift
@@ -1,0 +1,331 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+// MARK: - Initialization from nested Swift Arrays
+
+extension MLXArray {
+
+    // MARK: 2-D
+
+    /// Create a 2-D ``MLXArray`` from a row-major ``[[T]]`` literal.
+    ///
+    /// Each inner array becomes a row of the resulting array. All rows must
+    /// have the same length.
+    ///
+    /// Example:
+    ///
+    /// ```swift
+    /// let a = MLXArray([[1.0, 2.0],
+    ///                   [3.0, 4.0]])
+    /// // a.shape == [2, 2], a.dtype == .float32
+    /// ```
+    ///
+    /// Closes [#161](https://github.com/ml-explore/mlx-swift/issues/161).
+    ///
+    /// ### See Also
+    /// - <doc:initialization>
+    /// - ``asArray2(_:)``
+    public convenience init<T: HasDType>(_ value: [[T]]) {
+        let rows = value.count
+        let cols = value.first?.count ?? 0
+        precondition(
+            value.allSatisfy { $0.count == cols },
+            "MLXArray(nested): rows must have equal length (got \(value.map(\.count)))"
+        )
+        let flat = value.flatMap { $0 }
+        self.init(flat, [rows, cols])
+    }
+
+    /// Create a 2-D ``MLXArray`` of dtype `.int32` from a row-major ``[[Int]]`` literal.
+    ///
+    /// Mirrors the 1-D behavior of ``init(_:_:)-(value:[Int],_)``, which produces
+    /// an int32 array (and not int64) for ergonomic interop with Python /
+    /// numpy.
+    ///
+    /// ### See Also
+    /// - ``init(int64:)-([[Int]])``
+    public convenience init(_ value: [[Int]]) {
+        let rows = value.count
+        let cols = value.first?.count ?? 0
+        precondition(
+            value.allSatisfy { $0.count == cols },
+            "MLXArray(nested): rows must have equal length (got \(value.map(\.count)))"
+        )
+        let flat = value.flatMap { $0 }
+        self.init(flat, [rows, cols])
+    }
+
+    /// Create a 2-D `.int64` ``MLXArray`` from a row-major ``[[Int]]`` literal.
+    public convenience init(int64 value: [[Int]]) {
+        let rows = value.count
+        let cols = value.first?.count ?? 0
+        precondition(
+            value.allSatisfy { $0.count == cols },
+            "MLXArray(nested): rows must have equal length (got \(value.map(\.count)))"
+        )
+        let flat = value.flatMap { $0 }
+        self.init(int64: flat, [rows, cols])
+    }
+
+    /// Create a 2-D `.float32` ``MLXArray`` from a row-major ``[[Double]]`` literal.
+    ///
+    /// `Double` is converted to `Float` because MLX does not support `.float64`
+    /// natively on all backends.
+    public convenience init(converting value: [[Double]]) {
+        let rows = value.count
+        let cols = value.first?.count ?? 0
+        precondition(
+            value.allSatisfy { $0.count == cols },
+            "MLXArray(nested): rows must have equal length (got \(value.map(\.count)))"
+        )
+        let flat = value.flatMap { $0 }
+        self.init(converting: flat, [rows, cols])
+    }
+
+    // MARK: 3-D
+
+    /// Create a 3-D ``MLXArray`` from a nested ``[[[T]]]`` literal in
+    /// outer-to-inner order.
+    ///
+    /// All sub-arrays at the same depth must have equal length.
+    ///
+    /// Example:
+    ///
+    /// ```swift
+    /// let a = MLXArray([[[1.0], [2.0]],
+    ///                   [[3.0], [4.0]]])
+    /// // a.shape == [2, 2, 1]
+    /// ```
+    public convenience init<T: HasDType>(_ value: [[[T]]]) {
+        let d0 = value.count
+        let d1 = value.first?.count ?? 0
+        let d2 = value.first?.first?.count ?? 0
+        precondition(
+            value.allSatisfy { $0.count == d1 && $0.allSatisfy { $0.count == d2 } },
+            "MLXArray(nested): inner arrays must have equal length at every depth"
+        )
+        let flat = value.flatMap { $0.flatMap { $0 } }
+        self.init(flat, [d0, d1, d2])
+    }
+
+    /// Create a 3-D `.int32` ``MLXArray`` from a ``[[[Int]]]`` literal.
+    public convenience init(_ value: [[[Int]]]) {
+        let d0 = value.count
+        let d1 = value.first?.count ?? 0
+        let d2 = value.first?.first?.count ?? 0
+        precondition(
+            value.allSatisfy { $0.count == d1 && $0.allSatisfy { $0.count == d2 } },
+            "MLXArray(nested): inner arrays must have equal length at every depth"
+        )
+        let flat = value.flatMap { $0.flatMap { $0 } }
+        self.init(flat, [d0, d1, d2])
+    }
+
+    /// Create a 3-D `.int64` ``MLXArray`` from a ``[[[Int]]]`` literal.
+    public convenience init(int64 value: [[[Int]]]) {
+        let d0 = value.count
+        let d1 = value.first?.count ?? 0
+        let d2 = value.first?.first?.count ?? 0
+        precondition(
+            value.allSatisfy { $0.count == d1 && $0.allSatisfy { $0.count == d2 } },
+            "MLXArray(nested): inner arrays must have equal length at every depth"
+        )
+        let flat = value.flatMap { $0.flatMap { $0 } }
+        self.init(int64: flat, [d0, d1, d2])
+    }
+
+    /// Create a 3-D `.float32` ``MLXArray`` from a ``[[[Double]]]`` literal.
+    public convenience init(converting value: [[[Double]]]) {
+        let d0 = value.count
+        let d1 = value.first?.count ?? 0
+        let d2 = value.first?.first?.count ?? 0
+        precondition(
+            value.allSatisfy { $0.count == d1 && $0.allSatisfy { $0.count == d2 } },
+            "MLXArray(nested): inner arrays must have equal length at every depth"
+        )
+        let flat = value.flatMap { $0.flatMap { $0 } }
+        self.init(converting: flat, [d0, d1, d2])
+    }
+
+    // MARK: 4-D
+
+    /// Create a 4-D ``MLXArray`` from a nested ``[[[[T]]]]`` literal.
+    ///
+    /// All sub-arrays at the same depth must have equal length.
+    ///
+    /// Useful for inputs shaped like `[batch, channels, height, width]` or
+    /// `[batch, height, width, channels]`.
+    public convenience init<T: HasDType>(_ value: [[[[T]]]]) {
+        let d0 = value.count
+        let d1 = value.first?.count ?? 0
+        let d2 = value.first?.first?.count ?? 0
+        let d3 = value.first?.first?.first?.count ?? 0
+        precondition(
+            value.allSatisfy {
+                $0.count == d1
+                    && $0.allSatisfy {
+                        $0.count == d2 && $0.allSatisfy { $0.count == d3 }
+                    }
+            },
+            "MLXArray(nested): inner arrays must have equal length at every depth"
+        )
+        let flat = value.flatMap { $0.flatMap { $0.flatMap { $0 } } }
+        self.init(flat, [d0, d1, d2, d3])
+    }
+
+    /// Create a 4-D `.int32` ``MLXArray`` from a ``[[[[Int]]]]`` literal.
+    public convenience init(_ value: [[[[Int]]]]) {
+        let d0 = value.count
+        let d1 = value.first?.count ?? 0
+        let d2 = value.first?.first?.count ?? 0
+        let d3 = value.first?.first?.first?.count ?? 0
+        precondition(
+            value.allSatisfy {
+                $0.count == d1
+                    && $0.allSatisfy {
+                        $0.count == d2 && $0.allSatisfy { $0.count == d3 }
+                    }
+            },
+            "MLXArray(nested): inner arrays must have equal length at every depth"
+        )
+        let flat = value.flatMap { $0.flatMap { $0.flatMap { $0 } } }
+        self.init(flat, [d0, d1, d2, d3])
+    }
+
+    /// Create a 4-D `.int64` ``MLXArray`` from a ``[[[[Int]]]]`` literal.
+    public convenience init(int64 value: [[[[Int]]]]) {
+        let d0 = value.count
+        let d1 = value.first?.count ?? 0
+        let d2 = value.first?.first?.count ?? 0
+        let d3 = value.first?.first?.first?.count ?? 0
+        precondition(
+            value.allSatisfy {
+                $0.count == d1
+                    && $0.allSatisfy {
+                        $0.count == d2 && $0.allSatisfy { $0.count == d3 }
+                    }
+            },
+            "MLXArray(nested): inner arrays must have equal length at every depth"
+        )
+        let flat = value.flatMap { $0.flatMap { $0.flatMap { $0 } } }
+        self.init(int64: flat, [d0, d1, d2, d3])
+    }
+
+    /// Create a 4-D `.float32` ``MLXArray`` from a ``[[[[Double]]]]`` literal.
+    public convenience init(converting value: [[[[Double]]]]) {
+        let d0 = value.count
+        let d1 = value.first?.count ?? 0
+        let d2 = value.first?.first?.count ?? 0
+        let d3 = value.first?.first?.first?.count ?? 0
+        precondition(
+            value.allSatisfy {
+                $0.count == d1
+                    && $0.allSatisfy {
+                        $0.count == d2 && $0.allSatisfy { $0.count == d3 }
+                    }
+            },
+            "MLXArray(nested): inner arrays must have equal length at every depth"
+        )
+        let flat = value.flatMap { $0.flatMap { $0.flatMap { $0 } } }
+        self.init(converting: flat, [d0, d1, d2, d3])
+    }
+}
+
+// MARK: - Extracting nested Swift Arrays from an MLXArray
+
+extension MLXArray {
+
+    /// Return the contents as a row-major 2-D Swift array.
+    ///
+    /// The array's ``dtype`` is preserved if it equals `T.dtype`; otherwise
+    /// values are cast to `T` (matching the semantics of ``asArray(_:)``).
+    /// The receiver must be a 2-D ``MLXArray``.
+    ///
+    /// Example:
+    ///
+    /// ```swift
+    /// let a = MLXArray([[1.0, 2.0], [3.0, 4.0]])
+    /// let rows = a.asArray2(Float.self)
+    /// // rows == [[1.0, 2.0], [3.0, 4.0]]
+    /// ```
+    ///
+    /// ### See Also
+    /// - <doc:conversion>
+    /// - ``asArray(_:)``
+    /// - ``init(_:)-([[T]])``
+    public func asArray2<T: HasDType>(_ type: T.Type) -> [[T]] {
+        precondition(
+            ndim == 2,
+            "asArray2 requires a 2-D MLXArray (got \(ndim)-D, shape \(shape))"
+        )
+        let rows = dim(0)
+        let cols = dim(1)
+        let flat = asArray(type)
+        var result = [[T]]()
+        result.reserveCapacity(rows)
+        for r in 0..<rows {
+            let start = r * cols
+            result.append(Array(flat[start..<(start + cols)]))
+        }
+        return result
+    }
+
+    /// Return the contents as a 3-D nested Swift array.
+    ///
+    /// The receiver must be a 3-D ``MLXArray``.
+    public func asArray3<T: HasDType>(_ type: T.Type) -> [[[T]]] {
+        precondition(
+            ndim == 3,
+            "asArray3 requires a 3-D MLXArray (got \(ndim)-D, shape \(shape))"
+        )
+        let d0 = dim(0)
+        let d1 = dim(1)
+        let d2 = dim(2)
+        let flat = asArray(type)
+        var result = [[[T]]]()
+        result.reserveCapacity(d0)
+        for i in 0..<d0 {
+            var plane = [[T]]()
+            plane.reserveCapacity(d1)
+            for j in 0..<d1 {
+                let start = (i * d1 + j) * d2
+                plane.append(Array(flat[start..<(start + d2)]))
+            }
+            result.append(plane)
+        }
+        return result
+    }
+
+    /// Return the contents as a 4-D nested Swift array.
+    ///
+    /// The receiver must be a 4-D ``MLXArray``.
+    public func asArray4<T: HasDType>(_ type: T.Type) -> [[[[T]]]] {
+        precondition(
+            ndim == 4,
+            "asArray4 requires a 4-D MLXArray (got \(ndim)-D, shape \(shape))"
+        )
+        let d0 = dim(0)
+        let d1 = dim(1)
+        let d2 = dim(2)
+        let d3 = dim(3)
+        let flat = asArray(type)
+        var result = [[[[T]]]]()
+        result.reserveCapacity(d0)
+        for i in 0..<d0 {
+            var cube = [[[T]]]()
+            cube.reserveCapacity(d1)
+            for j in 0..<d1 {
+                var plane = [[T]]()
+                plane.reserveCapacity(d2)
+                for k in 0..<d2 {
+                    let start = ((i * d1 + j) * d2 + k) * d3
+                    plane.append(Array(flat[start..<(start + d3)]))
+                }
+                cube.append(plane)
+            }
+            result.append(cube)
+        }
+        return result
+    }
+}

--- a/Tests/MLXTests/MLXArray+NestedArrayInitTests.swift
+++ b/Tests/MLXTests/MLXArray+NestedArrayInitTests.swift
@@ -1,0 +1,134 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import XCTest
+
+@testable import MLX
+
+class MLXArrayNestedArrayInitTests: XCTestCase {
+
+    override class func setUp() {
+        setDefaultDevice()
+    }
+
+    // MARK: - 2-D init
+
+    func testInit2DFloat() {
+        let a = MLXArray([[Float(1), 2], [3, 4]])
+        XCTAssertEqual(a.shape, [2, 2])
+        XCTAssertEqual(a.dtype, .float32)
+        XCTAssertEqual(a.asArray(Float.self), [1, 2, 3, 4])
+    }
+
+    func testInit2DInt() {
+        let a = MLXArray([[1, 2, 3], [4, 5, 6]])
+        XCTAssertEqual(a.shape, [2, 3])
+        XCTAssertEqual(a.dtype, .int32)
+        XCTAssertEqual(a.asArray(Int32.self), [1, 2, 3, 4, 5, 6])
+    }
+
+    func testInit2DInt64() {
+        let a = MLXArray(int64: [[1, 2], [3, 4]])
+        XCTAssertEqual(a.shape, [2, 2])
+        XCTAssertEqual(a.dtype, .int64)
+        XCTAssertEqual(a.asArray(Int.self), [1, 2, 3, 4])
+    }
+
+    func testInit2DDoubleConverting() {
+        let a = MLXArray(converting: [[1.5, 2.5], [3.5, 4.5]])
+        XCTAssertEqual(a.shape, [2, 2])
+        XCTAssertEqual(a.dtype, .float32)
+        XCTAssertEqual(a.asArray(Float.self), [1.5, 2.5, 3.5, 4.5])
+    }
+
+    func testInit2DSingleRow() {
+        let a = MLXArray([[Float(1), 2, 3]])
+        XCTAssertEqual(a.shape, [1, 3])
+        XCTAssertEqual(a.asArray(Float.self), [1, 2, 3])
+    }
+
+    // MARK: - 3-D init
+
+    func testInit3DFloat() {
+        let a = MLXArray([
+            [[Float(1), 2], [3, 4]],
+            [[5, 6], [7, 8]],
+        ])
+        XCTAssertEqual(a.shape, [2, 2, 2])
+        XCTAssertEqual(a.dtype, .float32)
+        XCTAssertEqual(a.asArray(Float.self), [1, 2, 3, 4, 5, 6, 7, 8])
+    }
+
+    func testInit3DInt() {
+        let a = MLXArray([
+            [[1], [2]],
+            [[3], [4]],
+        ])
+        XCTAssertEqual(a.shape, [2, 2, 1])
+        XCTAssertEqual(a.dtype, .int32)
+        XCTAssertEqual(a.asArray(Int32.self), [1, 2, 3, 4])
+    }
+
+    // MARK: - 4-D init
+
+    func testInit4DFloat() {
+        // batch=1, channel=2, height=2, width=2
+        let a = MLXArray([
+            [
+                [[Float(1), 2], [3, 4]],
+                [[5, 6], [7, 8]],
+            ]
+        ])
+        XCTAssertEqual(a.shape, [1, 2, 2, 2])
+        XCTAssertEqual(a.dtype, .float32)
+        XCTAssertEqual(a.asArray(Float.self), [1, 2, 3, 4, 5, 6, 7, 8])
+    }
+
+    // MARK: - Round-trip with asArray2 / 3 / 4
+
+    func testAsArray2RoundTrip() {
+        let original: [[Float]] = [[1, 2, 3], [4, 5, 6]]
+        let a = MLXArray(original)
+        let recovered = a.asArray2(Float.self)
+        XCTAssertEqual(recovered, original)
+    }
+
+    func testAsArray3RoundTrip() {
+        let original: [[[Float]]] = [
+            [[1, 2], [3, 4]],
+            [[5, 6], [7, 8]],
+        ]
+        let a = MLXArray(original)
+        let recovered = a.asArray3(Float.self)
+        XCTAssertEqual(recovered, original)
+    }
+
+    func testAsArray4RoundTrip() {
+        let original: [[[[Float]]]] = [
+            [
+                [[1, 2], [3, 4]],
+                [[5, 6], [7, 8]],
+            ]
+        ]
+        let a = MLXArray(original)
+        let recovered = a.asArray4(Float.self)
+        XCTAssertEqual(recovered, original)
+    }
+
+    // MARK: - Cross-type extraction (asArray converts via asType)
+
+    func testAsArray2WithTypeConversion() {
+        let a = MLXArray([[1, 2], [3, 4]])  // int32
+        let recovered = a.asArray2(Float.self)  // requested as Float
+        XCTAssertEqual(recovered, [[1.0, 2.0], [3.0, 4.0]])
+    }
+
+    // MARK: - asArray2/3/4 honor the actual MLX layout
+
+    func testAsArray2ReshapesFromComputedTensor() {
+        // construct a 2-D array via reshape then verify extraction respects strides
+        let a = MLXArray(0 ..< 12).reshaped([3, 4])
+        let recovered = a.asArray2(Int32.self)
+        XCTAssertEqual(recovered, [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]])
+    }
+}


### PR DESCRIPTION
Closes #161.

Adds row-major nested Swift Array initializers for `MLXArray` (and the matching reverse extraction methods) for 2-, 3-, and 4-dimensional arrays. Higher ranks are intentionally left out — that question was the main reason this issue had been waiting (cf. @davidkoski: \"We can certainly do it for a fixed number of dimensions… the types will be tricky\" for arbitrary N). 4-D covers \`NCHW\` / \`NHWC\` image literals without introducing a macro dependency, so it felt like a natural stopping point.

## API additions

\`\`\`swift
// 2-D
MLXArray([[1.0, 2.0], [3.0, 4.0]])         // .float32, shape [2, 2]
MLXArray([[1, 2], [3, 4]])                 // .int32,   shape [2, 2]  (matches MLXArray([Int]))
MLXArray(int64: [[1, 2], [3, 4]])          // .int64
MLXArray(converting: [[1.5, 2.5], [3.5, 4.5]])  // .float32 from Double

// 3-D (same four shapes)
MLXArray([[[1.0], [2.0]], [[3.0], [4.0]]])  // .float32, shape [2, 2, 1]

// 4-D (same four shapes), useful for NCHW / NHWC literals
MLXArray([[
    [[1.0, 2.0], [3.0, 4.0]],
    [[5.0, 6.0], [7.0, 8.0]],
]])  // .float32, shape [1, 2, 2, 2]
\`\`\`

Each initializer flattens the nested array and forwards to the existing \`MLXArray(_: [T], _ shape:)\` path, so the dtype rules match the 1-D initializers exactly (notably: \`[Int]\` → \`.int32\`, \`int64:\` produces \`.int64\`, \`converting:\` casts \`Double\` → \`Float\`). Uneven inner-array lengths trigger a \`precondition\` failure, matching the existing convention for shape-mismatch elsewhere in \`MLXArray+Init.swift\`.

## Reverse extraction

@JimWallace asked in the issue for the inverse direction (\"MLXArray to nested Swift arrays would also be handy\"). Adding three matching helpers on `MLXArray`:

\`\`\`swift
let m = MLXArray([[1.0, 2.0], [3.0, 4.0]])
m.asArray2(Float.self)                  // [[1.0, 2.0], [3.0, 4.0]]
m.reshaped([2, 2, 1]).asArray3(Float.self)  // 3-D nested
m.reshaped([1, 2, 2, 1]).asArray4(Float.self)  // 4-D nested
\`\`\`

\`asArray2\` / \`asArray3\` / \`asArray4\` reuse the existing \`asArray(_:) -> [T]\` path, so cross-dtype extraction follows the same \`asType\` semantics — \`asArray2(Float.self)\` on an int32 array implicitly converts to float32. Rank mismatches trigger a \`precondition\` failure, matching the existing 1-D \`asArray\` style.

## Files

- \`Source/MLX/MLXArray+NestedArrayInit.swift\` — initializers and reverse extraction (purely Swift, no Cmlx calls beyond the existing 1-D path).
- \`Tests/MLXTests/MLXArray+NestedArrayInitTests.swift\` — 12 tests covering dtype inference, shape, round-trip on plain 2/3/4-D, round-trip after \`reshaped\`, and cross-type extraction (\`asArray2(Float.self)\` from an int32 array).

## Verification

\`\`\`
swift build      # Build complete!, no new warnings
\`\`\`

\`swift test\` for the broader package hits the pre-existing \"Failed to load the default metallib\" error (#349 / #342) before any of the new tests can be exercised on this machine. The added code is pure Swift Array ↔ existing \`MLXArray(_: [T], _ shape:)\` plumbing, so the runtime path is identical to the 1-D initializers. I'd appreciate a maintainer running the new test class through Xcode to confirm; happy to iterate on the test set if helpful.

## Intentional non-goals

- **5-D and higher**: per the issue thread (\"the types will be tricky\" for arbitrary N), and because 5+D literals are uncommon in user code.
- **Macro-based variant**: @robertmsale floated an expression macro (\`#mlx([[...]])\`). That is a heavier dependency choice and orthogonal to this PR; can be added on top if desired.
- **\`throws\` instead of \`precondition\`**: I matched the precondition style already used by \`MLXArray(_: [Int], _ shape:)\` and \`asArray(_:)\`. Happy to convert to \`throws\` if you prefer that for the shape-mismatch / rank-mismatch paths.