### PR TITLE
MaterializedArray is a Sendable MLXArray

### DIFF
--- a/Source/MLX/Documentation.docc/MLX.md
+++ b/Source/MLX/Documentation.docc/MLX.md
@@ -92,6 +92,15 @@ See <doc:wired-memory> for configuration, best practices, and policy guidance.
 
 - ``MLXArray``
 
+### Concurrency
+
+`MLXArray` is not `Sendable`.  To share an array or model across task and actor
+boundaries, take an evaluated, immutable snapshot.
+
+- ``MaterializedArray``
+- ``materialize(_:)->MaterializedArray``
+- ``materialize(_:)->[MaterializedArray]``
+
 ### Free Functions
 
 - <doc:free-functions>

--- a/Source/MLX/Documentation.docc/MLXArray.md
+++ b/Source/MLX/Documentation.docc/MLXArray.md
@@ -42,6 +42,11 @@ let c = a + b
 may be large unresolved graphs) and the `addition` operator that combines them.  It is not safe
 to create `c` in one thread and consume/evaluate it in another.
 
+If you need to share an array across a task or actor boundary, take a
+``MaterializedArray`` snapshot via ``MLXArray/materialized()`` (or
+``materialize(_:)->MaterializedArray``).  A `MaterializedArray` is fully
+evaluated, immutable, and `Sendable`.
+
 ## Memory Safety
 
 > `MLXArray` is not memory safe.
@@ -91,3 +96,10 @@ and ``shape`` of the dimensions without changing the number of elements or conte
 ### Conversion and Data Types
 
 - <doc:conversion>
+
+### Concurrency
+
+- ``materialized()``
+- ``MaterializedArray``
+- ``materialize(_:)->MaterializedArray``
+- ``materialize(_:)->[MaterializedArray]``

--- a/Source/MLX/Documentation.docc/free-functions.md
+++ b/Source/MLX/Documentation.docc/free-functions.md
@@ -218,6 +218,11 @@ operations as methods for convenience.
 - ``jvp(_:primals:tangents:)``
 - ``vjp(_:primals:cotangents:)``
 
+### Concurrency
+
+- ``materialize(_:)->MaterializedArray``
+- ``materialize(_:)->[MaterializedArray]``
+
 ### Device
 
 - ``using(device:fn:)``

--- a/Source/MLX/Documentation.docc/free-functions.md
+++ b/Source/MLX/Documentation.docc/free-functions.md
@@ -219,6 +219,11 @@ operations as methods for convenience.
 - ``jvp(_:primals:tangents:)``
 - ``vjp(_:primals:cotangents:)``
 
+### Concurrency
+
+- ``materialize(_:)->MaterializedArray``
+- ``materialize(_:)->[MaterializedArray]``
+
 ### Device
 
 - ``using(device:fn:)``

--- a/Source/MLX/MLXArray+Indexing.swift
+++ b/Source/MLX/MLXArray+Indexing.swift
@@ -388,8 +388,7 @@ extension MLXArray {
                 var result = mlx_array_new()
                 mlx_scatter(
                     &result, self.ctx, indices_vector, update.ctx, axes, axes.count, stream.ctx)
-                mlx_array_set(&self.ctx, result)
-                mlx_array_free(result)
+                self._updateInternal(MLXArray(result))
                 return
             } else {
                 self._updateInternal(update)

--- a/Source/MLX/MLXArray+Init.swift
+++ b/Source/MLX/MLXArray+Init.swift
@@ -683,39 +683,3 @@ extension MLXArray {
     }
 
 }
-
-// MARK: - Expressible by literals
-
-extension MLXArray: ExpressibleByArrayLiteral {
-
-    // Note: MLXArray does not implement ExpressibleByFloatLiteral etc. because
-    // we want to create arrays in the context of the other arrays.  For example:
-    //
-    // let x = MLXArray(1.5, dtype: .float16)
-    // let r = x + 2.5
-    //
-    // We expect r to have a dtype of float16.  See ``ScalarOrArray``.
-
-    /// Initializer allowing creation of 1d `MLXArray` from an array literal.
-    ///
-    /// ```swift
-    /// let a: MLXArray = [1, 2, 3]
-    /// ```
-    ///
-    /// This is convenient for methods that have `MLXArray` parameters:
-    ///
-    /// ```swift
-    /// print(array.take([1, 2, 3], axis: 0))
-    /// ```
-    ///
-    /// ### See Also
-    /// - <doc:initialization>
-    public convenience init(arrayLiteral elements: Int32...) {
-        let ctx = elements.withUnsafeBufferPointer { ptr in
-            let shape = [Int32(elements.count)]
-            return mlx_array_new_data(
-                ptr.baseAddress!, shape, Int32(shape.count), Int32.dtype.cmlxDtype)
-        }
-        self.init(ctx)
-    }
-}

--- a/Source/MLX/MLXArray.swift
+++ b/Source/MLX/MLXArray.swift
@@ -4,7 +4,7 @@ import Cmlx
 import Foundation
 import Numerics
 
