### PR TITLE
fix(Device): resolve initial default from MLX core, not hard-coded GPU

### DIFF
--- a/Source/MLX/Device.swift
+++ b/Source/MLX/Device.swift
@@ -102,7 +102,18 @@ public final class Device: @unchecked Sendable, Equatable {
 
     private static func _resolveGlobalDefaultDevice() -> Device {
         _lock.withLock {
-            _defaultDevice ?? .gpu
+            if let device = _defaultDevice {
+                return device
+            }
+            // Ask the underlying MLX C++ core for its default device rather
+            // than hard-coding `.gpu`. On Apple platforms with Metal this
+            // still resolves to GPU; on a CPU-only host (Linux without
+            // CUDA / no Metal) it correctly resolves to CPU. Hard-coding GPU
+            // here meant `defaultDevice()` / `StreamOrDevice.default`
+            // returned an unavailable device on those hosts.
+            var ctx = mlx_device_new()
+            mlx_get_default_device(&ctx)
+            return Device(ctx)
         }
     }
 


### PR DESCRIPTION
Closes #395.

`_resolveGlobalDefaultDevice()` returned `.gpu` whenever no explicit `setDefault(...)` had been called, so on a CPU-only host (Linux with no Metal / no CUDA) `Device.defaultDevice()` and `StreamOrDevice.default` both returned a device that doesn't actually exist on that machine — every subsequent op routed to the default stream then failed.

The deprecated `Device.init()` already encodes the right pattern: ask the underlying C++ core with `mlx_get_default_device(...)` and let it pick the device its build supports. Switch `_resolveGlobalDefaultDevice` to that path.

```diff
 private static func _resolveGlobalDefaultDevice() -> Device {
     _lock.withLock {
-        _defaultDevice ?? .gpu
+        if let device = _defaultDevice {
+            return device
+        }
+        var ctx = mlx_device_new()
+        mlx_get_default_device(&ctx)
+        return Device(ctx)
     }
 }
```

On Apple platforms with Metal this still resolves to GPU — `testUsingDevice` already covers that and continues to pass — and `setDefault` / `withDefaultDevice` overrides still win through the same `_defaultDevice` check above the fall-through.

Matches the fix proposed in the issue.