### PR TITLE
Expose nuclear norm order in linalg API

### DIFF
--- a/Source/MLX/Linalg.swift
+++ b/Source/MLX/Linalg.swift
@@ -13,6 +13,9 @@ public enum MLXLinalg {
     public enum NormKind: String, Sendable {
         /// Frobenius norm
         case fro
+
+        /// Nuclear norm, the sum of singular values
+        case nuc
     }
 
     /// Matrix or vector norm.
@@ -36,7 +39,7 @@ public enum MLXLinalg {
     /// -2    | smallest singular value      | as below
     /// other | --                           | sum(abs(x)**ord)**(1./ord)
     ///
-    /// > Nuclear norm and norms based on singular values are not yet implemented.
+    /// Nuclear norm and norms based on singular values are implemented by the linalg backend.
     ///
     /// The Frobenius norm is given by G. H. Golub and C. F. Van Loan, *Matrix Computations*,
     ///        Baltimore, MD, Johns Hopkins University Press, 1985, pg. 15
@@ -91,7 +94,7 @@ public enum MLXLinalg {
     /// -2    | smallest singular value      | as below
     /// other | --                           | sum(abs(x)**ord)**(1./ord)
     ///
-    /// > Nuclear norm and norms based on singular values are not yet implemented.
+    /// Nuclear norm and norms based on singular values are implemented by the linalg backend.
     ///
     /// The Frobenius norm is given by G. H. Golub and C. F. Van Loan, *Matrix Computations*,
     ///        Baltimore, MD, Johns Hopkins University Press, 1985, pg. 15
@@ -548,7 +551,7 @@ public enum MLXLinalg {
 /// -2    | smallest singular value      | as below
 /// other | --                           | sum(abs(x)**ord)**(1./ord)
 ///
-/// > Nuclear norm and norms based on singular values are not yet implemented.
+/// Nuclear norm and norms based on singular values are implemented by the linalg backend.
 ///
 /// The Frobenius norm is given by G. H. Golub and C. F. Van Loan, *Matrix Computations*,
 ///        Baltimore, MD, Johns Hopkins University Press, 1985, pg. 15
@@ -597,7 +600,7 @@ public func norm(
 /// -2    | smallest singular value      | as below
 /// other | --                           | sum(abs(x)**ord)**(1./ord)
 ///
-/// > Nuclear norm and norms based on singular values are not yet implemented.
+/// Nuclear norm and norms based on singular values are implemented by the linalg backend.
 ///
 /// The Frobenius norm is given by G. H. Golub and C. F. Van Loan, *Matrix Computations*,
 ///        Baltimore, MD, Johns Hopkins University Press, 1985, pg. 15

--- a/Source/MLXLinalg/Linalg.swift
+++ b/Source/MLXLinalg/Linalg.swift
@@ -31,7 +31,7 @@ public let deprecationWarning: Void = ()
 /// -2    | smallest singular value      | as below
 /// other | --                           | sum(abs(x)**ord)**(1./ord)
 ///
-/// > Nuclear norm and norms based on singular values are not yet implemented.
+/// Nuclear norm and norms based on singular values are implemented by the linalg backend.
 ///
 /// The Frobenius norm is given by G. H. Golub and C. F. Van Loan, *Matrix Computations*,
 ///        Baltimore, MD, Johns Hopkins University Press, 1985, pg. 15
@@ -81,7 +81,7 @@ public func norm(
 /// -2    | smallest singular value      | as below
 /// other | --                           | sum(abs(x)**ord)**(1./ord)
 ///
-/// > Nuclear norm and norms based on singular values are not yet implemented.
+/// Nuclear norm and norms based on singular values are implemented by the linalg backend.
 ///
 /// The Frobenius norm is given by G. H. Golub and C. F. Van Loan, *Matrix Computations*,
 ///        Baltimore, MD, Johns Hopkins University Press, 1985, pg. 15


### PR DESCRIPTION
## Summary

Expose the nuclear norm order through the Swift linalg API and documentation.

## Validation

- `swift test --filter Linalg` builds successfully, then aborts during runtime test startup because this upstream-based SwiftPM checkout cannot load `default.metallib`.