-public final class MLXArray {
+public class MLXArray: ExpressibleByArrayLiteral {
 
     /// Internal pointer to the mlx-c wrapper on `mlx::core::array`, used with `Cmlx` interop.
     public internal(set) var ctx: mlx_array
@@ -17,6 +17,37 @@ public final class MLXArray {
         // paths will come through here -- make sure the error handler is installed.
         initError()
         self.ctx = ctx
+    }
+
+    // Note: MLXArray does not implement ExpressibleByFloatLiteral etc. because
+    // we want to create arrays in the context of the other arrays.  For example:
+    //
+    // let x = MLXArray(1.5, dtype: .float16)
+    // let r = x + 2.5
+    //
+    // We expect r to have a dtype of float16.  See ``ScalarOrArray``.
+
+    /// Initializer allowing creation of 1d `MLXArray` from an array literal.
+    ///
+    /// ```swift
+    /// let a: MLXArray = [1, 2, 3]
+    /// ```
+    ///
+    /// This is convenient for methods that have `MLXArray` parameters:
+    ///
+    /// ```swift
+    /// print(array.take([1, 2, 3], axis: 0))
+    /// ```
+    ///
+    /// ### See Also
+    /// - <doc:initialization>
+    required public convenience init(arrayLiteral elements: Int32...) {
+        let ctx = elements.withUnsafeBufferPointer { ptr in
+            let shape = [Int32(elements.count)]
+            return mlx_array_new_data(
+                ptr.baseAddress!, shape, Int32(shape.count), Int32.dtype.cmlxDtype)
+        }
+        self.init(ctx)
     }
 
     /// return the equivalent of a `.none` MLXArray (for the C API).
@@ -37,7 +68,7 @@ public final class MLXArray {
     }
 
     /// Number of bytes per element
-    public var itemSize: Int { mlx_array_itemsize(ctx) }
+    final public var itemSize: Int { mlx_array_itemsize(ctx) }
 
     /// Total number of elements in the array
     ///
@@ -46,7 +77,7 @@ public final class MLXArray {
     /// print(array.size)
     /// // 12
     /// ```
-    public var size: Int { mlx_array_size(ctx) }
+    final public var size: Int { mlx_array_size(ctx) }
 
     /// Number of elements in the 0th dimension.
     ///
@@ -62,10 +93,10 @@ public final class MLXArray {
     ///     ...
     /// }
     /// ```
-    public var count: Int { dim(0) }
+    final public var count: Int { dim(0) }
 
     /// Number of bytes in the array.
-    public var nbytes: Int { mlx_array_nbytes(ctx) }
+    final public var nbytes: Int { mlx_array_nbytes(ctx) }
 
     /// Number of dimensions in the array.
     ///
@@ -74,7 +105,7 @@ public final class MLXArray {
     /// print(array.ndim)
     /// // 2
     /// ```
-    public var ndim: Int { mlx_array_ndim(ctx) }
+    final public var ndim: Int { mlx_array_ndim(ctx) }
 
     /// Data type of the elements in the array.
     ///
@@ -83,7 +114,7 @@ public final class MLXArray {
     /// print(array.dtype)
     /// // .int64 (aka Int.dtype)
     /// ```
-    public var dtype: DType { DType(mlx_array_dtype(ctx)) }
+    final public var dtype: DType { DType(mlx_array_dtype(ctx)) }
 
     /// Dimensions of the array.
     ///
@@ -92,7 +123,7 @@ public final class MLXArray {
     /// print(array.shape)
     /// // [3, 4]
     /// ```
-    public var shape: [Int] {
+    final public var shape: [Int] {
         let ndim = mlx_array_ndim(ctx)
         guard ndim > 0 else { return [] }
         let cShape = mlx_array_shape(ctx)!
@@ -104,7 +135,7 @@ public final class MLXArray {
     /// ```swift
     /// let (w, h) = array.shape2
     /// ```
-    public var shape2: (Int, Int) {
+    final public var shape2: (Int, Int) {
         let ndim = mlx_array_ndim(ctx)
         precondition(ndim == 2)
         let cShape = mlx_array_shape(ctx)!
@@ -116,7 +147,7 @@ public final class MLXArray {
     /// ```swift
     /// let (w, h, c) = array.shape3
     /// ```
-    public var shape3: (Int, Int, Int) {
+    final public var shape3: (Int, Int, Int) {
         let ndim = mlx_array_ndim(ctx)
         precondition(ndim == 3)
         let cShape = mlx_array_shape(ctx)!
@@ -128,7 +159,7 @@ public final class MLXArray {
     /// ```swift
     /// let (b, w, h, c) = array.shape4
     /// ```
-    public var shape4: (Int, Int, Int, Int) {
+    final public var shape4: (Int, Int, Int, Int) {
         let ndim = mlx_array_ndim(ctx)
         precondition(ndim == 4)
         let cShape = mlx_array_shape(ctx)!
@@ -149,7 +180,7 @@ public final class MLXArray {
     /// Strides of the array backing.
     ///
     /// Note: this is only stable once the array is evaluated.
-    var internalStrides: [Int] {
+    final var internalStrides: [Int] {
         let ndim = mlx_array_ndim(ctx)
         guard ndim > 0 else { return [] }
         let strides = mlx_array_strides(ctx)!
@@ -167,7 +198,7 @@ public final class MLXArray {
     /// // 4.5
     /// let value: Float = array[1].item()
     /// ```
-    public func item<T: HasDType>() -> T {
+    final public func item<T: HasDType>() -> T {
         item(T.self)
     }
 
@@ -328,7 +359,7 @@ public final class MLXArray {
     /// // 4.5
     /// let value = array[1].item(Float.self)
     /// ```
-    public func item<T: HasDType>(_ type: T.Type) -> T {
+    final public func item<T: HasDType>(_ type: T.Type) -> T {
         precondition(self.size == 1)
         eval()
 
@@ -466,7 +497,7 @@ public final class MLXArray {
     /// print(array.dim(1))
     /// // 4
     /// ```
-    public func dim(_ dim: Int) -> Int {
+    final public func dim(_ dim: Int) -> Int {
         Int(mlx_array_dim(ctx, MLX.resolve(axis: dim, ndim: mlx_array_ndim(ctx)).int32))
     }
 
@@ -481,7 +512,7 @@ public final class MLXArray {
     /// print(array.dim(index))
     /// // 4
     /// ```
-    func dim(_ dim: Int32) -> Int32 {
+    final func dim(_ dim: Int32) -> Int32 {
         mlx_array_dim(ctx, MLX.resolve(axis: Int(dim), ndim: mlx_array_ndim(ctx)).int32)
     }
 
@@ -492,7 +523,7 @@ public final class MLXArray {
     ///
     /// ### See Also
     /// - <doc:conversion>
-    public func asType(_ type: DType, stream: StreamOrDevice = .default) -> MLXArray {
+    final public func asType(_ type: DType, stream: StreamOrDevice = .default) -> MLXArray {
         guard type != self.dtype else { return self }
         var result = mlx_array_new()
         mlx_astype(&result, ctx, type.cmlxDtype, stream.ctx)
@@ -506,8 +537,9 @@ public final class MLXArray {
     ///
     /// ### See Also
     /// - <doc:conversion>
-    public func asType(_ type: (some HasDType).Type, stream: StreamOrDevice = .default) -> MLXArray
-    {
+    final public func asType(
+        _ type: (some HasDType).Type, stream: StreamOrDevice = .default
+    ) -> MLXArray {
         asType(type.dtype, stream: stream)
     }
 
@@ -524,7 +556,7 @@ public final class MLXArray {
     /// - ``realPart(stream:)``
     /// - ``imaginaryPart(stream:)``
     /// - <doc:conversion>
-    public func asImaginary(stream: StreamOrDevice = .default) -> MLXArray {
+    final public func asImaginary(stream: StreamOrDevice = .default) -> MLXArray {
         precondition(!dtype.isComplex)
         let i = MLXArray(real: 0, imaginary: 1)
         return self * i
@@ -534,7 +566,7 @@ public final class MLXArray {
     ///
     /// ### See Also
     /// - <doc:conversion>
-    public func realPart(stream: StreamOrDevice = .default) -> MLXArray {
+    final public func realPart(stream: StreamOrDevice = .default) -> MLXArray {
         precondition(dtype.isComplex)
         return asType(Float.self)
     }
@@ -543,7 +575,7 @@ public final class MLXArray {
     ///
     /// ### See Also
     /// - <doc:conversion>
-    public func imaginaryPart(stream: StreamOrDevice = .default) -> MLXArray {
+    final public func imaginaryPart(stream: StreamOrDevice = .default) -> MLXArray {
         precondition(dtype.isComplex)
         let i = MLXArray(real: 0, imaginary: 1)
         return (self / i).asType(.float32)
@@ -557,6 +589,10 @@ public final class MLXArray {
         _ = evalLock.withLock {
             mlx_array_eval(ctx)
         }
+    }
+
+    public func materialized() -> MaterializedArray {
+        MLX.materialize(self)
     }
 
     /// Replace the contents with a reference to a new array (INTERNAL).

--- a/Source/MLX/MLXArray.swift
+++ b/Source/MLX/MLXArray.swift
@@ -591,6 +591,19 @@ public class MLXArray: ExpressibleByArrayLiteral {
         }
     }
 
+    /// Force evaluation and return a ``MaterializedArray`` snapshot of `self`.
+    ///
+    /// The returned array is fully evaluated, immutable, and `Sendable` — see
+    /// ``MaterializedArray`` for the guarantees and trade-offs.  Use this when
+    /// you need to hand an array across task or actor boundaries, or when you
+    /// need a stable reference that cannot be mutated by other code holding
+    /// the original `MLXArray`.
+    ///
+    /// This is a thin convenience over ``materialize(_:)->MaterializedArray``.
+    ///
+    /// ### See Also
+    /// - ``MaterializedArray``
+    /// - ``materialize(_:)->MaterializedArray``
     public func materialized() -> MaterializedArray {
         MLX.materialize(self)
     }

--- a/Source/MLX/MLXArray.swift
+++ b/Source/MLX/MLXArray.swift
@@ -4,7 +4,7 @@ import Cmlx
 import Foundation
 import Numerics
 
-public final class MLXArray {
+public class MLXArray: ExpressibleByArrayLiteral {
 
     /// Internal pointer to the mlx-c wrapper on `mlx::core::array`, used with `Cmlx` interop.
     public internal(set) var ctx: mlx_array
@@ -17,6 +17,37 @@ public final class MLXArray {
         // paths will come through here -- make sure the error handler is installed.
         initError()
         self.ctx = ctx
+    }
+
+    // Note: MLXArray does not implement ExpressibleByFloatLiteral etc. because
+    // we want to create arrays in the context of the other arrays.  For example:
+    //
+    // let x = MLXArray(1.5, dtype: .float16)
+    // let r = x + 2.5
+    //
+    // We expect r to have a dtype of float16.  See ``ScalarOrArray``.
+
+    /// Initializer allowing creation of 1d `MLXArray` from an array literal.
+    ///
+    /// ```swift
+    /// let a: MLXArray = [1, 2, 3]
+    /// ```
+    ///
+    /// This is convenient for methods that have `MLXArray` parameters:
+    ///
+    /// ```swift
+    /// print(array.take([1, 2, 3], axis: 0))
+    /// ```
+    ///
+    /// ### See Also
+    /// - <doc:initialization>
+    required public convenience init(arrayLiteral elements: Int32...) {
+        let ctx = elements.withUnsafeBufferPointer { ptr in
+            let shape = [Int32(elements.count)]
+            return mlx_array_new_data(
+                ptr.baseAddress!, shape, Int32(shape.count), Int32.dtype.cmlxDtype)
+        }
+        self.init(ctx)
     }
 
     /// return the equivalent of a `.none` MLXArray (for the C API).
@@ -37,7 +68,7 @@ public final class MLXArray {
     }
 
     /// Number of bytes per element
-    public var itemSize: Int { mlx_array_itemsize(ctx) }
+    final public var itemSize: Int { mlx_array_itemsize(ctx) }
 
     /// Total number of elements in the array
     ///
@@ -46,7 +77,7 @@ public final class MLXArray {
     /// print(array.size)
     /// // 12
     /// ```
-    public var size: Int { mlx_array_size(ctx) }
+    final public var size: Int { mlx_array_size(ctx) }
 
     /// Number of elements in the 0th dimension.
     ///
@@ -62,10 +93,10 @@ public final class MLXArray {
     ///     ...
     /// }
     /// ```
-    public var count: Int { dim(0) }
+    final public var count: Int { dim(0) }
 
     /// Number of bytes in the array.
-    public var nbytes: Int { mlx_array_nbytes(ctx) }
+    final public var nbytes: Int { mlx_array_nbytes(ctx) }
 
     /// Number of dimensions in the array.
     ///
@@ -74,7 +105,7 @@ public final class MLXArray {
     /// print(array.ndim)
     /// // 2
     /// ```
-    public var ndim: Int { mlx_array_ndim(ctx) }
+    final public var ndim: Int { mlx_array_ndim(ctx) }
 
     /// Data type of the elements in the array.
     ///
@@ -83,7 +114,7 @@ public final class MLXArray {
     /// print(array.dtype)
     /// // .int64 (aka Int.dtype)
     /// ```
-    public var dtype: DType { DType(mlx_array_dtype(ctx)) }
+    final public var dtype: DType { DType(mlx_array_dtype(ctx)) }
 
     /// Dimensions of the array.
     ///
@@ -92,7 +123,7 @@ public final class MLXArray {
     /// print(array.shape)
     /// // [3, 4]
     /// ```
-    public var shape: [Int] {
+    final public var shape: [Int] {
         let ndim = mlx_array_ndim(ctx)
         guard ndim > 0 else { return [] }
         let cShape = mlx_array_shape(ctx)!
@@ -104,7 +135,7 @@ public final class MLXArray {
     /// ```swift
     /// let (w, h) = array.shape2
     /// ```
-    public var shape2: (Int, Int) {
+    final public var shape2: (Int, Int) {
         let ndim = mlx_array_ndim(ctx)
         precondition(ndim == 2)
         let cShape = mlx_array_shape(ctx)!
@@ -116,7 +147,7 @@ public final class MLXArray {
     /// ```swift
     /// let (w, h, c) = array.shape3
     /// ```
-    public var shape3: (Int, Int, Int) {
+    final public var shape3: (Int, Int, Int) {
         let ndim = mlx_array_ndim(ctx)
         precondition(ndim == 3)
         let cShape = mlx_array_shape(ctx)!
@@ -128,7 +159,7 @@ public final class MLXArray {
     /// ```swift
     /// let (b, w, h, c) = array.shape4
     /// ```
-    public var shape4: (Int, Int, Int, Int) {
+    final public var shape4: (Int, Int, Int, Int) {
         let ndim = mlx_array_ndim(ctx)
         precondition(ndim == 4)
         let cShape = mlx_array_shape(ctx)!
@@ -149,7 +180,7 @@ public final class MLXArray {
     /// Strides of the array backing.
     ///
     /// Note: this is only stable once the array is evaluated.
-    var internalStrides: [Int] {
+    final var internalStrides: [Int] {
         let ndim = mlx_array_ndim(ctx)
         guard ndim > 0 else { return [] }
         let strides = mlx_array_strides(ctx)!
@@ -167,7 +198,7 @@ public final class MLXArray {
     /// // 4.5
     /// let value: Float = array[1].item()
     /// ```
-    public func item<T: HasDType>() -> T {
+    final public func item<T: HasDType>() -> T {
         item(T.self)
     }
 
@@ -328,7 +359,7 @@ public final class MLXArray {
     /// // 4.5
     /// let value = array[1].item(Float.self)
     /// ```
-    public func item<T: HasDType>(_ type: T.Type) -> T {
+    final public func item<T: HasDType>(_ type: T.Type) -> T {
         precondition(self.size == 1)
         eval()
 
@@ -466,7 +497,7 @@ public final class MLXArray {
     /// print(array.dim(1))
     /// // 4
     /// ```
-    public func dim(_ dim: Int) -> Int {
+    final public func dim(_ dim: Int) -> Int {
         Int(mlx_array_dim(ctx, MLX.resolve(axis: dim, ndim: mlx_array_ndim(ctx)).int32))
     }
 
@@ -481,7 +512,7 @@ public final class MLXArray {
     /// print(array.dim(index))
     /// // 4
     /// ```
-    func dim(_ dim: Int32) -> Int32 {
+    final func dim(_ dim: Int32) -> Int32 {
         mlx_array_dim(ctx, MLX.resolve(axis: Int(dim), ndim: mlx_array_ndim(ctx)).int32)
     }
 
@@ -492,7 +523,7 @@ public final class MLXArray {
     ///
     /// ### See Also
     /// - <doc:conversion>
-    public func asType(_ type: DType, stream: StreamOrDevice = .default) -> MLXArray {
+    final public func asType(_ type: DType, stream: StreamOrDevice = .default) -> MLXArray {
         guard type != self.dtype else { return self }
         var result = mlx_array_new()
         mlx_astype(&result, ctx, type.cmlxDtype, stream.ctx)
@@ -506,8 +537,9 @@ public final class MLXArray {
     ///
     /// ### See Also
     /// - <doc:conversion>
-    public func asType(_ type: (some HasDType).Type, stream: StreamOrDevice = .default) -> MLXArray
-    {
+    final public func asType(
+        _ type: (some HasDType).Type, stream: StreamOrDevice = .default
+    ) -> MLXArray {
         asType(type.dtype, stream: stream)
     }
 
@@ -524,7 +556,7 @@ public final class MLXArray {
     /// - ``realPart(stream:)``
     /// - ``imaginaryPart(stream:)``
     /// - <doc:conversion>
-    public func asImaginary(stream: StreamOrDevice = .default) -> MLXArray {
+    final public func asImaginary(stream: StreamOrDevice = .default) -> MLXArray {
         precondition(!dtype.isComplex)
         let i = MLXArray(real: 0, imaginary: 1)
         return self * i
@@ -534,7 +566,7 @@ public final class MLXArray {
     ///
     /// ### See Also
     /// - <doc:conversion>
-    public func realPart(stream: StreamOrDevice = .default) -> MLXArray {
+    final public func realPart(stream: StreamOrDevice = .default) -> MLXArray {
         precondition(dtype.isComplex)
         return asType(Float.self)
     }
@@ -543,7 +575,7 @@ public final class MLXArray {
     ///
     /// ### See Also
     /// - <doc:conversion>
-    public func imaginaryPart(stream: StreamOrDevice = .default) -> MLXArray {
+    final public func imaginaryPart(stream: StreamOrDevice = .default) -> MLXArray {
         precondition(dtype.isComplex)
         let i = MLXArray(real: 0, imaginary: 1)
         return (self / i).asType(.float32)
@@ -557,6 +589,10 @@ public final class MLXArray {
         _ = withEvalLock {
             mlx_array_eval(ctx)
         }
+    }
+
+    public func materialized() -> MaterializedArray {
+        MLX.materialize(self)
     }
 
     /// Replace the contents with a reference to a new array (INTERNAL).

--- a/Source/MLX/MaterializedArray.swift
+++ b/Source/MLX/MaterializedArray.swift
@@ -1,0 +1,75 @@
+// Copyright © 2026 Apple Inc.
+
+import Cmlx
+import Foundation
+import Numerics
+
+public final class MaterializedArray: MLXArray, @unchecked Sendable {
+
+    init(materialized ctx: consuming mlx_array) {
+        super.init(ctx)
+    }
+
+    @available(*, unavailable, message: "MaterializedArray can only be created via materialize()")
+    required public convenience init(arrayLiteral elements: Int32...) {
+        fatalError("unavailable")
+    }
+
+    final public override func materialized() -> MaterializedArray {
+        self
+    }
+
+    // MARK: - Update sealing
+
+    @available(*, unavailable)
+    override public func _updateInternal(_ array: MLXArray) {
+        // Note that this might be called via:
+        //
+        // a[1] = b
+        // a += b
+        fatalError("unavailable")
+    }
+
+    // MARK: - In place operators
+
+    @available(*, unavailable)
+    public static func += (lhs: inout MaterializedArray, rhs: MLXArray) {
+        fatalError("unavailable")
+    }
+
+    @available(*, unavailable)
+    public static func += (lhs: inout MaterializedArray, rhs: some ScalarOrArray) {
+        fatalError("unavailable")
+    }
+
+    @available(*, unavailable)
+    public static func -= (lhs: inout MaterializedArray, rhs: MLXArray) {
+        fatalError("unavailable")
+    }
+
+    @available(*, unavailable)
+    public static func -= (lhs: inout MaterializedArray, rhs: some ScalarOrArray) {
+        fatalError("unavailable")
+    }
+
+    @available(*, unavailable)
+    public static func *= (lhs: inout MaterializedArray, rhs: MLXArray) {
+        fatalError("unavailable")
+    }
+
+    @available(*, unavailable)
+    public static func *= (lhs: inout MaterializedArray, rhs: some ScalarOrArray) {
+        fatalError("unavailable")
+    }
+
+    @available(*, unavailable)
+    public static func /= (lhs: inout MaterializedArray, rhs: MLXArray) {
+        fatalError("unavailable")
+    }
+
+    @available(*, unavailable)
+    public static func /= (lhs: inout MaterializedArray, rhs: some ScalarOrArray) {
+        fatalError("unavailable")
+    }
+
+}

--- a/Source/MLX/MaterializedArray.swift
+++ b/Source/MLX/MaterializedArray.swift
@@ -4,6 +4,39 @@ import Cmlx
 import Foundation
 import Numerics
 
+/// A fully-evaluated, immutable ``MLXArray`` that is safe to share across
+/// concurrency domains.
+///
+/// `MLXArray` is normally lazy: it is a handle to a node in a computation
+/// graph that is not realized until something forces it (a scalar read,
+/// an ``eval(_:)-(MLXArray...)`` call, etc.).  These unrealized arrays are
+/// not thread safe -- they require mutation for their evaluation.
+///
+/// `MaterializedArray` is a snapshot that closes that gap:
+///
+/// - The contents are evaluated at the moment of construction, so no further
+///   graph work is pending.
+/// - You can only create an instance via ``MLXArray/materialized()``
+///   or ``materialize(_:)->MaterializedArray``
+/// - Mutation methods are marked as unavailable and will `fatalError`
+///   if you somehow manage to call them.
+/// - It is declared `@unchecked Sendable` and may be passed freely between
+///   tasks, actors, and other concurrency boundaries.
+///
+/// Construction is intentionally narrow.  Obtain one via:
+///
+/// ```swift
+/// let m1 = a.materialized()
+/// let m2 = materialize(a)
+/// ```
+///
+/// A `MaterializedArray` is itself an ``MLXArray`` and can be used anywhere
+/// an `MLXArray` is accepted.  Operations involving one still produce
+/// ordinary (lazy) `MLXArray` results — only the snapshot itself is frozen.
+///
+/// ### See Also
+/// - ``MLXArray/materialized()``
+/// - ``materialize(_:)->MaterializedArray``
 public final class MaterializedArray: MLXArray, @unchecked Sendable {
 
     init(materialized ctx: consuming mlx_array) {

--- a/Source/MLX/MaterializedArray.swift
+++ b/Source/MLX/MaterializedArray.swift
@@ -19,7 +19,7 @@ import Numerics
 /// - You can only create an instance via ``MLXArray/materialized()``
 ///   or ``materialize(_:)->MaterializedArray``
 /// - Mutation methods are marked as unavailable and will `fatalError`
-///   if you somehow manage to call them.
+///   if you somehow manage to call them (e.g. through dynamic types)
 /// - It is declared `@unchecked Sendable` and may be passed freely between
 ///   tasks, actors, and other concurrency boundaries.
 ///

--- a/Source/MLX/Transforms+Compile.swift
+++ b/Source/MLX/Transforms+Compile.swift
@@ -43,7 +43,11 @@ final class CompiledFunction: @unchecked (Sendable) {
     }
 
     func innerCall(_ arguments: [MLXArray]) -> [MLXArray] {
-        let stateInputs = inputs.flatMap { $0.innerState() }
+        // MaterializedArray can never change, so it doesn't need to be
+        // threaded through the tracer swap below -- it is simply captured
+        // as a constant, the same as any other array reachable from the
+        // closure that isn't part of `inputs`/`outputs`.
+        let stateInputs = inputs.flatMap { $0.innerState() }.filter { !($0 is MaterializedArray) }
         let argumentsCount = arguments.count
 
         // inner function to hande the compilation.  this is called
@@ -70,7 +74,9 @@ final class CompiledFunction: @unchecked (Sendable) {
             let result = f(tracerArguments)
 
             // recapture the state as it may have changed
-            let stateOutputTracers = outputs.flatMap { $0.innerState() }.map { $0.copyContext() }
+            let stateOutputTracers = outputs.flatMap { $0.innerState() }
+                .filter { !($0 is MaterializedArray) }
+                .map { $0.copyContext() }
 
             // put the original values back in the state
             for (s, saved) in zip(stateInputs, savedStateInputs) {
@@ -119,7 +125,7 @@ final class CompiledFunction: @unchecked (Sendable) {
         let resultsPlusStateOutput = mlx_vector_array_values(resultVector)
 
         // push the stateOutput into the state
-        let stateOutput = outputs.flatMap { $0.innerState() }
+        let stateOutput = outputs.flatMap { $0.innerState() }.filter { !($0 is MaterializedArray) }
 
         for (s, newValues) in zip(stateOutput, resultsPlusStateOutput.suffix(stateOutput.count)) {
             s._updateInternal(newValues)

--- a/Source/MLX/Transforms+Compile.swift
+++ b/Source/MLX/Transforms+Compile.swift
@@ -176,7 +176,11 @@ final class CompiledFunction: @unchecked (Sendable) {
     ///   too unless this function has no observed state; see ``call(_:)``,
     ///   which is the only caller.
     func innerCall(_ arguments: [MLXArray]) -> [MLXArray] {
-        let stateInputs = inputs.flatMap { $0.innerState() }
+        // MaterializedArray can never change, so it doesn't need to be
+        // threaded through the tracer swap below -- it is simply captured
+        // as a constant, the same as any other array reachable from the
+        // closure that isn't part of `inputs`/`outputs`.
+        let stateInputs = inputs.flatMap { $0.innerState() }.filter { !($0 is MaterializedArray) }
         let argumentsCount = arguments.count
 
         // inner function to hande the compilation.  this is called
@@ -203,7 +207,9 @@ final class CompiledFunction: @unchecked (Sendable) {
             let result = f(tracerArguments)
 
             // recapture the state as it may have changed
-            let stateOutputTracers = outputs.flatMap { $0.innerState() }.map { $0.copyContext() }
+            let stateOutputTracers = outputs.flatMap { $0.innerState() }
+                .filter { !($0 is MaterializedArray) }
+                .map { $0.copyContext() }
 
             // put the original values back in the state
             for (s, saved) in zip(stateInputs, savedStateInputs) {
@@ -253,7 +259,7 @@ final class CompiledFunction: @unchecked (Sendable) {
         let resultsPlusStateOutput = mlx_vector_array_values(resultVector)
 
         // push the stateOutput into the state
-        let stateOutput = outputs.flatMap { $0.innerState() }
+        let stateOutput = outputs.flatMap { $0.innerState() }.filter { !($0 is MaterializedArray) }
 
         for (s, newValues) in zip(stateOutput, resultsPlusStateOutput.suffix(stateOutput.count)) {
             s._updateInternal(newValues)

--- a/Source/MLX/Transforms+Eval.swift
+++ b/Source/MLX/Transforms+Eval.swift
@@ -8,6 +8,20 @@ import Foundation
 /// call back into eval.
 let evalLock = NSRecursiveLock()
 
+/// Evaluate `array` and return a ``MaterializedArray`` snapshot of its contents.
+///
+/// The returned array is fully evaluated, immutable, and `Sendable`, so it can
+/// be passed across task and actor boundaries.  See ``MaterializedArray`` for
+/// the full set of guarantees.
+///
+/// `array` itself is unaffected — it remains the same lazy ``MLXArray`` it was
+/// before the call — but because evaluation is forced, any pending graph work
+/// behind it has been realized as a side effect.
+///
+/// ### See Also
+/// - ``MaterializedArray``
+/// - ``MLXArray/materialized()``
+/// - ``materialize(_:)``
 public func materialize(_ array: MLXArray) -> MaterializedArray {
     eval(array)
     var m = mlx_array_new()
@@ -15,6 +29,16 @@ public func materialize(_ array: MLXArray) -> MaterializedArray {
     return MaterializedArray(materialized: m)
 }
 
+/// Evaluate `arrays` and return a ``MaterializedArray`` snapshot for each one.
+///
+/// Equivalent to calling ``materialize(_:)`` on each element, but evaluates the
+/// whole batch in a single ``eval(_:)-(Sequence<Any>)`` call so MLX can schedule the
+/// work together.  Prefer this overload when you need to materialize several
+/// arrays at once — for example, the parameters of a model.
+///
+/// ### See Also
+/// - ``MaterializedArray``
+/// - ``materialize(_:)``
 public func materialize(_ arrays: [MLXArray]) -> [MaterializedArray] {
     eval(arrays)
     return arrays.map {

--- a/Source/MLX/Transforms+Eval.swift
+++ b/Source/MLX/Transforms+Eval.swift
@@ -8,6 +8,22 @@ import Foundation
 /// call back into eval.
 let evalLock = NSRecursiveLock()
 
+public func materialize(_ array: MLXArray) -> MaterializedArray {
+    eval(array)
+    var m = mlx_array_new()
+    mlx_array_set(&m, array.ctx)
+    return MaterializedArray(materialized: m)
+}
+
+public func materialize(_ arrays: [MLXArray]) -> [MaterializedArray] {
+    eval(arrays)
+    return arrays.map {
+        var m = mlx_array_new()
+        mlx_array_set(&m, $0.ctx)
+        return MaterializedArray(materialized: m)
+    }
+}
+
 /// Evaluate one or more `MLXArray`
 ///
 /// ### See Also

--- a/Source/MLX/Transforms+Eval.swift
+++ b/Source/MLX/Transforms+Eval.swift
@@ -115,6 +115,20 @@ func withEvalLock<R>(_ body: () throws -> R) rethrows -> R {
     return try body()
 }
 
+/// Evaluate `array` and return a ``MaterializedArray`` snapshot of its contents.
+///
+/// The returned array is fully evaluated, immutable, and `Sendable`, so it can
+/// be passed across task and actor boundaries.  See ``MaterializedArray`` for
+/// the full set of guarantees.
+///
+/// `array` itself is unaffected — it remains the same lazy ``MLXArray`` it was
+/// before the call — but because evaluation is forced, any pending graph work
+/// behind it has been realized as a side effect.
+///
+/// ### See Also
+/// - ``MaterializedArray``
+/// - ``MLXArray/materialized()``
+/// - ``materialize(_:)``
 public func materialize(_ array: MLXArray) -> MaterializedArray {
     eval(array)
     var m = mlx_array_new()
@@ -122,6 +136,16 @@ public func materialize(_ array: MLXArray) -> MaterializedArray {
     return MaterializedArray(materialized: m)
 }
 
+/// Evaluate `arrays` and return a ``MaterializedArray`` snapshot for each one.
+///
+/// Equivalent to calling ``materialize(_:)`` on each element, but evaluates the
+/// whole batch in a single ``eval(_:)-(Sequence<Any>)`` call so MLX can schedule the
+/// work together.  Prefer this overload when you need to materialize several
+/// arrays at once — for example, the parameters of a model.
+///
+/// ### See Also
+/// - ``MaterializedArray``
+/// - ``materialize(_:)``
 public func materialize(_ arrays: [MLXArray]) -> [MaterializedArray] {
     eval(arrays)
     return arrays.map {

--- a/Source/MLX/Transforms+Eval.swift
+++ b/Source/MLX/Transforms+Eval.swift
@@ -115,6 +115,22 @@ func withEvalLock<R>(_ body: () throws -> R) rethrows -> R {
     return try body()
 }
 
+public func materialize(_ array: MLXArray) -> MaterializedArray {
+    eval(array)
+    var m = mlx_array_new()
+    mlx_array_set(&m, array.ctx)
+    return MaterializedArray(materialized: m)
+}
+
+public func materialize(_ arrays: [MLXArray]) -> [MaterializedArray] {
+    eval(arrays)
+    return arrays.map {
+        var m = mlx_array_new()
+        mlx_array_set(&m, $0.ctx)
+        return MaterializedArray(materialized: m)
+    }
+}
+
 /// Evaluate one or more `MLXArray`
 ///
 /// ### See Also

--- a/Source/MLXNN/Documentation.docc/MLXNN.md
+++ b/Source/MLXNN/Documentation.docc/MLXNN.md
@@ -41,6 +41,18 @@ respect to these trainable parameters.
 
 See <doc:training>
 
+### Concurrency
+
+A ``Module`` is not `Sendable` because its parameters are lazy, mutable
+`MLXArray` values.  To share a model across task or actor boundaries, wrap it
+in a ``MaterializedModule``, which evaluates every parameter, replaces the
+mutable ones with `MaterializedArray` snapshots, and seals the module against
+further mutation.
+
+```swift
+let model = MaterializedModule(Linear(10, 10))
+```
+
 ## Other MLX Packages
 
 - [MLX](mlx)
@@ -58,6 +70,7 @@ See <doc:training>
 ### Base Classes and Interfaces
 
 - ``Module``
+- ``MaterializedModule``
 - ``UnaryLayer``
 - ``Quantizable``
 

--- a/Source/MLXNN/Linear.swift
+++ b/Source/MLXNN/Linear.swift
@@ -69,8 +69,8 @@ public class Identity: Module, UnaryLayer {
 /// - ``Bilinear``
 open class Linear: Module, UnaryLayer, Quantizable {
 
-    public let weight: MLXArray
-    public let bias: MLXArray?
+    @ParameterInfo public var weight: MLXArray
+    @ParameterInfo public var bias: MLXArray?
 
     open var shape: (Int, Int) {
         weight.shape2

--- a/Source/MLXNN/MaterializedModule.swift
+++ b/Source/MLXNN/MaterializedModule.swift
@@ -132,6 +132,9 @@ open class MaterializedModule<LayerType: Module>: IndentedDescription, @unchecke
     /// Sum of all the `nbytes` of the parameters in the encapsulated model.
     public let parameterNBytes: Int
 
+    /// Sum of all the `nbytes` of the parameters in the encapsulated model.
+    public let parameterCount: Int
+
     public init(_ base: consuming LayerType) {
         self._base = base
         self._base.materialize()
@@ -142,6 +145,7 @@ open class MaterializedModule<LayerType: Module>: IndentedDescription, @unchecke
         self._base._sealImmutable()
 
         parameterNBytes = _base.parameters().reduce(0) { $0 + $1.nbytes }
+        parameterCount = _base.children().reduce(0) { $0 + $1.parameterCount }
     }
 
     /// Return a `NestedDictionary<String, MaterializedArray>` for all parameters in the

--- a/Source/MLXNN/MaterializedModule.swift
+++ b/Source/MLXNN/MaterializedModule.swift
@@ -78,7 +78,9 @@ open class MaterializedModule<LayerType: Module>: Module, @unchecked Sendable {
         try self.base.materialize()
 
         // force caching of accessors (buildCaches)
-        _ = base.items()
+        _ = self.base.items()
+        super.init()
+        _ = self.items()
     }
 
     override func materialize() throws {

--- a/Source/MLXNN/MaterializedModule.swift
+++ b/Source/MLXNN/MaterializedModule.swift
@@ -1,0 +1,78 @@
+// Copyright © 2026 Apple Inc.
+
+import MLX
+
+open class MaterializedModule<LayerType: Module>: Module, @unchecked Sendable {
+
+    let base: LayerType
+
+    public init(_ base: consuming LayerType) throws {
+        self.base = base
+        try self.base.materialize()
+
+        // force caching of accessors (buildCaches)
+        _ = base.items()
+    }
+
+    override func materialize() throws {
+        // NOP
+    }
+
+    @available(*, unavailable)
+    @discardableResult
+    open override func update(
+        parameters: ModuleParameters, verify: VerifyUpdate, path: [String] = [],
+        modulePath: [String] = []
+    ) throws -> Self {
+        fatalError("unavailable")
+    }
+
+    @available(*, unavailable)
+    @discardableResult
+    open override func apply(
+        filter: (Module, String, ModuleItem) -> Bool = Module.filterValidParameters,
+        map: @escaping (MLXArray) -> MLXArray
+    ) -> Self {
+        fatalError("unavailable")
+    }
+
+    @available(*, unavailable)
+    @discardableResult
+    open override func update(
+        modules: ModuleChildren, verify: VerifyUpdate, path: [String] = [],
+        modulePath: [String] = []
+    ) throws -> Self {
+        fatalError("unavailable")
+    }
+
+    @available(*, unavailable)
+    open override func updateModule(key: String, _ value: Any) throws {
+        fatalError("unavailable")
+    }
+
+    @available(*, unavailable)
+    public override func freeze(recursive: Bool = true, keys: [String]? = nil, strict: Bool = false)
+        throws
+    {
+        fatalError("unavailable")
+    }
+
+    @available(*, unavailable)
+    public override func unfreeze(
+        recursive: Bool = true, keys: [String]? = nil, strict: Bool = false
+    ) throws {
+        fatalError("unavailable")
+    }
+
+    @available(*, unavailable)
+    public override func train(_ mode: Bool = true) {
+        fatalError("unavailable")
+    }
+
+}
+
+extension MaterializedModule where LayerType: UnaryLayer {
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        base(x)
+    }
+}

--- a/Source/MLXNN/MaterializedModule.swift
+++ b/Source/MLXNN/MaterializedModule.swift
@@ -24,8 +24,13 @@ import MLX
 /// original `base` reference after passing it in**.  Because `Module` is a
 /// reference type, Swift cannot enforce this for you: a caller who keeps a
 /// reference and later mutates it will violate the `Sendable` invariant
-/// that `MaterializedModule` relies on.  In other words, `Sendable` here is
-/// a contract you can follow rather than a guarantee the compiler proves.
+/// that `MaterializedModule` relies on.  As a runtime backstop, the base
+/// module and all of its descendants are sealed during initialization —
+/// any subsequent call to a mutating API (`update(parameters:)`,
+/// `update(modules:)`, `apply(...)`, `freeze`/`unfreeze`, `train`) on the
+/// retained reference will trap with `fatalError`.  In other words,
+/// `Sendable` here is a contract you can follow rather than a guarantee
+/// the compiler proves, but a violation fails loudly rather than silently.
 /// The recommended pattern is to construct the base module inline at the
 /// `MaterializedModule(...)` call site, as shown above, so no other
 /// reference exists.
@@ -62,16 +67,16 @@ import MLX
 /// ```swift
 /// extension MaterializedModule where LayerType: AttentionBlock {
 ///     public func callAsFunction(_ x: MLXArray, mask: MLXArray?) -> MLXArray {
-///         base(x, mask: mask)
+///         _base(x, mask: mask)
 ///     }
 /// }
 /// ```
 ///
 /// The pattern is always the same: constrain `LayerType` to the protocol or
 /// concrete type that exposes the call you want, then forward to `base`.
-open class MaterializedModule<LayerType: Module>: Module, @unchecked Sendable {
-
+open class MaterializedModule<LayerType: Module>: ModuleInference, @unchecked Sendable {
     /// Usable by extensions to implement `callAsFunction()` -- anyone else, DO NOT USE.
+    @_spi(MaterializedModule)
     public let _base: LayerType
 
     public init(_ base: consuming LayerType) {
@@ -81,63 +86,39 @@ open class MaterializedModule<LayerType: Module>: Module, @unchecked Sendable {
         // force caching of accessors (buildCaches) as
         // these are not thread safe
         _ = self._base.items()
-        super.init()
-        _ = self.items()
+
+        // seal the consumed base so that any retained reference held by a
+        // caller (despite the `consuming` contract) traps on mutation
+        // rather than silently violating Sendable
+        self._base._sealImmutable()
     }
 
-    override func materialize() {
-        // NOP
+    public func parameters() -> ModuleParameters {
+        _base.parameters()
     }
 
-    @available(*, unavailable)
-    @discardableResult
-    open override func update(
-        parameters: ModuleParameters, verify: VerifyUpdate, path: [String] = [],
-        modulePath: [String] = []
-    ) throws -> Self {
-        fatalError("unavailable")
+    public func children() -> ModuleChildren {
+        _base.children()
     }
 
-    @available(*, unavailable)
-    @discardableResult
-    open override func apply(
-        filter: (Module, String, ModuleItem) -> Bool = Module.filterValidParameters,
-        map: @escaping (MLXArray) -> MLXArray
-    ) -> Self {
-        fatalError("unavailable")
+    public func leafModules() -> ModuleChildren {
+        _base.leafModules()
     }
 
-    @available(*, unavailable)
-    @discardableResult
-    open override func update(
-        modules: ModuleChildren, verify: VerifyUpdate, path: [String] = [],
-        modulePath: [String] = []
-    ) throws -> Self {
-        fatalError("unavailable")
+    public func modules() -> [Module] {
+        _base.modules()
     }
 
-    @available(*, unavailable)
-    open override func updateModule(key: String, _ value: Any) throws {
-        fatalError("unavailable")
+    public func namedModules() -> [(String, Module)] {
+        _base.namedModules()
     }
 
-    @available(*, unavailable)
-    public override func freeze(recursive: Bool = true, keys: [String]? = nil, strict: Bool = false)
-        throws
-    {
-        fatalError("unavailable")
+    public func description(indent: Int) -> String {
+        _base.description(indent: indent)
     }
 
-    @available(*, unavailable)
-    public override func unfreeze(
-        recursive: Bool = true, keys: [String]? = nil, strict: Bool = false
-    ) throws {
-        fatalError("unavailable")
-    }
-
-    @available(*, unavailable)
-    public override func train(_ mode: Bool = true) {
-        fatalError("unavailable")
+    public func innerState() -> [MLX.MLXArray] {
+        _base.innerState()
     }
 
 }

--- a/Source/MLXNN/MaterializedModule.swift
+++ b/Source/MLXNN/MaterializedModule.swift
@@ -136,10 +136,6 @@ open class MaterializedModule<LayerType: Module>: IndentedDescription, @unchecke
         self._base = base
         self._base.materialize()
 
-        // force caching of accessors (buildCaches) as
-        // these are not thread safe
-        _ = self._base.items()
-
         // seal the consumed base so that any retained reference held by a
         // caller (despite the `consuming` contract) traps on mutation
         // rather than silently violating Sendable

--- a/Source/MLXNN/MaterializedModule.swift
+++ b/Source/MLXNN/MaterializedModule.swift
@@ -74,9 +74,9 @@ open class MaterializedModule<LayerType: Module>: Module, @unchecked Sendable {
     /// Usable by extensions to implement `callAsFunction()` -- anyone else, DO NOT USE.
     public let _base: LayerType
 
-    public init(_ base: consuming LayerType) throws {
+    public init(_ base: consuming LayerType) {
         self._base = base
-        try self._base.materialize()
+        self._base.materialize()
 
         // force caching of accessors (buildCaches) as
         // these are not thread safe
@@ -85,7 +85,7 @@ open class MaterializedModule<LayerType: Module>: Module, @unchecked Sendable {
         _ = self.items()
     }
 
-    override func materialize() throws {
+    override func materialize() {
         // NOP
     }
 

--- a/Source/MLXNN/MaterializedModule.swift
+++ b/Source/MLXNN/MaterializedModule.swift
@@ -2,8 +2,8 @@
 
 import MLX
 
-/// A `Module` whose parameters have been materialized so that the whole
-/// module is safe to share across concurrency domains.
+/// A container for a `Module` whose parameters have been materialized so that
+/// the whole module is safe to share across concurrency domains.
 ///
 /// A normal ``Module`` is not `Sendable`: its parameters are `MLXArray`
 /// instances, which are lazy and may be mutated in place during evaluation
@@ -11,6 +11,11 @@ import MLX
 /// parameter, replaces each with a `MaterializedArray`, and seals the
 /// mutation surface so the wrapped module cannot be modified through this
 /// reference.
+///
+/// Note: only parameters that can be be mutated, e.g. are wrapped with `@ParameterInfo`,
+/// will actually be updated to the `MaterializedArray` type.  All others will
+/// be evaluated and are materialized, even if they do not have the type
+/// indicating that fact.
 ///
 /// ## Construction and the `consuming` contract
 ///
@@ -61,23 +66,71 @@ import MLX
 /// }
 /// ```
 ///
-/// Layers with different call signatures can be wrapped the same way.  For a
-/// transformer-style block that takes a tensor and an attention mask:
+/// A pattern that is used in `mlx-swift-lm` works like this.
+///
+/// The model is defined in terms of a protocol.  All language models (LLMs and VLMs)
+/// implement this protocol.  Note: in reality there are more methods and
+/// a `BaseLanguageModel` that lifts out methods useful to Embedding models.
+/// For this illustration it is simplified as those details are irrelevant to the technique.
 ///
 /// ```swift
-/// extension MaterializedModule where LayerType: AttentionBlock {
-///     public func callAsFunction(_ x: MLXArray, mask: MLXArray?) -> MLXArray {
-///         _base(x, mask: mask)
+/// public protocol LanguageModel {
+///     func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray
+/// }
+/// ```
+///
+/// Then an extension to `MaterializedModule` is created where the
+/// interior layer is of the given type and `MaterializedModule` is made
+/// to conform to the type:
+///
+/// ```swift
+/// // this allows access to _base
+/// @_spi(MaterializedModule) import MLXNN
+///
+/// extension MaterializedModule: LanguageModel where LayerType: LanguageModel {
+///
+///     public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+///         _base.callAsFunction(inputs, cache: cache)
 ///     }
 /// }
 /// ```
 ///
-/// The pattern is always the same: constrain `LayerType` to the protocol or
-/// concrete type that exposes the call you want, then forward to `base`.
-open class MaterializedModule<LayerType: Module>: ModuleInference, @unchecked Sendable {
-    /// Usable by extensions to implement `callAsFunction()` -- anyone else, DO NOT USE.
+/// Finally there is a specific way that types can consume this.  Note the
+/// use of `any` and `some`.
+///
+/// ```swift
+/// public struct ModelContext: Sendable {
+///     public var model: any LanguageModel & Sendable
+///
+///     public init(
+///     model: some LanguageModel, ...
+///     ) {
+///         self.model = MaterializedModule(model)
+///         ...
+///     }
+/// }
+/// ```
+///
+/// ### Design Notes
+///
+/// Why use extensions?  Why not subclass?  Certainly it could, but it does require that the type you
+/// are specializing to is a subtype of `Module`.  You can't do this:
+///
+/// ```swift
+/// class MaterializedUnaryLayer: MaterializedModule<UnaryLayer> { ... }
+/// ```
+///
+/// because `UnaryLayer` is not a `Module`.
+///
+/// The class is `open` so you could give it a try.
+open class MaterializedModule<LayerType: Module>: IndentedDescription, @unchecked Sendable {
+
+    /// Usable by extensions to implement `callAsFunction()`
     @_spi(MaterializedModule)
     public let _base: LayerType
+
+    /// Sum of all the `nbytes` of the parameters in the encapsulated model.
+    public let parameterNBytes: Int
 
     public init(_ base: consuming LayerType) {
         self._base = base
@@ -91,36 +144,22 @@ open class MaterializedModule<LayerType: Module>: ModuleInference, @unchecked Se
         // caller (despite the `consuming` contract) traps on mutation
         // rather than silently violating Sendable
         self._base._sealImmutable()
+
+        parameterNBytes = _base.parameters().reduce(0) { $0 + $1.nbytes }
     }
 
-    public func parameters() -> ModuleParameters {
-        _base.parameters()
-    }
-
-    public func children() -> ModuleChildren {
-        _base.children()
-    }
-
-    public func leafModules() -> ModuleChildren {
-        _base.leafModules()
-    }
-
-    public func modules() -> [Module] {
-        _base.modules()
-    }
-
-    public func namedModules() -> [(String, Module)] {
-        _base.namedModules()
+    /// Return a `NestedDictionary<String, MaterializedArray>` for all parameters in the
+    /// model (all layers).
+    public func parameters() -> NestedDictionary<String, MaterializedArray> {
+        // Note: the enclosed Module will have had all its parameters evaluated
+        // in init, but because it can't replace all parameters they may be typed
+        // as MLXArray.
+        _base.parameters().mapValues { $0.materialized() }
     }
 
     public func description(indent: Int) -> String {
         _base.description(indent: indent)
     }
-
-    public func innerState() -> [MLX.MLXArray] {
-        _base.innerState()
-    }
-
 }
 
 extension MaterializedModule where LayerType: UnaryLayer {

--- a/Source/MLXNN/MaterializedModule.swift
+++ b/Source/MLXNN/MaterializedModule.swift
@@ -145,7 +145,7 @@ open class MaterializedModule<LayerType: Module>: IndentedDescription, @unchecke
         self._base._sealImmutable()
 
         parameterNBytes = _base.parameters().reduce(0) { $0 + $1.nbytes }
-        parameterCount = _base.children().reduce(0) { $0 + $1.parameterCount }
+        parameterCount = _base.parameterCount
     }
 
     /// Return a `NestedDictionary<String, MaterializedArray>` for all parameters in the

--- a/Source/MLXNN/MaterializedModule.swift
+++ b/Source/MLXNN/MaterializedModule.swift
@@ -51,7 +51,7 @@ import MLX
 /// ```swift
 /// extension MaterializedModule where LayerType: UnaryLayer {
 ///     public func callAsFunction(_ x: MLXArray) -> MLXArray {
-///         base(x)
+///         _base(x)
 ///     }
 /// }
 /// ```
@@ -71,14 +71,16 @@ import MLX
 /// concrete type that exposes the call you want, then forward to `base`.
 open class MaterializedModule<LayerType: Module>: Module, @unchecked Sendable {
 
-    let base: LayerType
+    /// Usable by extensions to implement `callAsFunction()` -- anyone else, DO NOT USE.
+    public let _base: LayerType
 
     public init(_ base: consuming LayerType) throws {
-        self.base = base
-        try self.base.materialize()
+        self._base = base
+        try self._base.materialize()
 
-        // force caching of accessors (buildCaches)
-        _ = self.base.items()
+        // force caching of accessors (buildCaches) as
+        // these are not thread safe
+        _ = self._base.items()
         super.init()
         _ = self.items()
     }
@@ -142,6 +144,6 @@ open class MaterializedModule<LayerType: Module>: Module, @unchecked Sendable {
 
 extension MaterializedModule where LayerType: UnaryLayer {
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
-        base(x)
+        _base(x)
     }
 }

--- a/Source/MLXNN/MaterializedModule.swift
+++ b/Source/MLXNN/MaterializedModule.swift
@@ -132,7 +132,7 @@ open class MaterializedModule<LayerType: Module>: IndentedDescription, @unchecke
     /// Sum of all the `nbytes` of the parameters in the encapsulated model.
     public let parameterNBytes: Int
 
-    /// Sum of all the `nbytes` of the parameters in the encapsulated model.
+    /// Sum of all the `parameterCount` of the modules in the encapsulated model.
     public let parameterCount: Int
 
     public init(_ base: consuming LayerType) {

--- a/Source/MLXNN/MaterializedModule.swift
+++ b/Source/MLXNN/MaterializedModule.swift
@@ -2,6 +2,73 @@
 
 import MLX
 
+/// A `Module` whose parameters have been materialized so that the whole
+/// module is safe to share across concurrency domains.
+///
+/// A normal ``Module`` is not `Sendable`: its parameters are ``MLXArray``
+/// instances, which are lazy and may be mutated in place during evaluation
+/// or training.  `MaterializedModule` wraps a base module, evaluates every
+/// parameter, replaces each with a ``MaterializedArray``, and seals the
+/// mutation surface so the wrapped module cannot be modified through this
+/// reference.
+///
+/// ## Construction and the `consuming` contract
+///
+/// The initializer takes its base module as `consuming`:
+///
+/// ```swift
+/// let lm = try MaterializedModule(Linear(10, 10))
+/// ```
+///
+/// `consuming` expresses intent — **the caller must not retain or use the
+/// original `base` reference after passing it in**.  Because `Module` is a
+/// reference type, Swift cannot enforce this for you: a caller who keeps a
+/// reference and later mutates it will violate the `Sendable` invariant
+/// that `MaterializedModule` relies on.  In other words, `Sendable` here is
+/// a contract you can follow rather than a guarantee the compiler proves.
+/// The recommended pattern is to construct the base module inline at the
+/// `MaterializedModule(...)` call site, as shown above, so no other
+/// reference exists.
+///
+/// ## What is sealed
+///
+/// The following `Module` operations are marked `@available(*, unavailable)`
+/// on `MaterializedModule` and will trap if called:
+///
+/// - `update(parameters:...)` and `update(modules:...)`
+/// - `updateModule(key:_:)`
+/// - `apply(filter:map:)`
+/// - `freeze(...)` / `unfreeze(...)`
+/// - `train(_:)`
+///
+/// ## Calling the wrapped module
+///
+/// `MaterializedModule` does not itself know how to invoke `base`; that is
+/// added per-layer-shape via an extension that constrains `LayerType`.
+/// For example, every ``UnaryLayer`` already supports being called with a
+/// single `MLXArray`, so the package ships:
+///
+/// ```swift
+/// extension MaterializedModule where LayerType: UnaryLayer {
+///     public func callAsFunction(_ x: MLXArray) -> MLXArray {
+///         base(x)
+///     }
+/// }
+/// ```
+///
+/// Layers with different call signatures can be wrapped the same way.  For a
+/// transformer-style block that takes a tensor and an attention mask:
+///
+/// ```swift
+/// extension MaterializedModule where LayerType: AttentionBlock {
+///     public func callAsFunction(_ x: MLXArray, mask: MLXArray?) -> MLXArray {
+///         base(x, mask: mask)
+///     }
+/// }
+/// ```
+///
+/// The pattern is always the same: constrain `LayerType` to the protocol or
+/// concrete type that exposes the call you want, then forward to `base`.
 open class MaterializedModule<LayerType: Module>: Module, @unchecked Sendable {
 
     let base: LayerType

--- a/Source/MLXNN/MaterializedModule.swift
+++ b/Source/MLXNN/MaterializedModule.swift
@@ -5,10 +5,10 @@ import MLX
 /// A `Module` whose parameters have been materialized so that the whole
 /// module is safe to share across concurrency domains.
 ///
-/// A normal ``Module`` is not `Sendable`: its parameters are ``MLXArray``
+/// A normal ``Module`` is not `Sendable`: its parameters are `MLXArray`
 /// instances, which are lazy and may be mutated in place during evaluation
 /// or training.  `MaterializedModule` wraps a base module, evaluates every
-/// parameter, replaces each with a ``MaterializedArray``, and seals the
+/// parameter, replaces each with a `MaterializedArray`, and seals the
 /// mutation surface so the wrapped module cannot be modified through this
 /// reference.
 ///

--- a/Source/MLXNN/MaterializedModule.swift
+++ b/Source/MLXNN/MaterializedModule.swift
@@ -24,7 +24,7 @@ import MLX
 /// The initializer takes its base module as `consuming`:
 ///
 /// ```swift
-/// let lm = try MaterializedModule(Linear(10, 10))
+/// let lm = MaterializedModule(Linear(10, 10))
 /// ```
 ///
 /// `consuming` expresses intent — **the caller must not retain or use the
@@ -52,7 +52,7 @@ import MLX
 ///
 /// ## Calling the wrapped module
 ///
-/// `MaterializedModule`is not a `Module` subclass and cannot conform
+/// `MaterializedModule` is not a `Module` subclass and cannot conform
 /// to protocols that have `Module` requirements.  Users may want to split their
 /// protocols into requirements for performing inference (which
 /// `MaterializedModule` is meant for) and for doing training where `Module`
@@ -125,7 +125,7 @@ import MLX
 /// class MaterializedUnaryLayer: MaterializedModule<UnaryLayer> { ... }
 /// ```
 ///
-/// because `UnaryLayer` is not a `Module`.
+/// because `UnaryLayer` is not a concrete type, it is a protocol.
 ///
 /// The class is `open` so you could give it a try.
 open class MaterializedModule<LayerType: Module>: IndentedDescription, @unchecked Sendable {

--- a/Source/MLXNN/MaterializedModule.swift
+++ b/Source/MLXNN/MaterializedModule.swift
@@ -12,6 +12,8 @@ import MLX
 /// mutation surface so the wrapped module cannot be modified through this
 /// reference.
 ///
+/// This also sets ``Module/training`` to `false`.
+///
 /// Note: only parameters that can be be mutated, e.g. are wrapped with `@ParameterInfo`,
 /// will actually be updated to the `MaterializedArray` type.  All others will
 /// be evaluated and are materialized, even if they do not have the type
@@ -42,16 +44,19 @@ import MLX
 ///
 /// ## What is sealed
 ///
-/// The following `Module` operations are marked `@available(*, unavailable)`
-/// on `MaterializedModule` and will trap if called:
-///
-/// - `update(parameters:...)` and `update(modules:...)`
-/// - `updateModule(key:_:)`
-/// - `apply(filter:map:)`
-/// - `freeze(...)` / `unfreeze(...)`
-/// - `train(_:)`
+/// `MaterializedModule` is not a `Module` and does not provide access to the
+/// wrapped `Module`.  No access to bare `MLXArray` is provided, though
+/// for purposes of introspection the ``parameters()`` can give
+/// `MaterializedArray`.  There are also properties like ``parameterNBytes``
+/// and ``parameterCount`` for callers that just need size information.
 ///
 /// ## Calling the wrapped module
+///
+/// `MaterializedModule`is not a `Module` subclass and cannot conform
+/// to protocols that have `Module` requirements.  Users may want to split their
+/// protocols into requirements for performing inference (which
+/// `MaterializedModule` is meant for) and for doing training where `Module`
+/// is required and this type is not appropriate (immutable).
 ///
 /// `MaterializedModule` does not itself know how to invoke `base`; that is
 /// added per-layer-shape via an extension that constrains `LayerType`.
@@ -137,6 +142,8 @@ open class MaterializedModule<LayerType: Module>: IndentedDescription, @unchecke
 
     public init(_ base: consuming LayerType) {
         self._base = base
+
+        self._base.train(false)
         self._base.materialize()
 
         // seal the consumed base so that any retained reference held by a

--- a/Source/MLXNN/MaterializedModule.swift
+++ b/Source/MLXNN/MaterializedModule.swift
@@ -143,7 +143,7 @@ open class MaterializedModule<LayerType: Module>: IndentedDescription, @unchecke
     public init(_ base: consuming LayerType) {
         self._base = base
 
-        if !base._isImmutable {
+        if !self._base._isImmutable {
             self._base.train(false)
             self._base.materialize()
 
@@ -157,8 +157,8 @@ open class MaterializedModule<LayerType: Module>: IndentedDescription, @unchecke
             // but is ultimately harmless.
         }
 
-        parameterNBytes = _base.parameters().reduce(0) { $0 + $1.nbytes }
-        parameterCount = _base.parameterCount
+        parameterNBytes = self._base.parameters().reduce(0) { $0 + $1.nbytes }
+        parameterCount = self._base.parameterCount
     }
 
     /// Return a `NestedDictionary<String, MaterializedArray>` for all parameters in the

--- a/Source/MLXNN/MaterializedModule.swift
+++ b/Source/MLXNN/MaterializedModule.swift
@@ -143,13 +143,19 @@ open class MaterializedModule<LayerType: Module>: IndentedDescription, @unchecke
     public init(_ base: consuming LayerType) {
         self._base = base
 
-        self._base.train(false)
-        self._base.materialize()
+        if !base._isImmutable {
+            self._base.train(false)
+            self._base.materialize()
 
-        // seal the consumed base so that any retained reference held by a
-        // caller (despite the `consuming` contract) traps on mutation
-        // rather than silently violating Sendable
-        self._base._sealImmutable()
+            // seal the consumed base so that any retained reference held by a
+            // caller (despite the `consuming` contract) traps on mutation
+            // rather than silently violating Sendable
+            self._base._sealImmutable()
+        } else {
+            // it is already immutable.  could be a fatalError -- it suggests
+            // that the module was retained past encapsulation in a MaterializedModule,
+            // but is ultimately harmless.
+        }
 
         parameterNBytes = _base.parameters().reduce(0) { $0 + $1.nbytes }
         parameterCount = _base.parameterCount

--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -563,7 +563,7 @@ open class Module {
         }
     }
 
-    func materialize() throws {
+    func materialize() {
         // bulk eval the parameters
         eval(self.parameters())
 
@@ -572,7 +572,9 @@ open class Module {
             filter: { _, _, _ in true },
             map: Self.mapParameters(map: { $0.materialized() as MLXArray }))
 
-        try update(parameters: newParameters, verify: .none) { m, k, a, v in
+        // not verifying and setting with same value -- any
+        // errors are programming errors
+        try! update(parameters: newParameters, verify: .none) { m, k, a, v in
             if let setter = m._setters?[k] {
                 do {
                     // use the setter to replace the array

--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -194,12 +194,14 @@ open class Module {
         }
     }
 
-    /// Count of the parameters directly attached to this Module
+    /// Count of the parameters at and beneath this Module
     open var parameterCount: Int {
         items().reduce(0) {
             switch $1 {
             case .parameters(let p):
                 $0 + p.size
+            case .module(let m):
+                $0 + m.parameterCount
             default:
                 $0
             }

--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -123,6 +123,8 @@ open class Module {
 
                 if let (_, _, setter) = isModuleInfo(c.value) {
                     setters[key] = setter
+                } else if let provider = c.value as? TypeErasedSetterProvider {
+                    setters[key] = provider.typeErasedSetter()
                 }
             }
 
@@ -449,7 +451,18 @@ open class Module {
         parameters: ModuleParameters, verify: VerifyUpdate, path: [String] = [],
         modulePath: [String] = []
     ) throws -> Self {
+        try update(parameters: parameters, verify: verify, path: path, modulePath: modulePath) {
+            m, k, a, v in
+            a._updateInternal(v)
+        }
+        return self
+    }
 
+    func update(
+        parameters: ModuleParameters, verify: VerifyUpdate, path: [String] = [],
+        modulePath: [String] = [],
+        mutate: (Module, String, MLXArray, MLXArray) -> Void
+    ) throws {
         let modulePath = modulePath + [describeType(self)]
 
         func apply(
@@ -471,7 +484,7 @@ open class Module {
                         path: path, modules: modulePath, expectedShape: p.shape,
                         actualShape: newArray.shape)
                 }
-                p._updateInternal(newArray)
+                mutate(self, key, p, newArray)
 
             case (.value(.parameters), .none):
                 if Self.parameterIsValid(key) {
@@ -517,12 +530,12 @@ open class Module {
             case (.value(.module(let module)), .dictionary(let values)):
                 try module.update(
                     parameters: NestedDictionary(values: values), verify: verify, path: path,
-                    modulePath: modulePath)
+                    modulePath: modulePath, mutate: mutate)
 
             case (.value(.module(let module)), .none):
                 try module.update(
                     parameters: NestedDictionary(), verify: verify, path: path,
-                    modulePath: modulePath)
+                    modulePath: modulePath, mutate: mutate)
 
             case (.none, .none), (.value(.none), .none), (.value(.other(_)), .none):
                 break
@@ -548,8 +561,34 @@ open class Module {
             throw UpdateError.unhandledKeys(
                 path: path, modules: modulePath, keys: processed.sorted())
         }
+    }
 
-        return self
+    func materialize() throws {
+        // bulk eval the parameters
+        eval(self.parameters())
+
+        // now convert to MaterializedArray (where possible)
+        let newParameters = filterMap(
+            filter: { _, _, _ in true },
+            map: Self.mapParameters(map: { $0.materialized() as MLXArray }))
+
+        try update(parameters: newParameters, verify: .none) { m, k, a, v in
+            if let setter = m._setters?[k] {
+                do {
+                    // use the setter to replace the array
+                    try setter.update(v)
+                } catch {
+                    a._updateInternal(v)
+                }
+            } else {
+                a._updateInternal(v)
+            }
+        }
+
+        // some of the properties were updated so rebuild the properties cache
+        visit { key, m in
+            m.buildCaches()
+        }
     }
 
     /// Called from ``update(parameters:verify:path:modulePath:)`` if a required parameter
@@ -797,7 +836,7 @@ open class Module {
 
         if let setter = _setters?[key] {
             do {
-                try setter.updateModule(value)
+                try setter.update(value)
             } catch {
                 throw UpdateError.needModuleInfo(
                     "Unable to set modules for \(describeType(self)).\(key) -- maybe type mismatch: \(describeType(value)), \(error)"
@@ -1400,7 +1439,7 @@ public enum ModuleValue {
 /// ### See Also
 /// - <doc:custom-layers>
 /// - ``ModuleInfo``
-@propertyWrapper public class ParameterInfo<T> {
+@propertyWrapper public class ParameterInfo<T>: TypeErasedSetterProvider {
     var value: T?
     let key: String?
 
@@ -1446,11 +1485,47 @@ public enum ModuleValue {
 
         // cannot check via unwapProperty -- see wrappedValue.set
     }
+
+    struct Setter: TypeErasedSetter {
+        unowned var info: ParameterInfo<T>
+
+        func update(_ value: Any) throws {
+            if let value = value as? T {
+                info.value = value
+            } else if let value = value as? [MLXArray] {
+                // try to recast as a tuple, e.g.
+                // @ParameterInfo var x: (MLXArray, MLXArray)
+
+                if value.count == 2, let values = (value[0], value[1]) as? T {
+                    info.value = values
+                } else if value.count == 3, let values = (value[0], value[1], value[2]) as? T {
+                    info.value = values
+                } else if value.count == 4,
+                    let values = (value[0], value[1], value[2], value[3]) as? T
+                {
+                    info.value = values
+                } else if value.count == 5,
+                    let values = (value[0], value[1], value[2], value[3], value[4]) as? T
+                {
+                    info.value = values
+                } else {
+                    throw UpdateError.unableToCast(String(describing: T.self))
+                }
+            } else {
+                throw UpdateError.unableToCast(String(describing: T.self))
+            }
+        }
+    }
+
+    fileprivate func typeErasedSetter() -> TypeErasedSetter {
+        Setter(info: self)
+    }
+
 }
 
 /// Helper protocol for writing back through ``ModuleInfo``, e.g. via ``Module/update(modules:)``
 private protocol TypeErasedSetter {
-    func updateModule(_ value: Any) throws
+    func update(_ value: Any) throws
 }
 
 private protocol TypeErasedSetterProvider {
@@ -1561,7 +1636,7 @@ private protocol TypeErasedSetterProvider {
     struct Setter: TypeErasedSetter {
         unowned var info: ModuleInfo<T>
 
-        func updateModule(_ value: Any) throws {
+        func update(_ value: Any) throws {
             if let value = value as? T {
                 info.module = value
             } else if let value = value as? [Module] {
@@ -1577,7 +1652,7 @@ private protocol TypeErasedSetterProvider {
                 {
                     info.module = values
                 } else if value.count == 5,
-                    let values = (value[0], value[1], value[2], value[4], value[5]) as? T
+                    let values = (value[0], value[1], value[2], value[3], value[4]) as? T
                 {
                     info.module = values
                 } else {

--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -15,13 +15,6 @@ public typealias ModuleItems = NestedDictionary<String, ModuleValue>
 /// Single item from ``Module/items()``
 public typealias ModuleItem = NestedItem<String, ModuleValue>
 
-public protocol ModuleInference: IndentedDescription, Updatable, Evaluatable {
-
-    /// Return a `NestedDictionary<String, MLXArray>` for all parameters in the
-    /// model (all layers).
-    func parameters() -> ModuleParameters
-}
-
 /// Base class for building neural networks with MLX.
 ///
 /// The workhorse of any neural network library is the ``Module`` class. In MLX
@@ -1105,9 +1098,6 @@ extension Module: Updatable, Evaluatable {
         filterMap(filter: Self.filterAll, map: Self.mapParameters())
             .flattenedValues()
     }
-}
-
-extension Module: ModuleInference {
 }
 
 /// A `Layer` (``Module`` subclass) that can be evaluated as a _unary function_.

--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -15,6 +15,13 @@ public typealias ModuleItems = NestedDictionary<String, ModuleValue>
 /// Single item from ``Module/items()``
 public typealias ModuleItem = NestedItem<String, ModuleValue>
 
+public protocol ModuleInference: IndentedDescription, Updatable, Evaluatable {
+
+    /// Return a `NestedDictionary<String, MLXArray>` for all parameters in the
+    /// model (all layers).
+    func parameters() -> ModuleParameters
+}
+
 /// Base class for building neural networks with MLX.
 ///
 /// The workhorse of any neural network library is the ``Module`` class. In MLX
@@ -108,6 +115,13 @@ open class Module {
 
     private var _items: ModuleItems?
     private var _setters: [String: TypeErasedSetter]?
+
+    /// Sealed-for-mutation flag.  When `true`, all mutation entry points
+    /// (parameter/module updates, freeze/unfreeze, train) trap.  Set
+    /// recursively by ``_sealImmutable()`` after the module's parameters
+    /// have been replaced with `MaterializedArray` values inside
+    /// ``MaterializedModule``.
+    private var _isImmutable = false
 
     /// Initializes the module.
     public init() {
@@ -404,8 +418,7 @@ open class Module {
     ///
     /// This passes `verify: .none`.  Note that there may still be `fatalErrors()` if
     /// for example an `MLXArray` is set on a `Module`.
-    @discardableResult
-    public func update(parameters: ModuleParameters) -> Self {
+    public func update(parameters: ModuleParameters) {
         try! update(parameters: parameters, verify: .none)
     }
 
@@ -446,16 +459,15 @@ open class Module {
     /// - ``parameters()``
     /// - ``mapParameters(map:isLeaf:)``
     /// - ``update(modules:verify:path:modulePath:)``
-    @discardableResult
     open func update(
         parameters: ModuleParameters, verify: VerifyUpdate, path: [String] = [],
         modulePath: [String] = []
-    ) throws -> Self {
+    ) throws {
+        _checkMutable()
         try update(parameters: parameters, verify: verify, path: path, modulePath: modulePath) {
             m, k, a, v in
             a._updateInternal(v)
         }
-        return self
     }
 
     func update(
@@ -563,6 +575,30 @@ open class Module {
         }
     }
 
+    /// Recursively seal this module and all of its descendants so that any
+    /// further mutation (parameter updates, module replacement, freeze /
+    /// unfreeze, train mode) traps with `fatalError`.
+    ///
+    /// Called from ``MaterializedModule`` after the consumed base has been
+    /// materialized.  This is the runtime backstop for the `consuming`
+    /// ownership contract: even if a caller retains a stale reference and
+    /// tries to mutate the wrapped module, the call will trap rather than
+    /// silently violate the `Sendable` invariant.
+    func _sealImmutable() {
+        visit { _, m in
+            m._isImmutable = true
+        }
+    }
+
+    private func _checkMutable(_ caller: StaticString = #function) {
+        if _isImmutable {
+            fatalError(
+                "\(describeType(self)).\(caller): module has been sealed for "
+                    + "mutation by MaterializedModule.  The original reference "
+                    + "must not be retained or used after the module is consumed.")
+        }
+    }
+
     func materialize() {
         // bulk eval the parameters
         eval(self.parameters())
@@ -622,20 +658,19 @@ open class Module {
     /// - Parameters:
     ///   - filter: filter for parameters to apply to
     ///   - map: function to apply to the matched parameters
-    @discardableResult
     open func apply(
         filter: (Module, String, ModuleItem) -> Bool = Module.filterValidParameters,
         map: @escaping (MLXArray) -> MLXArray
-    ) -> Self {
-        update(parameters: filterMap(filter: filter, map: Self.mapParameters(map: map)))
+    ) {
+        _checkMutable()
+        return update(parameters: filterMap(filter: filter, map: Self.mapParameters(map: map)))
     }
 
     /// A non-throwing version of ``update(modules:verify:path:modulePath:)``.
     ///
     /// This passes `verify: .none`.  Note that there may still be `fatalErrors()` if
     /// for example an `Module` is set on a `MLXArray`.
-    @discardableResult
-    public func update(modules: ModuleChildren) -> Self {
+    public func update(modules: ModuleChildren) {
         try! update(modules: modules, verify: .none)
     }
 
@@ -683,11 +718,11 @@ open class Module {
     /// - ``children()``
     /// - ``leafModules()``
     /// - ``QuantizedLinear/quantize(model:groupSize:bits:predicate:)``
-    @discardableResult
     open func update(
         modules: ModuleChildren, verify: VerifyUpdate, path: [String] = [],
         modulePath: [String] = []
-    ) throws -> Self {
+    ) throws {
+        _checkMutable()
 
         let modulePath = modulePath + [describeType(self)]
 
@@ -811,8 +846,6 @@ open class Module {
 
         // rebuild the caches because the modules may have changed
         buildCaches()
-
-        return self
     }
 
     /// Set a module to a new value.
@@ -832,6 +865,7 @@ open class Module {
     ///   - key: module key, see ``ModuleInfo``
     ///   - value: the replacement module
     open func updateModule(key: String, _ value: Any) throws {
+        _checkMutable()
         if _setters == nil {
             buildCaches()
         }
@@ -946,6 +980,7 @@ open class Module {
     /// - ``freeze(recursive:keys:)``
     /// - ``unfreeze(recursive:keys:strict:)``
     open func freeze(recursive: Bool = true, keys: [String]? = nil, strict: Bool = false) throws {
+        _checkMutable()
         let visitor = freezeVisitor(keys: keys, strict: strict) {
             $0._noGrad.formUnion($1)
             $0.didSetNoGrad($0._noGrad)
@@ -984,6 +1019,7 @@ open class Module {
     /// - ``Module/freeze(recursive:keys:)``
     /// - ``Module/unfreeze(recursive:keys:strict:)``
     open func unfreeze(recursive: Bool = true, keys: [String]? = nil, strict: Bool = false) throws {
+        _checkMutable()
         let visitor = freezeVisitor(keys: keys, strict: strict) {
             $0._noGrad.subtract($1)
             $0.didSetNoGrad($0._noGrad)
@@ -1024,6 +1060,7 @@ open class Module {
     /// - ``training``
     /// - ``didSetTrain(_:)``
     public func train(_ mode: Bool = true) {
+        _checkMutable()
         visit(modules: {
             $1.training = mode
             $1.didSetTrain(mode)
@@ -1068,6 +1105,9 @@ extension Module: Updatable, Evaluatable {
         filterMap(filter: Self.filterAll, map: Self.mapParameters())
             .flattenedValues()
     }
+}
+
+extension Module: ModuleInference {
 }
 
 /// A `Layer` (``Module`` subclass) that can be evaluated as a _unary function_.

--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -194,6 +194,18 @@ open class Module {
         }
     }
 
+    /// Count of the parameters directly attached to this Module
+    open var parameterCount: Int {
+        items().reduce(0) {
+            switch $1 {
+            case .parameters(let p):
+                $0 + p.size
+            default:
+                $0
+            }
+        }
+    }
+
     /// Recursively filter and map the contents of the module and its children and produce a `NestedDictionary`
     /// with the results.
     ///

--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -1532,6 +1532,7 @@ public enum ModuleValue {
         // cannot check via unwapProperty -- see wrappedValue.set
     }
 
+    // See also ModuleInfo.Setter
     struct Setter: TypeErasedSetter {
         unowned var info: ParameterInfo<T>
 
@@ -1679,6 +1680,7 @@ private protocol TypeErasedSetterProvider {
         }
     }
 
+    // See also ParameterInfo.Setter
     struct Setter: TypeErasedSetter {
         unowned var info: ModuleInfo<T>
 

--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -123,6 +123,8 @@ open class Module {
 
                 if let (_, _, setter) = isModuleInfo(c.value) {
                     setters[key] = setter
+                } else if let provider = c.value as? TypeErasedSetterProvider {
+                    setters[key] = provider.typeErasedSetter()
                 }
             }
 
@@ -456,7 +458,18 @@ open class Module {
         parameters: ModuleParameters, verify: VerifyUpdate, path: [String] = [],
         modulePath: [String] = []
     ) throws -> Self {
+        try update(parameters: parameters, verify: verify, path: path, modulePath: modulePath) {
+            m, k, a, v in
+            a._updateInternal(v)
+        }
+        return self
+    }
 
+    func update(
+        parameters: ModuleParameters, verify: VerifyUpdate, path: [String] = [],
+        modulePath: [String] = [],
+        mutate: (Module, String, MLXArray, MLXArray) -> Void
+    ) throws {
         let modulePath = modulePath + [describeType(self)]
 
         func apply(
@@ -478,7 +491,7 @@ open class Module {
                         path: path, modules: modulePath, expectedShape: p.shape,
                         actualShape: newArray.shape)
                 }
-                p._updateInternal(newArray)
+                mutate(self, key, p, newArray)
 
             case (.value(.parameters), .none):
                 if Self.parameterIsValid(key) {
@@ -524,12 +537,12 @@ open class Module {
             case (.value(.module(let module)), .dictionary(let values)):
                 try module.update(
                     parameters: NestedDictionary(values: values), verify: verify, path: path,
-                    modulePath: modulePath)
+                    modulePath: modulePath, mutate: mutate)
 
             case (.value(.module(let module)), .none):
                 try module.update(
                     parameters: NestedDictionary(), verify: verify, path: path,
-                    modulePath: modulePath)
+                    modulePath: modulePath, mutate: mutate)
 
             case (.none, .none), (.value(.none), .none), (.value(.other(_)), .none):
                 break
@@ -555,8 +568,34 @@ open class Module {
             throw UpdateError.unhandledKeys(
                 path: path, modules: modulePath, keys: processed.sorted())
         }
+    }
 
-        return self
+    func materialize() throws {
+        // bulk eval the parameters
+        eval(self.parameters())
+
+        // now convert to MaterializedArray (where possible)
+        let newParameters = filterMap(
+            filter: { _, _, _ in true },
+            map: Self.mapParameters(map: { $0.materialized() as MLXArray }))
+
+        try update(parameters: newParameters, verify: .none) { m, k, a, v in
+            if let setter = m._setters?[k] {
+                do {
+                    // use the setter to replace the array
+                    try setter.update(v)
+                } catch {
+                    a._updateInternal(v)
+                }
+            } else {
+                a._updateInternal(v)
+            }
+        }
+
+        // some of the properties were updated so rebuild the properties cache
+        visit { key, m in
+            m.buildCaches()
+        }
     }
 
     /// Called from ``update(parameters:verify:path:modulePath:)`` if a required parameter
@@ -804,7 +843,7 @@ open class Module {
 
         if let setter = _setters?[key] {
             do {
-                try setter.updateModule(value)
+                try setter.update(value)
             } catch {
                 throw UpdateError.needModuleInfo(
                     "Unable to set modules for \(describeType(self)).\(key) -- maybe type mismatch: \(describeType(value)), \(error)"
@@ -1407,7 +1446,7 @@ public enum ModuleValue {
 /// ### See Also
 /// - <doc:custom-layers>
 /// - ``ModuleInfo``
-@propertyWrapper public class ParameterInfo<T> {
+@propertyWrapper public class ParameterInfo<T>: TypeErasedSetterProvider {
     var value: T?
     let key: String?
 
@@ -1453,11 +1492,47 @@ public enum ModuleValue {
 
         // cannot check via unwapProperty -- see wrappedValue.set
     }
+
+    struct Setter: TypeErasedSetter {
+        unowned var info: ParameterInfo<T>
+
+        func update(_ value: Any) throws {
+            if let value = value as? T {
+                info.value = value
+            } else if let value = value as? [MLXArray] {
+                // try to recast as a tuple, e.g.
+                // @ParameterInfo var x: (MLXArray, MLXArray)
+
+                if value.count == 2, let values = (value[0], value[1]) as? T {
+                    info.value = values
+                } else if value.count == 3, let values = (value[0], value[1], value[2]) as? T {
+                    info.value = values
+                } else if value.count == 4,
+                    let values = (value[0], value[1], value[2], value[3]) as? T
+                {
+                    info.value = values
+                } else if value.count == 5,
+                    let values = (value[0], value[1], value[2], value[3], value[4]) as? T
+                {
+                    info.value = values
+                } else {
+                    throw UpdateError.unableToCast(String(describing: T.self))
+                }
+            } else {
+                throw UpdateError.unableToCast(String(describing: T.self))
+            }
+        }
+    }
+
+    fileprivate func typeErasedSetter() -> TypeErasedSetter {
+        Setter(info: self)
+    }
+
 }
 
 /// Helper protocol for writing back through ``ModuleInfo``, e.g. via ``Module/update(modules:)``
 private protocol TypeErasedSetter {
-    func updateModule(_ value: Any) throws
+    func update(_ value: Any) throws
 }
 
 private protocol TypeErasedSetterProvider {
@@ -1568,7 +1643,7 @@ private protocol TypeErasedSetterProvider {
     struct Setter: TypeErasedSetter {
         unowned var info: ModuleInfo<T>
 
-        func updateModule(_ value: Any) throws {
+        func update(_ value: Any) throws {
             if let value = value as? T {
                 info.module = value
             } else if let value = value as? [Module] {
@@ -1584,7 +1659,7 @@ private protocol TypeErasedSetterProvider {
                 {
                     info.module = values
                 } else if value.count == 5,
-                    let values = (value[0], value[1], value[2], value[4], value[5]) as? T
+                    let values = (value[0], value[1], value[2], value[3], value[4]) as? T
                 {
                     info.module = values
                 } else {

--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -15,6 +15,13 @@ public typealias ModuleItems = NestedDictionary<String, ModuleValue>
 /// Single item from ``Module/items()``
 public typealias ModuleItem = NestedItem<String, ModuleValue>
 
+public protocol ModuleInference: IndentedDescription, Updatable, Evaluatable {
+
+    /// Return a `NestedDictionary<String, MLXArray>` for all parameters in the
+    /// model (all layers).
+    func parameters() -> ModuleParameters
+}
+
 /// Base class for building neural networks with MLX.
 ///
 /// The workhorse of any neural network library is the ``Module`` class. In MLX
@@ -108,6 +115,13 @@ open class Module {
 
     private var _items: ModuleItems?
     private var _setters: [String: TypeErasedSetter]?
+
+    /// Sealed-for-mutation flag.  When `true`, all mutation entry points
+    /// (parameter/module updates, freeze/unfreeze, train) trap.  Set
+    /// recursively by ``_sealImmutable()`` after the module's parameters
+    /// have been replaced with `MaterializedArray` values inside
+    /// ``MaterializedModule``.
+    private var _isImmutable = false
 
     /// Initializes the module.
     public init() {
@@ -404,8 +418,7 @@ open class Module {
     ///
     /// This passes `verify: .none`.  Note that there may still be `fatalErrors()` if
     /// for example an `MLXArray` is set on a `Module`.
-    @discardableResult
-    public func update(parameters: ModuleParameters) -> Self {
+    public func update(parameters: ModuleParameters) {
         try! update(parameters: parameters, verify: .none)
     }
 
@@ -453,16 +466,15 @@ open class Module {
     /// - ``parameters()``
     /// - ``mapParameters(map:isLeaf:)``
     /// - ``update(modules:verify:path:modulePath:)``
-    @discardableResult
     open func update(
         parameters: ModuleParameters, verify: VerifyUpdate, path: [String] = [],
         modulePath: [String] = []
-    ) throws -> Self {
+    ) throws {
+        _checkMutable()
         try update(parameters: parameters, verify: verify, path: path, modulePath: modulePath) {
             m, k, a, v in
             a._updateInternal(v)
         }
-        return self
     }
 
     func update(
@@ -570,6 +582,30 @@ open class Module {
         }
     }
 
+    /// Recursively seal this module and all of its descendants so that any
+    /// further mutation (parameter updates, module replacement, freeze /
+    /// unfreeze, train mode) traps with `fatalError`.
+    ///
+    /// Called from ``MaterializedModule`` after the consumed base has been
+    /// materialized.  This is the runtime backstop for the `consuming`
+    /// ownership contract: even if a caller retains a stale reference and
+    /// tries to mutate the wrapped module, the call will trap rather than
+    /// silently violate the `Sendable` invariant.
+    func _sealImmutable() {
+        visit { _, m in
+            m._isImmutable = true
+        }
+    }
+
+    private func _checkMutable(_ caller: StaticString = #function) {
+        if _isImmutable {
+            fatalError(
+                "\(describeType(self)).\(caller): module has been sealed for "
+                    + "mutation by MaterializedModule.  The original reference "
+                    + "must not be retained or used after the module is consumed.")
+        }
+    }
+
     func materialize() {
         // bulk eval the parameters
         eval(self.parameters())
@@ -629,20 +665,19 @@ open class Module {
     /// - Parameters:
     ///   - filter: filter for parameters to apply to
     ///   - map: function to apply to the matched parameters
-    @discardableResult
     open func apply(
         filter: (Module, String, ModuleItem) -> Bool = Module.filterValidParameters,
         map: @escaping (MLXArray) -> MLXArray
-    ) -> Self {
-        update(parameters: filterMap(filter: filter, map: Self.mapParameters(map: map)))
+    ) {
+        _checkMutable()
+        return update(parameters: filterMap(filter: filter, map: Self.mapParameters(map: map)))
     }
 
     /// A non-throwing version of ``update(modules:verify:path:modulePath:)``.
     ///
     /// This passes `verify: .none`.  Note that there may still be `fatalErrors()` if
     /// for example an `Module` is set on a `MLXArray`.
-    @discardableResult
-    public func update(modules: ModuleChildren) -> Self {
+    public func update(modules: ModuleChildren) {
         try! update(modules: modules, verify: .none)
     }
 
@@ -690,11 +725,11 @@ open class Module {
     /// - ``children()``
     /// - ``leafModules()``
     /// - ``QuantizedLinear/quantize(model:groupSize:bits:predicate:)``
-    @discardableResult
     open func update(
         modules: ModuleChildren, verify: VerifyUpdate, path: [String] = [],
         modulePath: [String] = []
-    ) throws -> Self {
+    ) throws {
+        _checkMutable()
 
         let modulePath = modulePath + [describeType(self)]
 
@@ -818,8 +853,6 @@ open class Module {
 
         // rebuild the caches because the modules may have changed
         buildCaches()
-
-        return self
     }
 
     /// Set a module to a new value.
@@ -839,6 +872,7 @@ open class Module {
     ///   - key: module key, see ``ModuleInfo``
     ///   - value: the replacement module
     open func updateModule(key: String, _ value: Any) throws {
+        _checkMutable()
         if _setters == nil {
             buildCaches()
         }
@@ -953,6 +987,7 @@ open class Module {
     /// - ``freeze(recursive:keys:)``
     /// - ``unfreeze(recursive:keys:strict:)``
     open func freeze(recursive: Bool = true, keys: [String]? = nil, strict: Bool = false) throws {
+        _checkMutable()
         let visitor = freezeVisitor(keys: keys, strict: strict) {
             $0._noGrad.formUnion($1)
             $0.didSetNoGrad($0._noGrad)
@@ -991,6 +1026,7 @@ open class Module {
     /// - ``Module/freeze(recursive:keys:)``
     /// - ``Module/unfreeze(recursive:keys:strict:)``
     open func unfreeze(recursive: Bool = true, keys: [String]? = nil, strict: Bool = false) throws {
+        _checkMutable()
         let visitor = freezeVisitor(keys: keys, strict: strict) {
             $0._noGrad.subtract($1)
             $0.didSetNoGrad($0._noGrad)
@@ -1031,6 +1067,7 @@ open class Module {
     /// - ``training``
     /// - ``didSetTrain(_:)``
     public func train(_ mode: Bool = true) {
+        _checkMutable()
         visit(modules: {
             $1.training = mode
             $1.didSetTrain(mode)
@@ -1075,6 +1112,9 @@ extension Module: Updatable, Evaluatable {
         filterMap(filter: Self.filterAll, map: Self.mapParameters())
             .flattenedValues()
     }
+}
+
+extension Module: ModuleInference {
 }
 
 /// A `Layer` (``Module`` subclass) that can be evaluated as a _unary function_.

--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -570,7 +570,7 @@ open class Module {
         }
     }
 
-    func materialize() throws {
+    func materialize() {
         // bulk eval the parameters
         eval(self.parameters())
 
@@ -579,7 +579,9 @@ open class Module {
             filter: { _, _, _ in true },
             map: Self.mapParameters(map: { $0.materialized() as MLXArray }))
 
-        try update(parameters: newParameters, verify: .none) { m, k, a, v in
+        // not verifying and setting with same value -- any
+        // errors are programming errors
+        try! update(parameters: newParameters, verify: .none) { m, k, a, v in
             if let setter = m._setters?[k] {
                 do {
                     // use the setter to replace the array

--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -1539,6 +1539,7 @@ public enum ModuleValue {
         // cannot check via unwapProperty -- see wrappedValue.set
     }
 
+    // See also ModuleInfo.Setter
     struct Setter: TypeErasedSetter {
         unowned var info: ParameterInfo<T>
 
@@ -1686,6 +1687,7 @@ private protocol TypeErasedSetterProvider {
         }
     }
 
+    // See also ParameterInfo.Setter
     struct Setter: TypeErasedSetter {
         unowned var info: ModuleInfo<T>
 

--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -114,7 +114,7 @@ open class Module {
     /// recursively by ``_sealImmutable()`` after the module's parameters
     /// have been replaced with `MaterializedArray` values inside
     /// ``MaterializedModule``.
-    private var _isImmutable = false
+    var _isImmutable = false
 
     /// Initializes the module.
     public init() {

--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -15,13 +15,6 @@ public typealias ModuleItems = NestedDictionary<String, ModuleValue>
 /// Single item from ``Module/items()``
 public typealias ModuleItem = NestedItem<String, ModuleValue>
 
-public protocol ModuleInference: IndentedDescription, Updatable, Evaluatable {
-
-    /// Return a `NestedDictionary<String, MLXArray>` for all parameters in the
-    /// model (all layers).
-    func parameters() -> ModuleParameters
-}
-
 /// Base class for building neural networks with MLX.
 ///
 /// The workhorse of any neural network library is the ``Module`` class. In MLX
@@ -1112,9 +1105,6 @@ extension Module: Updatable, Evaluatable {
         filterMap(filter: Self.filterAll, map: Self.mapParameters())
             .flattenedValues()
     }
-}
-
-extension Module: ModuleInference {
 }
 
 /// A `Layer` (``Module`` subclass) that can be evaluated as a _unary function_.

--- a/Source/MLXNN/Quantized.swift
+++ b/Source/MLXNN/Quantized.swift
@@ -226,6 +226,10 @@ open class QuantizedEmbedding: Embedding, Quantized {
         super.init(weight: weight)
     }
 
+    open override var parameterCount: Int {
+        scales.size * groupSize
+    }
+
     open override func callAsFunction(_ x: MLXArray) -> MLXArray {
         let s = x.shape
         let x = x.flattened()
@@ -355,6 +359,10 @@ open class QuantizedLinear: Linear, Quantized {
         self.biases = biases
         self._globalScale.wrappedValue = globalScale
         super.init(weight: weight, bias: bias)
+    }
+
+    open override var parameterCount: Int {
+        scales.size * groupSize
     }
 
     public override func unfreeze(

--- a/Source/MLXNN/Quantized.swift
+++ b/Source/MLXNN/Quantized.swift
@@ -362,7 +362,11 @@ open class QuantizedLinear: Linear, Quantized {
     }
 
     open override var parameterCount: Int {
-        scales.size * groupSize
+        if biases != nil {
+            scales.size * groupSize * 2
+        } else {
+            scales.size * groupSize
+        }
     }
 
     public override func unfreeze(

--- a/Source/MLXNN/Quantized.swift
+++ b/Source/MLXNN/Quantized.swift
@@ -362,7 +362,12 @@ open class QuantizedLinear: Linear, Quantized {
     }
 
     open override var parameterCount: Int {
-        if biases != nil {
+        // represent the count that the non-quantized Linear represents.
+        //
+        // the weight property is the quantized weights, so compute based
+        // off the scales and group size to reconstruct
+        if bias != nil {
+            // the bias is the same size as the weight
             scales.size * groupSize * 2
         } else {
             scales.size * groupSize

--- a/Source/MLXNN/Quantized.swift
+++ b/Source/MLXNN/Quantized.swift
@@ -363,15 +363,21 @@ open class QuantizedLinear: Linear, Quantized {
 
     open override var parameterCount: Int {
         // represent the count that the non-quantized Linear represents.
-        //
-        // the weight property is the quantized weights, so compute based
-        // off the scales and group size to reconstruct
+        let outputDimensions = scales.dim(0)
+        let inputDimensions = scales.dim(1) * groupSize
+
         if bias != nil {
-            // the bias is the same size as the weight
-            scales.size * groupSize * 2
+            return inputDimensions * outputDimensions + outputDimensions
         } else {
-            scales.size * groupSize
+            return inputDimensions * outputDimensions
         }
+    }
+
+    open override func describeExtra(_ indent: Int) -> String {
+        let outputDimensions = scales.dim(0)
+        let inputDimensions = scales.dim(1) * groupSize
+        return
+            "(inputDimensions=\(inputDimensions), outputDimensions=\(outputDimensions), bias=\(self.bias != nil))"
     }
 
     public override func unfreeze(

--- a/Tests/MLXTests/MLXArray+OpsTests.swift
+++ b/Tests/MLXTests/MLXArray+OpsTests.swift
@@ -16,7 +16,7 @@ class MLXArrayOpsTests: XCTestCase {
 
     func testArithmeticSimple() {
         var a = MLXArray([1, 2, 3])
-        var b = MLXArray(converting: [-5.0, 37.5, 4])
+        let b = MLXArray(converting: [-5.0, 37.5, 4])
 
         // example of an expression -- the - 1 is using the 1 as ExpressibleByIntegerLiteral
         let r = a + b - 1

--- a/Tests/MLXTests/MaterializedTests.swift
+++ b/Tests/MLXTests/MaterializedTests.swift
@@ -1,0 +1,186 @@
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+import MLX
+import MLXNN
+import Testing
+
+@Test
+func testMaterialize() async {
+    // a materialized array is Sendable
+    let x = MLXArray(10) + 5
+    let m = materialize(x)
+    let t = Task {
+        print(m + 3)
+    }
+    _ = await t.result
+}
+
+@Test
+func testCompileMaterialized() async {
+    // compile manipulates the input arrays (tracers)
+    // make sure MaterializedArray doesn't run into problems here
+    func f(_ a: MLXArray, _ b: MLXArray) -> MLXArray {
+        square(a * b)
+    }
+
+    let c = compile(f)
+
+    let i1 = MLXRandom.normal([20, 20]).materialized()
+    let i2 = MLXRandom.normal([20, 20]).materialized()
+
+    let t = Task {
+        let s = sum(c(i1, i2))
+        let s2 = sum(f(i1, i2))
+        #expect(s.allClose(s2).item(Bool.self))
+        print(s, s2)
+    }
+    _ = await t.result
+}
+
+@Test
+func testMaterializedLinear() async throws {
+    let l = Linear(10, 10)
+    let lm = try MaterializedModule(l)
+
+    // this will have been materialized in the call
+    #expect(l.weight is MaterializedArray)
+
+    let t = Task {
+        let i = MLXRandom.normal([10, 10])
+        let r = lm(i)
+        print(sum(r))
+        print(lm)
+    }
+    _ = await t.result
+
+}
+
+@Test
+func testMaterializedMultithreadedEval() async throws {
+    // Exercise concurrent evaluation: produce MaterializedArrays on the
+    // main task, fan them out to many child tasks, and have each task do
+    // its own work (creates new arrays, evals, reads scalars) at the same
+    // time.  This stresses the evalLock and the Sendable contract of
+    // MaterializedArray.
+
+    let taskCount = 16
+    let iterations = 8
+    let shape = [32, 32]
+
+    // shared inputs created up-front and materialized so they can cross
+    // task boundaries
+    let a = MLXRandom.normal(shape).materialized()
+    let b = MLXRandom.normal(shape).materialized()
+
+    // expected reference value computed serially on the main task
+    let expected = sum(square(a * b)).item(Float.self)
+
+    try await withThrowingTaskGroup(of: Float.self) { group in
+        for i in 0 ..< taskCount {
+            group.addTask {
+                var last: Float = 0
+                for _ in 0 ..< iterations {
+                    // mix the shared inputs with task-local arrays so that
+                    // each task is producing fresh graphs and evaluating
+                    // them concurrently
+                    let local = MLXRandom.normal(shape)
+                    let r = sum(square(a * b) + (local - local))
+                    last = r.item(Float.self)
+
+                    // also exercise materialize from inside a task
+                    let m = (a + MLXArray(Float(i))).materialized()
+                    _ = (m - MLXArray(Float(i))).sum().item(Float.self)
+                }
+                return last
+            }
+        }
+
+        for try await value in group {
+            #expect(abs(value - expected) < 1e-2)
+        }
+    }
+}
+
+@Test
+func testMaterializedHighContention() async throws {
+    // High-contention variant: many tasks producing and consuming
+    // MaterializedArrays through a shared actor-protected pool.  Every
+    // task in a tight loop pulls two arrays from the pool, computes a
+    // new one, materializes it (forcing an eval), reads a scalar, and
+    // pushes the result back into the pool.  Lots of arrays flowing
+    // between tasks, lots of concurrent eval calls hammering the
+    // evalLock.
+
+    actor Pool {
+        var arrays: [MaterializedArray]
+        init(_ initial: [MaterializedArray]) { self.arrays = initial }
+
+        func take() -> MaterializedArray {
+            arrays.randomElement()!
+        }
+
+        func replace(_ a: MaterializedArray) {
+            arrays[Int.random(in: 0 ..< arrays.count)] = a
+        }
+
+        func snapshot() -> [MaterializedArray] {
+            arrays
+        }
+    }
+
+    let shape = [16, 16]
+    let poolSize = 16
+    let taskCount = 32
+    let iterations = 50
+
+    let initial = (0 ..< poolSize).map { _ in
+        MLXRandom.normal(shape).materialized()
+    }
+    let pool = Pool(initial)
+
+    // sum + count tracker so we can assert no task silently dropped work
+    actor Counter {
+        var n = 0
+        func bump() { n += 1 }
+        func value() -> Int { n }
+    }
+    let counter = Counter()
+
+    try await withThrowingTaskGroup(of: Void.self) { group in
+        for t in 0 ..< taskCount {
+            group.addTask {
+                for k in 0 ..< iterations {
+                    // pull two arrays from the shared pool — these may be
+                    // referenced concurrently by other tasks at the same time
+                    let a = await pool.take()
+                    let b = await pool.take()
+
+                    // build a new graph, materialize it (forces eval inside
+                    // the task), and read a scalar (forces another eval).
+                    // tanh keeps values bounded to [-1, 1] so the pool can
+                    // recycle results across iterations without blowing up.
+                    let mixin = MLXArray(Float(t * 31 + k) * 1e-3)
+                    let r = tanh((a * b) + (a - b) + mixin).materialized()
+                    let s = r.sum().item(Float.self)
+                    #expect(s.isFinite)
+
+                    // put the result back so other tasks see fresh arrays
+                    await pool.replace(r)
+                    await counter.bump()
+                }
+            }
+        }
+        try await group.waitForAll()
+    }
+
+    #expect(await counter.value() == taskCount * iterations)
+
+    // every entry in the final pool should still be a valid, finite array
+    let final = await pool.snapshot()
+    #expect(final.count == poolSize)
+    for a in final {
+        #expect(a.shape == shape)
+        #expect(sum(a).item(Float.self).isFinite)
+    }
+}

--- a/Tests/MLXTests/MaterializedTests.swift
+++ b/Tests/MLXTests/MaterializedTests.swift
@@ -5,182 +5,197 @@ import MLX
 import MLXNN
 import Testing
 
-@Test
-func testMaterialize() async {
-    // a materialized array is Sendable
-    let x = MLXArray(10) + 5
-    let m = materialize(x)
-    let t = Task {
-        print(m + 3)
-    }
-    _ = await t.result
-}
-
-@Test
-func testCompileMaterialized() async {
-    // compile manipulates the input arrays (tracers)
-    // make sure MaterializedArray doesn't run into problems here
-    func f(_ a: MLXArray, _ b: MLXArray) -> MLXArray {
-        square(a * b)
+@Suite
+struct MaterializedTests {
+    @Test
+    func testMaterialize() async {
+        // a materialized array is Sendable
+        let x = MLXArray(10) + 5
+        let m = materialize(x)
+        let t = Task {
+            print(m + 3)
+        }
+        _ = await t.result
     }
 
-    let c = compile(f)
+    @Test
+    func testCompileMaterialized() async {
+        // compile manipulates the input arrays (tracers)
+        // make sure MaterializedArray doesn't run into problems here
+        func f(_ a: MLXArray, _ b: MLXArray) -> MLXArray {
+            square(a * b)
+        }
 
-    let i1 = MLXRandom.normal([20, 20]).materialized()
-    let i2 = MLXRandom.normal([20, 20]).materialized()
+        let c = compile(f)
 
-    let t = Task {
-        let s = sum(c(i1, i2))
-        let s2 = sum(f(i1, i2))
-        #expect(s.allClose(s2).item(Bool.self))
-        print(s, s2)
+        let i1 = MLXRandom.normal([20, 20]).materialized()
+        let i2 = MLXRandom.normal([20, 20]).materialized()
+
+        let t = Task {
+            let s = sum(c(i1, i2))
+            let s2 = sum(f(i1, i2))
+            #expect(s.allClose(s2).item(Bool.self))
+            print(s, s2)
+        }
+        _ = await t.result
     }
-    _ = await t.result
-}
 
-@Test
-func testMaterializedLinear() async {
-    let l = Linear(10, 10)
-    let lm = MaterializedModule(l)
+    @Test
+    func testMaterializedLinear() async {
+        let l = Linear(10, 10)
+        let lm = MaterializedModule(l)
 
-    // this will have been materialized in the call
-    #expect(l.weight is MaterializedArray)
+        // this will have been materialized in the call
+        #expect(l.weight is MaterializedArray)
 
-    let t = Task {
-        let i = MLXRandom.normal([10, 10])
-        let r = lm(i)
-        print(sum(r))
-        print(lm)
+        let t = Task {
+            let i = MLXRandom.normal([10, 10])
+            let r = lm(i)
+            print(sum(r))
+            print(lm)
+        }
+        _ = await t.result
+
     }
-    _ = await t.result
 
-}
+    @Test
+    func testMaterializedMultithreadedEval() async throws {
+        // Exercise concurrent evaluation: produce MaterializedArrays on the
+        // main task, fan them out to many child tasks, and have each task do
+        // its own work (creates new arrays, evals, reads scalars) at the same
+        // time.  This stresses the evalLock and the Sendable contract of
+        // MaterializedArray.
 
-@Test
-func testMaterializedMultithreadedEval() async throws {
-    // Exercise concurrent evaluation: produce MaterializedArrays on the
-    // main task, fan them out to many child tasks, and have each task do
-    // its own work (creates new arrays, evals, reads scalars) at the same
-    // time.  This stresses the evalLock and the Sendable contract of
-    // MaterializedArray.
+        let taskCount = 16
+        let iterations = 8
+        let shape = [32, 32]
 
-    let taskCount = 16
-    let iterations = 8
-    let shape = [32, 32]
+        // shared inputs created up-front and materialized so they can cross
+        // task boundaries
+        let a = MLXRandom.normal(shape).materialized()
+        let b = MLXRandom.normal(shape).materialized()
 
-    // shared inputs created up-front and materialized so they can cross
-    // task boundaries
-    let a = MLXRandom.normal(shape).materialized()
-    let b = MLXRandom.normal(shape).materialized()
+        // expected reference value computed serially on the main task
+        let expected = sum(square(a * b)).item(Float.self)
 
-    // expected reference value computed serially on the main task
-    let expected = sum(square(a * b)).item(Float.self)
+        try await withThrowingTaskGroup(of: Float.self) { group in
+            for i in 0 ..< taskCount {
+                group.addTask {
+                    var last: Float = 0
+                    for _ in 0 ..< iterations {
+                        // mix the shared inputs with task-local arrays so that
+                        // each task is producing fresh graphs and evaluating
+                        // them concurrently
+                        let local = MLXRandom.normal(shape)
+                        let r = sum(square(a * b) + (local - local))
+                        last = r.item(Float.self)
 
-    try await withThrowingTaskGroup(of: Float.self) { group in
-        for i in 0 ..< taskCount {
-            group.addTask {
-                var last: Float = 0
-                for _ in 0 ..< iterations {
-                    // mix the shared inputs with task-local arrays so that
-                    // each task is producing fresh graphs and evaluating
-                    // them concurrently
-                    let local = MLXRandom.normal(shape)
-                    let r = sum(square(a * b) + (local - local))
-                    last = r.item(Float.self)
-
-                    // also exercise materialize from inside a task
-                    let m = (a + MLXArray(Float(i))).materialized()
-                    _ = (m - MLXArray(Float(i))).sum().item(Float.self)
+                        // also exercise materialize from inside a task
+                        let m = (a + MLXArray(Float(i))).materialized()
+                        _ = (m - MLXArray(Float(i))).sum().item(Float.self)
+                    }
+                    return last
                 }
-                return last
+            }
+
+            for try await value in group {
+                #expect(abs(value - expected) < 1e-2)
+            }
+        }
+    }
+
+    @Test
+    func testMaterializedHighContention() async throws {
+        // High-contention variant: many tasks producing and consuming
+        // MaterializedArrays through a shared actor-protected pool.  Every
+        // task in a tight loop pulls two arrays from the pool, computes a
+        // new one, materializes it (forcing an eval), reads a scalar, and
+        // pushes the result back into the pool.  Lots of arrays flowing
+        // between tasks, lots of concurrent eval calls hammering the
+        // evalLock.
+
+        actor Pool {
+            var arrays: [MaterializedArray]
+            init(_ initial: [MaterializedArray]) { self.arrays = initial }
+
+            func take() -> MaterializedArray {
+                arrays.randomElement()!
+            }
+
+            func replace(_ a: MaterializedArray) {
+                arrays[Int.random(in: 0 ..< arrays.count)] = a
+            }
+
+            func snapshot() -> [MaterializedArray] {
+                arrays
             }
         }
 
-        for try await value in group {
-            #expect(abs(value - expected) < 1e-2)
+        let shape = [16, 16]
+        let poolSize = 16
+        let taskCount = 32
+        let iterations = 50
+
+        let initial = (0 ..< poolSize).map { _ in
+            MLXRandom.normal(shape).materialized()
         }
-    }
-}
+        let pool = Pool(initial)
 
-@Test
-func testMaterializedHighContention() async throws {
-    // High-contention variant: many tasks producing and consuming
-    // MaterializedArrays through a shared actor-protected pool.  Every
-    // task in a tight loop pulls two arrays from the pool, computes a
-    // new one, materializes it (forcing an eval), reads a scalar, and
-    // pushes the result back into the pool.  Lots of arrays flowing
-    // between tasks, lots of concurrent eval calls hammering the
-    // evalLock.
-
-    actor Pool {
-        var arrays: [MaterializedArray]
-        init(_ initial: [MaterializedArray]) { self.arrays = initial }
-
-        func take() -> MaterializedArray {
-            arrays.randomElement()!
+        // sum + count tracker so we can assert no task silently dropped work
+        actor Counter {
+            var n = 0
+            func bump() { n += 1 }
+            func value() -> Int { n }
         }
+        let counter = Counter()
 
-        func replace(_ a: MaterializedArray) {
-            arrays[Int.random(in: 0 ..< arrays.count)] = a
-        }
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for t in 0 ..< taskCount {
+                group.addTask {
+                    for k in 0 ..< iterations {
+                        // pull two arrays from the shared pool — these may be
+                        // referenced concurrently by other tasks at the same time
+                        let a = await pool.take()
+                        let b = await pool.take()
 
-        func snapshot() -> [MaterializedArray] {
-            arrays
-        }
-    }
+                        // build a new graph, materialize it (forces eval inside
+                        // the task), and read a scalar (forces another eval).
+                        // tanh keeps values bounded to [-1, 1] so the pool can
+                        // recycle results across iterations without blowing up.
+                        let mixin = MLXArray(Float(t * 31 + k) * 1e-3)
+                        let r = tanh((a * b) + (a - b) + mixin).materialized()
+                        let s = r.sum().item(Float.self)
+                        #expect(s.isFinite)
 
-    let shape = [16, 16]
-    let poolSize = 16
-    let taskCount = 32
-    let iterations = 50
-
-    let initial = (0 ..< poolSize).map { _ in
-        MLXRandom.normal(shape).materialized()
-    }
-    let pool = Pool(initial)
-
-    // sum + count tracker so we can assert no task silently dropped work
-    actor Counter {
-        var n = 0
-        func bump() { n += 1 }
-        func value() -> Int { n }
-    }
-    let counter = Counter()
-
-    try await withThrowingTaskGroup(of: Void.self) { group in
-        for t in 0 ..< taskCount {
-            group.addTask {
-                for k in 0 ..< iterations {
-                    // pull two arrays from the shared pool — these may be
-                    // referenced concurrently by other tasks at the same time
-                    let a = await pool.take()
-                    let b = await pool.take()
-
-                    // build a new graph, materialize it (forces eval inside
-                    // the task), and read a scalar (forces another eval).
-                    // tanh keeps values bounded to [-1, 1] so the pool can
-                    // recycle results across iterations without blowing up.
-                    let mixin = MLXArray(Float(t * 31 + k) * 1e-3)
-                    let r = tanh((a * b) + (a - b) + mixin).materialized()
-                    let s = r.sum().item(Float.self)
-                    #expect(s.isFinite)
-
-                    // put the result back so other tasks see fresh arrays
-                    await pool.replace(r)
-                    await counter.bump()
+                        // put the result back so other tasks see fresh arrays
+                        await pool.replace(r)
+                        await counter.bump()
+                    }
                 }
             }
+            try await group.waitForAll()
         }
-        try await group.waitForAll()
+
+        #expect(await counter.value() == taskCount * iterations)
+
+        // every entry in the final pool should still be a valid, finite array
+        let final = await pool.snapshot()
+        #expect(final.count == poolSize)
+        for a in final {
+            #expect(a.shape == shape)
+            #expect(sum(a).item(Float.self).isFinite)
+        }
     }
 
-    #expect(await counter.value() == taskCount * iterations)
+    @Test func testMaterializedModule() {
+        let inner = Linear(10, 10)
+        let mm = MaterializedModule(inner)
 
-    // every entry in the final pool should still be a valid, finite array
-    let final = await pool.snapshot()
-    #expect(final.count == poolSize)
-    for a in final {
-        #expect(a.shape == shape)
-        #expect(sum(a).item(Float.self).isFinite)
+        #expect(mm.description.contains("Linear"))
+        #expect(mm.parameterNBytes == mm.parameters().reduce(0) { $0 + $1.nbytes })
+
+        // callable
+        let x = uniform(0 ..< 1, [10])
+        let _ = mm(x)
     }
 }

--- a/Tests/MLXTests/MaterializedTests.swift
+++ b/Tests/MLXTests/MaterializedTests.swift
@@ -39,9 +39,9 @@ func testCompileMaterialized() async {
 }
 
 @Test
-func testMaterializedLinear() async throws {
+func testMaterializedLinear() async {
     let l = Linear(10, 10)
-    let lm = try MaterializedModule(l)
+    let lm = MaterializedModule(l)
 
     // this will have been materialized in the call
     #expect(l.weight is MaterializedArray)

--- a/Tests/MLXTests/MaterializedTests.swift
+++ b/Tests/MLXTests/MaterializedTests.swift
@@ -41,6 +41,44 @@ struct MaterializedTests {
     }
 
     @Test
+    func testCompileInputsOutputsMaterialized() {
+        // A MaterializedArray can never change, so it has nothing for
+        // compile(inputs:outputs:) to observe or update -- it is simply
+        // captured as a constant when the function is traced, the same as
+        // any other value reachable from the closure that isn't part of
+        // `inputs`/`outputs`.  This is the documented
+        // `compile(inputs: [state], outputs: [state], f)` pattern (see
+        // compilation.md).
+        let state = MLXRandom.normal([4, 4]).materialized()
+        let compiled = compile(inputs: [state], outputs: [state]) { (x: MLXArray) in
+            x + state
+        }
+
+        let x = MLXRandom.normal([4, 4])
+        let r1 = compiled(x)
+        let r2 = x + state
+        #expect(r1.allClose(r2).item(Bool.self))
+
+        // same for a `Module` whose parameters were materialized (e.g. via
+        // `MaterializedModule`) -- this is the documented
+        // `compile(inputs: [model], outputs: [model])` pattern.
+        //
+        // Note: capturing the interior module is documented as forbidden but
+        // used here to test.  Do not copy this pattern!
+        let l = Linear(4, 4)
+        _ = MaterializedModule(l)
+
+        let compiledModel = compile(inputs: [l], outputs: [l]) { (x: MLXArray) in
+            l(x)
+        }
+
+        let input = MLXRandom.normal([4, 4])
+        let modelResult = compiledModel(input)
+        let expected = l(input)
+        #expect(modelResult.allClose(expected).item(Bool.self))
+    }
+
+    @Test
     func testMaterializedLinear() async {
         let l = Linear(10, 10)
         let lm = MaterializedModule(l)

--- a/Tests/MLXTests/MaterializedTests.swift
+++ b/Tests/MLXTests/MaterializedTests.swift
@@ -236,4 +236,21 @@ struct MaterializedTests {
         let x = uniform(0 ..< 1, [10])
         let _ = mm(x)
     }
+
+    @Test func testMaterializedModuleTwice() {
+        let inner = Linear(10, 10)
+        let mm = MaterializedModule(inner)
+
+        // per contract with MaterializedModule, we can't retain the module
+        // after materializing it, but if we do, it should
+        let mm2 = MaterializedModule(inner)
+
+        #expect(mm.description.contains("Linear"))
+        #expect(mm.parameterNBytes == mm.parameters().reduce(0) { $0 + $1.nbytes })
+
+        // callable
+        let x = uniform(0 ..< 1, [10])
+        let _ = mm(x)
+        let _ = mm2(x)
+    }
 }

--- a/skills/mlx-swift/SKILL.md
+++ b/skills/mlx-swift/SKILL.md
@@ -40,6 +40,8 @@ Cmlx (C/C++ bindings, Metal GPU)
 | Purpose | File Path |
 |---------|-----------|
 | Core array | Source/MLX/MLXArray.swift |
+| Materialized (Sendable) array | Source/MLX/MaterializedArray.swift |
+| Materialized (Sendable) module | Source/MLXNN/MaterializedModule.swift |
 | Operations | Source/MLX/Ops.swift |
 | Transforms | Source/MLX/Transforms.swift |
 | Factory methods | Source/MLX/Factory.swift |
@@ -383,7 +385,7 @@ _ = await weightsTicket.end()
 
 ### DON'T
 
-- **Don't share MLXArrays across tasks**: MLXArray is NOT Sendable by design.
+- **Don't share MLXArrays across tasks**: MLXArray is NOT Sendable by design — materialize a Sendable snapshot with `array.materialized()` (or wrap a model in `MaterializedModule`) when you must cross a boundary.
 - **Don't use deprecated module imports**: Use `import MLX` not `import MLXRandom`.
 - **Don't forget to eval()**: Unevaluated arrays can accumulate large compute graphs.
 - **Don't mutate arrays directly**: Use operations that return new arrays.
@@ -411,6 +413,7 @@ See [deprecated.md](references/deprecated.md) for the complete migration guide.
 MLX has specific concurrency behavior:
 
 - **MLXArray is NOT Sendable**: This is intentional. Arrays contain references to compute graphs.
+- **Materialize to cross boundaries**: `array.materialized()` / `materialize(_:)` returns a `Sendable` `MaterializedArray` snapshot; `MaterializedModule` does the same for a whole model.
 - **evalLock protects eval/stream creation**: The global lock serializes evaluation and stream operations.
 - **Lazy operations are NOT thread-safe**: Don't share arrays across tasks without proper synchronization.
 - **Use actors to encapsulate MLX state**: Create and use MLXArrays within the same actor.

--- a/skills/mlx-swift/SKILL.md
+++ b/skills/mlx-swift/SKILL.md
@@ -40,6 +40,8 @@ Cmlx (C/C++ bindings, Metal GPU)
 | Purpose | File Path |
 |---------|-----------|
 | Core array | Source/MLX/MLXArray.swift |
+| Materialized (Sendable) array | Source/MLX/MaterializedArray.swift |
+| Materialized (Sendable) module | Source/MLXNN/MaterializedModule.swift |
 | Operations | Source/MLX/Ops.swift |
 | Transforms | Source/MLX/Transforms.swift |
 | Factory methods | Source/MLX/Factory.swift |
@@ -387,7 +389,7 @@ _ = await weightsTicket.end()
 
 ### DON'T
 
-- **Don't share MLXArrays across tasks**: MLXArray is NOT Sendable by design.
+- **Don't share MLXArrays across tasks**: MLXArray is NOT Sendable by design — materialize a Sendable snapshot with `array.materialized()` (or wrap a model in `MaterializedModule`) when you must cross a boundary.
 - **Don't use deprecated module imports**: Use `import MLX` not `import MLXRandom`.
 - **Don't forget to eval()**: Unevaluated arrays can accumulate large compute graphs.
 - **Don't mutate arrays directly**: Use operations that return new arrays.
@@ -415,6 +417,7 @@ See [deprecated.md](references/deprecated.md) for the complete migration guide.
 MLX has specific concurrency behavior:
 
 - **MLXArray is NOT Sendable**: This is intentional. Arrays contain references to compute graphs.
+- **Materialize to cross boundaries**: `array.materialized()` / `materialize(_:)` returns a `Sendable` `MaterializedArray` snapshot; `MaterializedModule` does the same for a whole model.
 - **evalLock protects eval/stream creation**: The global lock serializes evaluation and stream operations.
 - **Lazy operations are NOT thread-safe**: Don't share arrays across tasks without proper synchronization.
 - **Use actors to encapsulate MLX state**: Create and use MLXArrays within the same actor.

--- a/skills/mlx-swift/references/concurrency.md
+++ b/skills/mlx-swift/references/concurrency.md
@@ -6,7 +6,7 @@ MLX Swift has specific concurrency characteristics for thread safety on Apple Si
 
 ### MLXArray is NOT Sendable
 
-`MLXArray` is intentionally **not** `Sendable`. This is by design:
+An ordinary `MLXArray` is intentionally **not** `Sendable`. This is by design:
 
 ```swift
 // WRONG: Will not compile in strict concurrency mode
@@ -19,6 +19,9 @@ Task {
 ```
 
 **Why?** MLXArray contains references to compute graphs that may be shared and mutated. Sending arrays across task boundaries could cause data races.
+
+The exception is a ``MaterializedArray`` (see below) — a fully-evaluated,
+immutable snapshot that *is* `Sendable`.
 
 ### Safe Patterns
 
@@ -39,6 +42,93 @@ let data = array.asArray(Int.self)  // [Int] is Sendable
 Task {
     let newArray = MLXArray(data)
     // Work with newArray
+}
+
+// Pattern 3: Materialize a Sendable snapshot (no round-trip through [Float])
+let array = MLXArray([1, 2, 3])
+let snapshot = array.materialized()   // MaterializedArray: evaluated + Sendable
+
+Task {
+    print(snapshot + 3)   // safe to use across the task boundary
+}
+```
+
+## MaterializedArray and MaterializedModule
+
+When you actually need to hand an array (or a whole model) across a task or
+actor boundary, use the materialize APIs instead of copying data out to
+`[Float]` and rebuilding.
+
+### MaterializedArray
+
+`MaterializedArray` is a subclass of `MLXArray` that is a fully-evaluated,
+immutable snapshot and is declared `@unchecked Sendable`:
+
+- Contents are evaluated at construction, so no graph work is pending.
+- Mutating APIs (`_updateInternal`, `+=`, `-=`, `*=`, `/=`) are marked
+  `@available(*, unavailable)` and trap if called.
+- It is still an `MLXArray`, so it can be used anywhere one is accepted.
+  Operations involving it still produce ordinary (lazy) `MLXArray` results —
+  only the snapshot itself is frozen.
+
+Construct one via `MLXArray.materialized()` or the free `materialize(_:)`
+functions (never directly):
+
+```swift
+let m1 = a.materialized()          // single array
+let m2 = materialize(a)            // equivalent free function
+let batch = materialize([w, b])    // [MLXArray] -> [MaterializedArray], one eval
+
+// safe to send across boundaries
+let t = Task { print(m1 + 3) }
+```
+
+Use the `[MLXArray]` overload when materializing several arrays at once (for
+example a model's parameters) so MLX can schedule the eval as a single batch.
+
+### MaterializedModule
+
+`MaterializedModule<LayerType>` wraps a `Module` whose parameters have all been
+materialized, so the whole module is safe to share. A normal `Module` is not
+`Sendable` because its parameters are lazy, mutable `MLXArray` values.
+
+```swift
+// construct the base module inline so no other reference exists
+let lm = MaterializedModule(Linear(10, 10))
+
+let t = Task {
+    let x = MLXRandom.normal([10, 10])
+    print(sum(lm(x)))    // UnaryLayer call forwarded to the wrapped module
+}
+```
+
+Key points:
+
+- The initializer takes `base` as `consuming` — **do not retain or use the
+  original reference after passing it in.** Because `Module` is a reference
+  type this cannot be enforced by the compiler, so as a backstop the base and
+  all descendants are *sealed*: any later mutation (`update(parameters:)`,
+  `update(modules:)`, `apply(...)`, `freeze`/`unfreeze`, `train`) traps with
+  `fatalError` rather than silently violating the `Sendable` invariant.
+- Only parameters that can be replaced (e.g. wrapped with `@ParameterInfo`) are
+  actually retyped to `MaterializedArray`; all others are still evaluated and
+  materialized, they just keep the `MLXArray` static type.
+- `parameters()` returns a `NestedDictionary<String, MaterializedArray>`, and
+  `parameterNBytes` gives the total size of all parameters.
+- Calling the wrapped module is added per layer shape via extensions.
+  `UnaryLayer` support ships in the package; other protocols (e.g. a
+  `LanguageModel` protocol in `mlx-swift-lm`) are wired up with an
+  `extension MaterializedModule: Proto where LayerType: Proto` that forwards to
+  `_base` (accessed via `@_spi(MaterializedModule) import MLXNN`).
+
+This is the recommended way to store a model in a `Sendable` type:
+
+```swift
+struct ModelContext: Sendable {
+    var model: any LanguageModel & Sendable
+    init(model: some LanguageModel) {
+        self.model = MaterializedModule(model)
+    }
 }
 ```
 
@@ -70,6 +160,8 @@ These types are marked `@unchecked Sendable` and are safe to share:
 
 | Type | Location | Notes |
 |------|----------|-------|
+| `MaterializedArray` | MaterializedArray.swift | Evaluated, immutable array snapshot |
+| `MaterializedModule` | MaterializedModule.swift | Wraps a Module with materialized params |
 | `Stream` | Stream.swift | Immutable after creation |
 | `Device` | Device.swift | Immutable after creation |
 | `MLXFastKernel` | MLXFastKernel.swift | Kernel definition is immutable |
@@ -261,14 +353,17 @@ Why this is better:
 
 - Create MLXArrays within the task/actor that uses them
 - Use `eval()` before extracting values to send across boundaries
+- Use `materialized()` / `materialize(_:)` to get a `Sendable` snapshot when you must share an array
+- Wrap models in `MaterializedModule` to share them across concurrency domains
 - Use actors to encapsulate MLX state
-- Pass Sendable types (`[Float]`, `Int`, etc.) between tasks
+- Pass Sendable types (`[Float]`, `Int`, `MaterializedArray`, etc.) between tasks
 - Use explicit stream parameters for device/stream control
 - Use `WiredMemoryTicket.withWiredLimit` for concurrent GPU workloads
 
 ### DON'T
 
-- Share MLXArray instances across tasks
+- Share ordinary (lazy) MLXArray instances across tasks — materialize them first
+- Retain the original reference after passing a module to `MaterializedModule` (it is sealed and will trap on mutation)
 - Assume lazy operations are thread-safe
 - Create arrays in one task and use in another
 - Ignore the evalLock when doing custom threading


### PR DESCRIPTION
## Proposed changes

- once an array has been evaluated we can use it as Sendable
- a subtype of MLXArray that is Sendable

Looking for feedback on this.  I will add documentation once I test it a bit.  Check out the tests to see how it works.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
