### PR TITLE
Build SwiftPM default Metal library resource

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -83,6 +83,7 @@ let noCudaCmlxExcludes = [
     let cxxSettings: [CXXSetting]
     let linkerSettings: [LinkerSetting]
     let mlxSwiftExcludes: [String]
+    let cmlxPlugins: [Target.PluginUsage]
 
     if Context.environment["SPM_CUDA"] != "0" {
         // Linux with CUDA
@@ -140,6 +141,10 @@ let noCudaCmlxExcludes = [
             "GPU+Metal.swift",
             "MLXArray+Metal.swift",
         ]
+
+        cmlxPlugins = [
+            .plugin(name: "CudaBuild")
+        ]
     } else {
         // Linux without CUDA (CPU only)
 
@@ -174,6 +179,10 @@ let noCudaCmlxExcludes = [
             "MLXArray+Metal.swift",
             "MLXFast.swift",
             "MLXFastKernel.swift",
+        ]
+
+        cmlxPlugins = [
+            .plugin(name: "CudaBuild")
         ]
     }
 #else
@@ -211,6 +220,11 @@ let noCudaCmlxExcludes = [
 
     let mlxSwiftExcludes: [String] = [
         "GPU+CUDA.swift"
+    ]
+
+    let cmlxPlugins: [Target.PluginUsage] = [
+        .plugin(name: "CudaBuild"),
+        .plugin(name: "BuildSwiftPMMetalLibrary"),
     ]
 #endif
 
@@ -289,9 +303,7 @@ let cmlx = Target.target(
         .define("MLX_VERSION", to: "\"0.31.1\""),
     ],
     linkerSettings: linkerSettings,
-    plugins: [
-        .plugin(name: "CudaBuild")
-    ],
+    plugins: cmlxPlugins
 )
 
 let package = Package(
@@ -321,6 +333,10 @@ let package = Package(
     ],
     targets: [
         cmlx,
+        .plugin(
+            name: "BuildSwiftPMMetalLibrary",
+            capability: .buildTool()
+        ),
         .testTarget(
             name: "CmlxTests",
             dependencies: ["Cmlx"]

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,12 @@
 import PackageDescription
 
 #if os(Linux)
+    let metalBuildPlugins: [Target.PluginUsage] = []
+#else
+    let metalBuildPlugins: [Target.PluginUsage] = [.plugin(name: "BuildSwiftPMMetalLibrary")]
+#endif
+
+#if os(Linux)
     let cudaBuildPlugins: [Target.PluginUsage] = [
         .plugin(name: "CudaBuild")
     ]
@@ -313,7 +319,7 @@ let cmlx = Target.target(
         .define("MLX_VERSION", to: "\"0.32.0\""),
     ],
     linkerSettings: linkerSettings,
-    plugins: cudaBuildPlugins,
+    plugins: cudaBuildPlugins + metalBuildPlugins,
 )
 
 let package = Package(
@@ -447,6 +453,7 @@ let package = Package(
                 .enableExperimentalFeature("StrictConcurrency")
             ]
         ),
+        .plugin(name: "BuildSwiftPMMetalLibrary", capability: .buildTool()),
     ] + cudaTargets,
     cxxLanguageStandard: .gnucxx20
 )

--- a/Plugins/BuildSwiftPMMetalLibrary/plugin.swift
+++ b/Plugins/BuildSwiftPMMetalLibrary/plugin.swift
@@ -7,15 +7,15 @@ struct BuildSwiftPMMetalLibrary: BuildToolPlugin {
         #if os(Linux)
             return []
         #else
-            let packageRoot = context.package.directory
-            let script = packageRoot.appending("tools", "build-swiftpm-metallib.sh")
-            let output = context.pluginWorkDirectory.appending("default.metallib")
+            let packageRoot = context.package.directoryURL
+            let script = packageRoot.appendingPathComponent("tools/build-swiftpm-metallib.sh")
+            let output = context.pluginWorkDirectoryURL.appendingPathComponent("default.metallib")
 
             return [
                 .buildCommand(
                     displayName: "Build SwiftPM default.metallib",
-                    executable: Path("/bin/bash"),
-                    arguments: [script, output],
+                    executable: URL(fileURLWithPath: "/bin/bash"),
+                    arguments: [script.path, output.path],
                     inputFiles: inputFiles(packageRoot: packageRoot, script: script),
                     outputFiles: [output]
                 )
@@ -24,32 +24,30 @@ struct BuildSwiftPMMetalLibrary: BuildToolPlugin {
     }
 
     #if !os(Linux)
-        private func inputFiles(packageRoot: Path, script: Path) -> [Path] {
-            let kernelsDirectory = packageRoot.appending(
-                "Source",
-                "Cmlx",
-                "mlx",
-                "mlx",
-                "backend",
-                "metal",
-                "kernels"
-            )
+        private func inputFiles(packageRoot: URL, script: URL) -> [URL] {
+            let kernelsDirectory = packageRoot.appendingPathComponent(
+                "Source/Cmlx/mlx/mlx/backend/metal/kernels")
             var files = [script]
             files.append(contentsOf: recursivelyCollectedMetalInputs(in: kernelsDirectory))
             return files
         }
 
-        private func recursivelyCollectedMetalInputs(in directory: Path) -> [Path] {
+        private func recursivelyCollectedMetalInputs(in directory: URL) -> [URL] {
             let fileManager = FileManager.default
-            guard let enumerator = fileManager.enumerator(atPath: directory.string) else {
+            guard
+                let enumerator = fileManager.enumerator(
+                    at: directory, includingPropertiesForKeys: nil)
+            else {
                 return []
             }
 
-            return enumerator.compactMap { entry -> Path? in
-                guard let entry = entry as? String else { return nil }
-                guard entry.hasSuffix(".metal") || entry.hasSuffix(".h") else { return nil }
-                return directory.appending(subpath: entry)
-            }.sorted { $0.string < $1.string }
+            return enumerator.compactMap { entry -> URL? in
+                guard let url = entry as? URL else { return nil }
+                guard url.pathExtension == "metal" || url.pathExtension == "h" else {
+                    return nil
+                }
+                return url
+            }.sorted { $0.path < $1.path }
         }
     #endif
 }

--- a/Plugins/BuildSwiftPMMetalLibrary/plugin.swift
+++ b/Plugins/BuildSwiftPMMetalLibrary/plugin.swift
@@ -1,0 +1,55 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct BuildSwiftPMMetalLibrary: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: any Target) async throws -> [Command] {
+        #if os(Linux)
+            return []
+        #else
+            let packageRoot = context.package.directory
+            let script = packageRoot.appending("tools", "build-swiftpm-metallib.sh")
+            let output = context.pluginWorkDirectory.appending("default.metallib")
+
+            return [
+                .buildCommand(
+                    displayName: "Build SwiftPM default.metallib",
+                    executable: Path("/bin/bash"),
+                    arguments: [script, output],
+                    inputFiles: inputFiles(packageRoot: packageRoot, script: script),
+                    outputFiles: [output]
+                )
+            ]
+        #endif
+    }
+
+    #if !os(Linux)
+        private func inputFiles(packageRoot: Path, script: Path) -> [Path] {
+            let kernelsDirectory = packageRoot.appending(
+                "Source",
+                "Cmlx",
+                "mlx",
+                "mlx",
+                "backend",
+                "metal",
+                "kernels"
+            )
+            var files = [script]
+            files.append(contentsOf: recursivelyCollectedMetalInputs(in: kernelsDirectory))
+            return files
+        }
+
+        private func recursivelyCollectedMetalInputs(in directory: Path) -> [Path] {
+            let fileManager = FileManager.default
+            guard let enumerator = fileManager.enumerator(atPath: directory.string) else {
+                return []
+            }
+
+            return enumerator.compactMap { entry -> Path? in
+                guard let entry = entry as? String else { return nil }
+                guard entry.hasSuffix(".metal") || entry.hasSuffix(".h") else { return nil }
+                return directory.appending(subpath: entry)
+            }.sorted { $0.string < $1.string }
+        }
+    #endif
+}

--- a/Plugins/BuildSwiftPMMetalLibrary/plugin.swift
+++ b/Plugins/BuildSwiftPMMetalLibrary/plugin.swift
@@ -1,0 +1,62 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct BuildSwiftPMMetalLibrary: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: any Target) async throws -> [Command] {
+        #if os(Linux)
+            return []
+        #else
+            // Xcode already compiles the target's Metal sources into the resource
+            // bundle. Declaring another default.metallib produces a duplicate-output
+            // build error, so this command is only needed by SwiftPM's native build.
+            if context.pluginWorkDirectoryURL.pathComponents.contains(
+                "BuildToolPluginIntermediates")
+            {
+                return []
+            }
+
+            let packageRoot = context.package.directoryURL
+            let script = packageRoot.appendingPathComponent("tools/build-swiftpm-metallib.sh")
+            let output = context.pluginWorkDirectoryURL.appendingPathComponent("default.metallib")
+
+            return [
+                .buildCommand(
+                    displayName: "Build SwiftPM default.metallib",
+                    executable: URL(fileURLWithPath: "/bin/bash"),
+                    arguments: [script.path, output.path],
+                    inputFiles: inputFiles(packageRoot: packageRoot, script: script),
+                    outputFiles: [output]
+                )
+            ]
+        #endif
+    }
+
+    #if !os(Linux)
+        private func inputFiles(packageRoot: URL, script: URL) -> [URL] {
+            let kernelsDirectory = packageRoot.appendingPathComponent(
+                "Source/Cmlx/mlx/mlx/backend/metal/kernels")
+            var files = [script]
+            files.append(contentsOf: recursivelyCollectedMetalInputs(in: kernelsDirectory))
+            return files
+        }
+
+        private func recursivelyCollectedMetalInputs(in directory: URL) -> [URL] {
+            let fileManager = FileManager.default
+            guard
+                let enumerator = fileManager.enumerator(
+                    at: directory, includingPropertiesForKeys: nil)
+            else {
+                return []
+            }
+
+            return enumerator.compactMap { entry -> URL? in
+                guard let url = entry as? URL else { return nil }
+                guard url.pathExtension == "metal" || url.pathExtension == "h" else {
+                    return nil
+                }
+                return url
+            }.sorted { $0.path < $1.path }
+        }
+    #endif
+}

--- a/Source/MLX/Stream.swift
+++ b/Source/MLX/Stream.swift
@@ -84,6 +84,11 @@ public final class Stream: @unchecked Sendable, Equatable {
     let ctx: mlx_stream
 
     private static func newStreamThreadUnsafe(_ deviceType: DeviceType) -> mlx_stream {
+        #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
+            if deviceType == .gpu {
+                SwiftPMMetallibResource.configureIfNeeded()
+            }
+        #endif
         var cDeviceType: mlx_device_type
         switch deviceType {
         case DeviceType.cpu:
@@ -126,6 +131,7 @@ public final class Stream: @unchecked Sendable, Equatable {
     /// Default stream on the default device.
     public init() {
         let device = Device.defaultDevice()
+        configureSwiftPMMetallibIfNeeded(for: device)
         self.ctx = evalLock.withLock {
             mlx_stream_new_thread_unsafe(device.ctx)
         }
@@ -133,6 +139,7 @@ public final class Stream: @unchecked Sendable, Equatable {
 
     @available(*, deprecated, message: "use init(Device) -- index not supported")
     public init(index: Int32, _ device: Device) {
+        configureSwiftPMMetallibIfNeeded(for: device)
         self.ctx = evalLock.withLock {
             mlx_stream_new_thread_unsafe(device.ctx)
         }
@@ -142,6 +149,7 @@ public final class Stream: @unchecked Sendable, Equatable {
     ///
     /// See also ``withNewDefaultStream(device:_:)-5bwc3``
     public init(_ device: Device) {
+        configureSwiftPMMetallibIfNeeded(for: device)
         self.ctx = evalLock.withLock {
             mlx_stream_new_thread_unsafe(device.ctx)
         }
@@ -171,6 +179,14 @@ public final class Stream: @unchecked Sendable, Equatable {
     public static func == (lhs: Stream, rhs: Stream) -> Bool {
         mlx_stream_equal(lhs.ctx, rhs.ctx)
     }
+}
+
+private func configureSwiftPMMetallibIfNeeded(for device: Device) {
+    #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
+        if device.deviceType == .gpu {
+            SwiftPMMetallibResource.configureIfNeeded()
+        }
+    #endif
 }
 
 extension Stream: CustomStringConvertible {

--- a/Source/MLX/SwiftPMMetallibResource.swift
+++ b/Source/MLX/SwiftPMMetallibResource.swift
@@ -1,0 +1,104 @@
+// Copyright © 2024 Apple Inc.
+
+import Foundation
+
+#if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
+    enum SwiftPMMetallibResource {
+        private static let lock = NSLock()
+        #if swift(>=5.10)
+            nonisolated(unsafe) private static var didConfigure = false
+        #else
+            private static var didConfigure = false
+        #endif
+        private static let bundleName = "mlx-swift_Cmlx.bundle"
+        private static let metallibName = "default.metallib"
+
+        static func configureIfNeeded() {
+            lock.withLock {
+                guard !didConfigure else { return }
+                defer { didConfigure = true }
+
+                guard GPU.metallib == nil, let url = findMetallibURL() else { return }
+                GPU.metallib = url
+            }
+        }
+
+        static func findMetallibURL() -> URL? {
+            var seen = Set<String>()
+
+            for directory in searchDirectories() {
+                var current: URL? = directory
+                for _ in 0 ..< 8 {
+                    guard let candidateDirectory = current else {
+                        break
+                    }
+
+                    let key = candidateDirectory.standardizedFileURL.path()
+                    if seen.insert(key).inserted,
+                        let url = metallibURL(near: candidateDirectory)
+                    {
+                        return url
+                    }
+
+                    let parent = candidateDirectory.deletingLastPathComponent()
+                    if parent.path() == candidateDirectory.path() {
+                        break
+                    }
+                    current = parent
+                }
+            }
+
+            return nil
+        }
+
+        private static func metallibURL(near directory: URL) -> URL? {
+            let candidates = [
+                directory.appendingPathComponent(metallibName),
+                directory.appendingPathComponent(bundleName).appendingPathComponent(metallibName),
+                directory.appendingPathComponent("Resources").appendingPathComponent(bundleName)
+                    .appendingPathComponent(metallibName),
+            ]
+
+            return candidates.first {
+                FileManager.default.isReadableFile(atPath: $0.path())
+            }
+        }
+
+        private static func searchDirectories() -> [URL] {
+            var directories = [URL]()
+            var seen = Set<String>()
+
+            func add(_ url: URL?) {
+                guard let url else {
+                    return
+                }
+                let standardized = url.standardizedFileURL
+                if seen.insert(standardized.path()).inserted {
+                    directories.append(standardized)
+                }
+            }
+
+            add(Bundle.main.resourceURL)
+            add(Bundle.main.bundleURL)
+            add(Bundle.main.executableURL?.deletingLastPathComponent())
+
+            for bundle in Bundle.allBundles {
+                add(bundle.resourceURL)
+                add(bundle.bundleURL)
+                add(bundle.executableURL?.deletingLastPathComponent())
+            }
+
+            for framework in Bundle.allFrameworks {
+                add(framework.resourceURL)
+                add(framework.bundleURL)
+                add(framework.executableURL?.deletingLastPathComponent())
+            }
+
+            if let executablePath = CommandLine.arguments.first, !executablePath.isEmpty {
+                add(URL(fileURLWithPath: executablePath).deletingLastPathComponent())
+            }
+
+            return directories
+        }
+    }
+#endif

--- a/Source/MLX/SwiftPMMetallibResource.swift
+++ b/Source/MLX/SwiftPMMetallibResource.swift
@@ -51,13 +51,30 @@ import Foundation
             return nil
         }
 
-        private static func metallibURL(near directory: URL) -> URL? {
-            let candidates = [
-                directory.appendingPathComponent(metallibName),
-                directory.appendingPathComponent(bundleName).appendingPathComponent(metallibName),
-                directory.appendingPathComponent("Resources").appendingPathComponent(bundleName)
-                    .appendingPathComponent(metallibName),
+        static func metallibURL(near directory: URL) -> URL? {
+            var bundles = [
+                directory.appendingPathComponent(bundleName),
+                directory.appendingPathComponent("Resources").appendingPathComponent(bundleName),
+                directory.appendingPathComponent("Contents/Resources").appendingPathComponent(
+                    bundleName),
             ]
+            if directory.lastPathComponent == bundleName {
+                bundles.insert(directory, at: 0)
+            } else if directory.lastPathComponent == "Resources",
+                directory.deletingLastPathComponent().lastPathComponent == "Contents",
+                directory.deletingLastPathComponent().deletingLastPathComponent().lastPathComponent
+                    == bundleName
+            {
+                bundles.insert(
+                    directory.deletingLastPathComponent().deletingLastPathComponent(), at: 0)
+            }
+            let candidates = bundles.flatMap { bundle in
+                [
+                    bundle.appendingPathComponent(metallibName),
+                    bundle.appendingPathComponent("Contents/Resources").appendingPathComponent(
+                        metallibName),
+                ]
+            }
 
             return candidates.first {
                 FileManager.default.isReadableFile(atPath: $0.path())

--- a/Tests/MLXTests/SwiftPMMetallibResourceTests.swift
+++ b/Tests/MLXTests/SwiftPMMetallibResourceTests.swift
@@ -6,11 +6,37 @@ import XCTest
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
     final class SwiftPMMetallibResourceTests: XCTestCase {
+        func testLookupRequiresMLXBundleAndSupportsBothLayouts() throws {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                UUID().uuidString)
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: root) }
+            try Data().write(to: root.appendingPathComponent("default.metallib"))
+            XCTAssertNil(SwiftPMMetallibResource.metallibURL(near: root))
+
+            let bundle = root.appendingPathComponent("mlx-swift_Cmlx.bundle")
+            let resources = bundle.appendingPathComponent("Contents/Resources")
+            try FileManager.default.createDirectory(
+                at: resources, withIntermediateDirectories: true)
+            let xcodeLibrary = resources.appendingPathComponent("default.metallib")
+            try Data().write(to: xcodeLibrary)
+            XCTAssertEqual(SwiftPMMetallibResource.metallibURL(near: root), xcodeLibrary)
+            XCTAssertEqual(SwiftPMMetallibResource.metallibURL(near: resources), xcodeLibrary)
+
+            let swiftPMLibrary = bundle.appendingPathComponent("default.metallib")
+            try Data().write(to: swiftPMLibrary)
+            XCTAssertEqual(SwiftPMMetallibResource.metallibURL(near: root), swiftPMLibrary)
+            XCTAssertEqual(SwiftPMMetallibResource.metallibURL(near: bundle), swiftPMLibrary)
+        }
+
         func testFindsGeneratedSwiftPMMetallib() throws {
             let url = try XCTUnwrap(SwiftPMMetallibResource.findMetallibURL())
             XCTAssertEqual(url.lastPathComponent, "default.metallib")
-            XCTAssertEqual(
-                url.deletingLastPathComponent().lastPathComponent, "mlx-swift_Cmlx.bundle")
+            let bundleLayouts = [
+                "/mlx-swift_Cmlx.bundle/default.metallib",
+                "/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib",
+            ]
+            XCTAssertTrue(bundleLayouts.contains { url.path.hasSuffix($0) }, url.path)
         }
 
         func testGPUStreamLoadsGeneratedSwiftPMMetallib() {

--- a/Tests/MLXTests/SwiftPMMetallibResourceTests.swift
+++ b/Tests/MLXTests/SwiftPMMetallibResourceTests.swift
@@ -1,0 +1,20 @@
+// Copyright © 2024 Apple Inc.
+
+import XCTest
+
+@testable import MLX
+
+#if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
+    final class SwiftPMMetallibResourceTests: XCTestCase {
+        func testFindsGeneratedSwiftPMMetallib() throws {
+            let url = try XCTUnwrap(SwiftPMMetallibResource.findMetallibURL())
+            XCTAssertEqual(url.lastPathComponent, "default.metallib")
+            XCTAssertEqual(
+                url.deletingLastPathComponent().lastPathComponent, "mlx-swift_Cmlx.bundle")
+        }
+
+        func testGPUStreamLoadsGeneratedSwiftPMMetallib() {
+            Stream.gpu.synchronize()
+        }
+    }
+#endif

--- a/Tests/SwiftPMMetallibConsumer/Package.swift
+++ b/Tests/SwiftPMMetallibConsumer/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 6.3
+
+import PackageDescription
+
+let package = Package(
+    name: "SwiftPMMetallibConsumer",
+    platforms: [.macOS(.v14)],
+    dependencies: [
+        .package(name: "mlx-swift", path: "../..")
+    ],
+    targets: [
+        .executableTarget(
+            name: "SwiftPMMetallibConsumer",
+            dependencies: [
+                .product(name: "MLX", package: "mlx-swift")
+            ]
+        )
+    ]
+)

--- a/Tests/SwiftPMMetallibConsumer/README.md
+++ b/Tests/SwiftPMMetallibConsumer/README.md
@@ -1,0 +1,15 @@
+# SwiftPM metallib consumer smoke test
+
+This nested package verifies the downstream macOS CLI use case rather than an
+in-package test target. It builds a release executable against the parent
+`mlx-swift` package, confirms that SwiftPM emitted
+`mlx-swift_Cmlx.bundle/default.metallib`, copies the executable and resource
+bundle into a clean deployment directory, and launches the executable from a
+different working directory. The executable races several first GPU stream
+initializations, then evaluates and verifies a GPU array operation.
+
+Run it from the repository root:
+
+```sh
+Tests/SwiftPMMetallibConsumer/run.sh
+```

--- a/Tests/SwiftPMMetallibConsumer/Sources/SwiftPMMetallibConsumer/main.swift
+++ b/Tests/SwiftPMMetallibConsumer/Sources/SwiftPMMetallibConsumer/main.swift
@@ -1,0 +1,16 @@
+import Dispatch
+import MLX
+
+@main
+struct SwiftPMMetallibConsumer {
+    static func main() {
+        DispatchQueue.concurrentPerform(iterations: 8) { _ in
+            Stream(Device.gpu).synchronize()
+        }
+
+        let result = MLXArray([Float(1), 2, 3]) + 1
+        eval(result)
+        precondition(result.asArray(Float.self) == [2, 3, 4])
+        print("GPU computation succeeded")
+    }
+}

--- a/Tests/SwiftPMMetallibConsumer/run.sh
+++ b/Tests/SwiftPMMetallibConsumer/run.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+scratch_path="${TMP_DIR}/build"
+swift build \
+  --package-path "${SCRIPT_DIR}" \
+  --scratch-path "${scratch_path}" \
+  -c release
+
+bin_dir=$(
+  swift build \
+    --package-path "${SCRIPT_DIR}" \
+    --scratch-path "${scratch_path}" \
+    -c release \
+    --show-bin-path
+)
+
+executable="${bin_dir}/SwiftPMMetallibConsumer"
+resource_bundle="${bin_dir}/mlx-swift_Cmlx.bundle"
+metallib="${resource_bundle}/default.metallib"
+
+test -x "${executable}"
+test -r "${metallib}"
+
+mkdir -p "${TMP_DIR}/deploy" "${TMP_DIR}/working-directory"
+cp "${executable}" "${TMP_DIR}/deploy/"
+cp -R "${resource_bundle}" "${TMP_DIR}/deploy/"
+
+output=$(
+  cd "${TMP_DIR}/working-directory"
+  "${TMP_DIR}/deploy/SwiftPMMetallibConsumer"
+)
+
+if [[ "${output}" != *"GPU computation succeeded"* ]]; then
+  printf 'unexpected consumer output:\n%s\n' "${output}" >&2
+  exit 1
+fi
+
+printf '%s\n' "${output}"

--- a/tools/build-swiftpm-metallib.sh
+++ b/tools/build-swiftpm-metallib.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Build the default Metal library resource used by SwiftPM Cmlx builds.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 OUTPUT_METALLIB" >&2
+  exit 64
+fi
+
+OUTPUT="$1"
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+ROOT_DIR=$(realpath "${SCRIPT_DIR}/..")
+KERNELS_DIR="${ROOT_DIR}/Source/Cmlx/mlx/mlx/backend/metal/kernels"
+
+METAL=$(xcrun -sdk macosx -find metal)
+METALLIB=$(xcrun -sdk macosx -find metallib)
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-14.0}"
+
+metal_version=$(
+  printf '%s\n' '__METAL_VERSION__' |
+    "${METAL}" "-mmacosx-version-min=${DEPLOYMENT_TARGET}" -E -x metal -P - |
+    tail -1 |
+    tr -d '[:space:]'
+)
+metal_version=${metal_version:-0}
+
+kernels=(
+  "arg_reduce"
+  "conv"
+  "gemv"
+  "layer_norm"
+  "random"
+  "rms_norm"
+  "rope"
+  "scaled_dot_product_attention"
+)
+
+if (( metal_version >= 320 )); then
+  kernels+=("fence")
+fi
+
+metal_flags=(
+  -x metal
+  -Wall
+  -Wextra
+  -fno-fast-math
+  -Wno-c++17-extensions
+  -Wno-c++20-extensions
+  -mmacosx-version-min="${DEPLOYMENT_TARGET}"
+)
+
+if (( metal_version >= 400 )); then
+  metal_flags+=(-std=metal4.0)
+elif (( metal_version >= 320 )); then
+  metal_flags+=(-std=metal3.2)
+elif (( metal_version >= 310 )); then
+  metal_flags+=(-std=metal3.1)
+elif (( metal_version >= 300 )); then
+  metal_flags+=(-std=metal3.0)
+fi
+
+air_files=()
+for kernel in "${kernels[@]}"; do
+  source="${KERNELS_DIR}/${kernel}.metal"
+  air="${TMP_DIR}/${kernel}.air"
+  "${METAL}" "${metal_flags[@]}" -c "${source}" -I"${ROOT_DIR}/Source/Cmlx/mlx" -o "${air}"
+  air_files+=("${air}")
+done
+
+mkdir -p "$(dirname "${OUTPUT}")"
+"${METALLIB}" "${air_files[@]}" -o "${TMP_DIR}/default.metallib"
+mv "${TMP_DIR}/default.metallib" "${OUTPUT}"

--- a/tools/build-swiftpm-metallib.sh
+++ b/tools/build-swiftpm-metallib.sh
@@ -13,16 +13,63 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 ROOT_DIR=$(realpath "${SCRIPT_DIR}/..")
 KERNELS_DIR="${ROOT_DIR}/Source/Cmlx/mlx/mlx/backend/metal/kernels"
 
-METAL=$(xcrun -sdk macosx -find metal)
-METALLIB=$(xcrun -sdk macosx -find metallib)
+normalize_sdk_name() {
+  local raw="$1"
+  raw=$(basename "${raw}")
+  raw=$(printf '%s' "${raw}" | tr '[:upper:]' '[:lower:]')
+  case "${raw}" in
+    macosx*) echo "macosx" ;;
+    iphoneos*) echo "iphoneos" ;;
+    iphonesimulator*) echo "iphonesimulator" ;;
+    appletvos*) echo "appletvos" ;;
+    appletvsimulator*) echo "appletvsimulator" ;;
+    xros* | visionos*) echo "xros" ;;
+    xrsimulator* | visionsimulator*) echo "xrsimulator" ;;
+    *) echo "${raw}" ;;
+  esac
+}
+
+requested_sdk="${SDK_NAME:-${PLATFORM_NAME:-}}"
+if [[ -z "${requested_sdk}" && -n "${SDKROOT:-}" ]]; then
+  requested_sdk=$(basename "${SDKROOT}")
+fi
+SDK=$(normalize_sdk_name "${requested_sdk:-macosx}")
+
+case "${SDK}" in
+  macosx)
+    DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-14.0}"
+    deployment_flag=("-mmacosx-version-min=${DEPLOYMENT_TARGET}")
+    ;;
+  iphoneos | iphonesimulator)
+    DEPLOYMENT_TARGET="${IPHONEOS_DEPLOYMENT_TARGET:-${IOS_DEPLOYMENT_TARGET:-17.0}}"
+    deployment_flag=("-mios-version-min=${DEPLOYMENT_TARGET}")
+    ;;
+  appletvos | appletvsimulator)
+    DEPLOYMENT_TARGET="${TVOS_DEPLOYMENT_TARGET:-17.0}"
+    deployment_flag=("-mtvos-version-min=${DEPLOYMENT_TARGET}")
+    ;;
+  xros)
+    DEPLOYMENT_TARGET="${XROS_DEPLOYMENT_TARGET:-${VISIONOS_DEPLOYMENT_TARGET:-1.0}}"
+    deployment_flag=("-mtargetos=xros${DEPLOYMENT_TARGET}")
+    ;;
+  xrsimulator)
+    DEPLOYMENT_TARGET="${XROS_DEPLOYMENT_TARGET:-${VISIONOS_DEPLOYMENT_TARGET:-1.0}}"
+    deployment_flag=("-mtargetos=xros${DEPLOYMENT_TARGET}-simulator")
+    ;;
+  *)
+    echo "unsupported SDK '${SDK}'" >&2
+    exit 65
+    ;;
+esac
+
+METAL=$(xcrun -sdk "${SDK}" -find metal)
+METALLIB=$(xcrun -sdk "${SDK}" -find metallib)
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "${TMP_DIR}"' EXIT
 
-DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-14.0}"
-
 metal_version=$(
   printf '%s\n' '__METAL_VERSION__' |
-    "${METAL}" "-mmacosx-version-min=${DEPLOYMENT_TARGET}" -E -x metal -P - |
+    "${METAL}" "${deployment_flag[@]}" -E -x metal -P - |
     tail -1 |
     tr -d '[:space:]'
 )
@@ -50,7 +97,7 @@ metal_flags=(
   -fno-fast-math
   -Wno-c++17-extensions
   -Wno-c++20-extensions
-  -mmacosx-version-min="${DEPLOYMENT_TARGET}"
+  "${deployment_flag[@]}"
 )
 
 if (( metal_version >= 400 )); then

--- a/tools/build-swiftpm-metallib.sh
+++ b/tools/build-swiftpm-metallib.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Build the default Metal library resource used by SwiftPM Cmlx builds.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 OUTPUT_METALLIB" >&2
+  exit 64
+fi
+
+OUTPUT="$1"
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+ROOT_DIR=$(realpath "${SCRIPT_DIR}/..")
+KERNELS_DIR="${ROOT_DIR}/Source/Cmlx/mlx/mlx/backend/metal/kernels"
+
+normalize_platform_name() {
+  local raw="$1"
+  raw=$(basename "${raw}")
+  raw=$(printf '%s' "${raw}" | tr '[:upper:]' '[:lower:]')
+  raw=${raw#-}
+  case "${raw}" in
+    macosx*) echo "macosx" ;;
+    iphoneos*) echo "iphoneos" ;;
+    iphonesimulator*) echo "iphonesimulator" ;;
+    appletvos*) echo "appletvos" ;;
+    appletvsimulator*) echo "appletvsimulator" ;;
+    xros* | visionos*) echo "xros" ;;
+    xrsimulator* | visionsimulator*) echo "xrsimulator" ;;
+    *) echo "${raw}" ;;
+  esac
+}
+
+requested_platform="${PLATFORM_NAME:-${EFFECTIVE_PLATFORM_NAME:-${SDK_NAME:-}}}"
+if [[ -z "${requested_platform}" && -n "${SDKROOT:-}" ]]; then
+  requested_platform=$(basename "${SDKROOT}")
+fi
+platform_name=$(normalize_platform_name "${requested_platform:-macosx}")
+
+case "${platform_name}" in
+  macosx)
+    sdk=macosx
+    target_os="macos${MACOSX_DEPLOYMENT_TARGET:-14.0}"
+    ;;
+  iphoneos)
+    sdk=iphoneos
+    target_os="ios${IPHONEOS_DEPLOYMENT_TARGET:-${IOS_DEPLOYMENT_TARGET:-17.0}}"
+    ;;
+  iphonesimulator)
+    sdk=iphonesimulator
+    target_os="ios${IPHONEOS_DEPLOYMENT_TARGET:-${IOS_DEPLOYMENT_TARGET:-17.0}}-simulator"
+    ;;
+  appletvos)
+    sdk=appletvos
+    target_os="tvos${TVOS_DEPLOYMENT_TARGET:-17.0}"
+    ;;
+  appletvsimulator)
+    sdk=appletvsimulator
+    target_os="tvos${TVOS_DEPLOYMENT_TARGET:-17.0}-simulator"
+    ;;
+  xros)
+    sdk=xros
+    target_os="xros${XROS_DEPLOYMENT_TARGET:-${VISIONOS_DEPLOYMENT_TARGET:-1.0}}"
+    ;;
+  xrsimulator)
+    sdk=xrsimulator
+    target_os="xros${XROS_DEPLOYMENT_TARGET:-${VISIONOS_DEPLOYMENT_TARGET:-1.0}}-simulator"
+    ;;
+  *)
+    echo "unsupported Apple platform '${platform_name}'" >&2
+    exit 65
+    ;;
+esac
+
+SDK_PATH=$(xcrun -sdk "${sdk}" -show-sdk-path)
+METAL=$(xcrun -sdk "${sdk}" -find metal)
+METALLIB=$(xcrun -sdk "${sdk}" -find metallib)
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "${TMP_DIR}"' EXIT
+target_flag="-mtargetos=${target_os}"
+
+echo "Building SwiftPM default.metallib for ${platform_name} (${target_os}; SDK ${sdk})"
+
+metal_version=$(
+  printf '%s\n' '__METAL_VERSION__' |
+    SDKROOT="${SDK_PATH}" "${METAL}" "${target_flag}" -E -x metal -P - |
+    tail -1 |
+    tr -d '[:space:]'
+)
+metal_version=${metal_version:-0}
+
+kernels=(
+  "arg_reduce"
+  "conv"
+  "gemv"
+  "layer_norm"
+  "random"
+  "rms_norm"
+  "rope"
+  "scaled_dot_product_attention"
+)
+
+if (( metal_version >= 320 )); then
+  kernels+=("fence")
+fi
+
+metal_flags=(
+  -x metal
+  -Wall
+  -Wextra
+  -fno-fast-math
+  -Wno-c++17-extensions
+  -Wno-c++20-extensions
+  "${target_flag}"
+)
+
+if (( metal_version >= 400 )); then
+  metal_flags+=(-std=metal4.0)
+elif (( metal_version >= 320 )); then
+  metal_flags+=(-std=metal3.2)
+elif (( metal_version >= 310 )); then
+  metal_flags+=(-std=metal3.1)
+elif (( metal_version >= 300 )); then
+  metal_flags+=(-std=metal3.0)
+fi
+
+air_files=()
+for kernel in "${kernels[@]}"; do
+  source="${KERNELS_DIR}/${kernel}.metal"
+  air="${TMP_DIR}/${kernel}.air"
+  SDKROOT="${SDK_PATH}" "${METAL}" "${metal_flags[@]}" -c "${source}" \
+    -I"${ROOT_DIR}/Source/Cmlx/mlx" -o "${air}"
+  air_files+=("${air}")
+done
+
+mkdir -p "$(dirname "${OUTPUT}")"
+SDKROOT="${SDK_PATH}" "${METALLIB}" "${air_files[@]}" -o "${TMP_DIR}/default.metallib"
+mv "${TMP_DIR}/default.metallib" "${OUTPUT}"


