### PR TITLE
Add MultiOptimizer (port from Python mlx.optimizers)

### DIFF
--- a/Source/MLXOptimizers/Optimizers.swift
+++ b/Source/MLXOptimizers/Optimizers.swift
@@ -15,6 +15,70 @@ public protocol Optimizer: Updatable, Evaluatable {
     func update(model: Module, gradients: ModuleParameters)
 }
 
+/// An optimizer that delegates to several sub-optimizers, routing each parameter to the first
+/// optimizer whose filter matches.
+///
+/// This makes it easy to use different optimizers (or different hyperparameters) for different
+/// weights. The `filters` are predicates over a parameter's flattened key path and its gradient
+/// and must be one fewer than `optimizers` -- the last optimizer is the fallback and receives
+/// every parameter not matched by an earlier filter.
+///
+/// ```swift
+/// // Adam for everything except biases, which use SGD.
+/// let optimizer = MultiOptimizer(
+///     optimizers: [SGD(learningRate: 0.1), Adam(learningRate: 1e-3)],
+///     filters: [{ key, _ in key.hasSuffix(".bias") }])
+/// ```
+///
+/// This is a port of Python `mlx.optimizers.MultiOptimizer`.
+///
+/// ### See Also
+/// - <doc:MLXOptimizers>
+open class MultiOptimizer: Optimizer {
+
+    /// The sub-optimizers; the last one is the fallback for unmatched parameters.
+    public let optimizers: [Optimizer]
+
+    /// Predicates over `(key, gradient)`, one per optimizer. The provided filters select the first
+    /// `optimizers.count - 1`; the last is an implicit always-true fallback.
+    private let filters: [(String, MLXArray) -> Bool]
+
+    /// - Parameters:
+    ///   - optimizers: the optimizers to delegate to (at least one)
+    ///   - filters: predicates selecting which parameters route to each optimizer; there must be
+    ///     `optimizers.count - 1` of them (the last optimizer is the unconditioned fallback)
+    public init(optimizers: [Optimizer], filters: [(String, MLXArray) -> Bool] = []) {
+        precondition(!optimizers.isEmpty, "MultiOptimizer requires at least one optimizer")
+        precondition(
+            filters.count == optimizers.count - 1,
+            "MultiOptimizer given \(filters.count) filters but \(optimizers.count - 1) needed")
+        self.optimizers = optimizers
+        self.filters = filters + [{ _, _ in true }]
+    }
+
+    /// Partition the flattened gradients into one group per optimizer, by first matching filter.
+    private func split(_ gradients: ModuleParameters) -> [[(String, MLXArray)]] {
+        var parts = Array(repeating: [(String, MLXArray)](), count: optimizers.count)
+        for (key, gradient) in gradients.flattened() {
+            for (i, filter) in filters.enumerated() where filter(key, gradient) {
+                parts[i].append((key, gradient))
+                break
+            }
+        }
+        return parts
+    }
+
+    public func update(model: Module, gradients: ModuleParameters) {
+        for (optimizer, part) in zip(optimizers, split(gradients)) where !part.isEmpty {
+            optimizer.update(model: model, gradients: ModuleParameters.unflattened(part))
+        }
+    }
+
+    public func innerState() -> [MLXArray] {
+        optimizers.flatMap { $0.innerState() }
+    }
+}
+
 /// The base class for all optimizers. It allows us to implement an optimizer on a per-parameter basis
 /// and apply it to a parameter tree.
 ///

--- a/Tests/MLXTests/OptimizerTests.swift
+++ b/Tests/MLXTests/OptimizerTests.swift
@@ -213,4 +213,30 @@ class OptimizerTests: XCTestCase {
         checkTrain(optimizer: Adafactor(learningRate: 0.1), compile: true)
     }
 
+    class TwoParameterModel: Module {
+        let weight = MLXArray.zeros([3])
+        let bias = MLXArray.zeros([3])
+    }
+
+    func testMultiOptimizer() {
+        let model = TwoParameterModel()
+        let grads = model.parameters().mapValues { MLXArray.ones(like: $0) }
+
+        // Route `bias` to a high learning-rate SGD; every other parameter falls back to the
+        // low learning-rate SGD. Distinct results prove each parameter was routed correctly.
+        let optimizer = MultiOptimizer(
+            optimizers: [SGD(learningRate: 1.0), SGD(learningRate: 0.1)],
+            filters: [{ key, _ in key == "bias" }])
+
+        optimizer.update(model: model, gradients: grads)
+        eval(model)
+
+        // plain SGD from zeros with unit gradients: new = -learningRate
+        assertEqual(model.bias, MLXArray([Float(-1.0), -1.0, -1.0]), atol: 1e-6)
+        assertEqual(model.weight, MLXArray([Float(-0.1), -0.1, -0.1]), atol: 1e-6)
+
+        // innerState surfaces the sub-optimizers' state.
+        XCTAssertEqual(optimizer.innerState().count, 2)
+    }
+
 }


### PR DESCRIPTION
## Proposed changes

Adds **`MultiOptimizer`** to `MLXOptimizers` — a Swift port of Python [`mlx.optimizers.MultiOptimizer`](https://github.com/ml-explore/mlx/blob/main/python/mlx/optimizers/optimizers.py). Closes #228.

A meta-optimizer that routes each model parameter to the first sub-optimizer whose filter predicate matches the parameter's flattened key path, with the last optimizer acting as the unconditioned fallback. This lets you use different optimizers (or different hyperparameters) for different subsets of a model's weights — e.g. a higher LR on newly-added layers, or no weight decay on norms/biases.

`update(model:gradients:)` partitions the flattened gradient tree by first-matching filter and delegates each subset to the corresponding child optimizer; `innerState()` surfaces the children's state. It conforms to the `Optimizer` protocol directly since it holds no per-parameter state of its own.

Mirrors the Python semantics (first-match wins, last filter is the catch-all).

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my feature works (`OptimizerTests.testMultiOptimizer`)
- [x] I have updated the necessary documentation (if needed)