### PR DESCRIPTION
SwiftPM CLI builds need a packaged Metal library to run MLX outside an app
bundle. This PR builds `mlx-swift_Cmlx.bundle/default.metallib` and configures
the existing upstream `GPU.metallib` property before GPU stream creation.

The dependency chain is now upstream-owned: the MLX v0.32.2 update includes
the core and C get/set APIs plus Swift's `GPU.metallib: URL?`. This PR adds no
replacement wrapper for #416 and changes no submodule pins or optimizer APIs.

The build plugin uses platform-specific SDK/deployment flags and skips its
command under Xcode, where Metal resources are already built. Runtime lookup
accepts only the named MLX bundle, supporting both SwiftPM's flat layout and
Xcode's `Contents/Resources` layout. It preserves an explicit caller override.
A regression test excludes unrelated `default.metallib` files, including the
Metal.framework collision found during Xcode validation.

Validation on Xcode 26.6 / Swift 6.3.3:

- Clean SwiftPM release consumer: generated bundle, relocation, concurrent GPU
  stream creation and numerical GPU operation.
- `swift test --filter 'SwiftPMMetallibResourceTests|StreamTests/testDeviceType'`:
  four tests passed.
- Xcode macOS package build-for-testing and the same four tests passed.
- Metal library compilation passed for iOS, tvOS and visionOS device and
  simulator SDKs. These are compilation checks, not physical-device runs.
- Changed Swift sources formatted with swift-format 603.0.0; `git diff --check`.

The Hummingbird gateway adopter report in this thread remains relevant: the
earlier proof eliminated its extra Xcode metallib build step. Consumers must
ship the resource bundle with a relocated executable and align package URLs
across direct/transitive dependencies. The earlier proof's unrelated AdamW
signature delta is excluded here.

AI assistance was used for the rebase, dependency audit, bundle lookup fix and
validation. No TurboQuant kernel or quantized-prefill change is included.
