### PR TITLE
Add Muon optimizer (port from Python mlx.optimizers)

### DIFF
--- a/Source/MLXOptimizers/Optimizers.swift
+++ b/Source/MLXOptimizers/Optimizers.swift
@@ -767,6 +767,101 @@ open class Adafactor: OptimizerBase<Adafactor.State> {
     }
 }
 
+/// The Muon (MomentUm Orthogonalized by Newton-schulz) optimizer.
+///
+/// Follows the original implementation: [Muon: An optimizer for hidden layers in
+/// neural networks](https://kellerjordan.github.io/posts/muon/).
+///
+/// - Note: Muon may be sub-optimal for the embedding layer, the final fully
+///   connected layer, or any 0D/1D parameters; optimize those with a different
+///   method (e.g. ``AdamW``). For parameters with more than 2 dimensions (e.g. 4D
+///   convolution filters) the trailing dimensions are flattened.
+///
+/// ### See Also
+/// - <doc:MLXOptimizers>
+open class Muon: OptimizerBaseArrayState {
+
+    /// The learning rate
+    public var learningRate: Float
+    /// The momentum strength
+    public var momentum: Float = 0.95
+    /// The weight decay (L2 penalty)
+    public var weightDecay: Float = 0.01
+    /// Enables Nesterov momentum (recommended)
+    public var nesterov = true
+    /// Number of Newton-Schulz iteration steps for orthogonalization
+    public var nsSteps: Int = 5
+
+    /// Initialize the optimizer.
+    /// - Parameters:
+    ///   - learningRate: the learning rate
+    ///   - momentum: the momentum strength
+    ///   - weightDecay: the weight decay (L2 penalty)
+    ///   - nesterov: enables Nesterov momentum
+    ///   - nsSteps: number of Newton-Schulz iteration steps
+    public init(
+        learningRate: Float, momentum: Float = 0.95, weightDecay: Float = 0.01,
+        nesterov: Bool = true, nsSteps: Int = 5
+    ) {
+        self.learningRate = learningRate
+        self.momentum = momentum
+        self.weightDecay = weightDecay
+        self.nesterov = nesterov
+        self.nsSteps = nsSteps
+    }
+
+    /// Orthogonalize a 2D matrix via a quintic Newton-Schulz iteration.
+    private func zeropowerViaNewtonSchulz5(_ input: MLXArray, steps: Int) -> MLXArray {
+        precondition(input.ndim == 2, "Newton-Schulz iteration expects a 2D array")
+        let (a, b, c): (Float, Float, Float) = (3.4445, -4.7750, 2.0315)
+        let transposeNeeded = input.dim(-2) > input.dim(-1)
+
+        var X = transposeNeeded ? input.transposed(1, 0) : input
+        // Frobenius-normalize so the iteration converges.
+        X = X / (sqrt((X * X).sum(keepDims: true)) + 1e-7)
+
+        for _ in 0 ..< steps {
+            let A = matmul(X, X.transposed(1, 0))
+            let B = b * A + c * matmul(A, A)
+            X = a * X + matmul(B, X)
+        }
+
+        return transposeNeeded ? X.transposed(1, 0) : X
+    }
+
+    override open func applySingle(gradient: MLXArray, parameter: MLXArray, state: MLXArray) -> (
+        MLXArray, MLXArray
+    ) {
+        var gradient = gradient
+        if weightDecay != 0 {
+            gradient = gradient + weightDecay * parameter
+        }
+
+        let v = momentum * state + (1 - momentum) * gradient
+
+        var update = nesterov ? (gradient * (1 - momentum) + v * momentum) : v
+        var lr = learningRate
+
+        if update.ndim >= 2 {
+            let originalShape = update.shape
+            let reshapeNeeded = update.ndim > 2
+            if reshapeNeeded {
+                update = update.reshaped([update.dim(0), -1])
+            }
+            update = zeropowerViaNewtonSchulz5(update, steps: nsSteps)
+            if reshapeNeeded {
+                update = update.reshaped(originalShape)
+            }
+            // Scale the learning rate by sqrt(max(1, rows / cols)).
+            let rows = Float(update.dim(-2))
+            let cols = Float(update.dim(-1))
+            lr *= pow(max(1, rows / cols), 0.5)
+        }
+
+        return (parameter - lr * update, v)
+    }
+}
+
 /// Clips the global norm of the gradients.
 ///
 /// This function ensures that the global norm of the gradients does not exceed

--- a/Tests/MLXTests/OptimizerTests.swift
+++ b/Tests/MLXTests/OptimizerTests.swift
@@ -239,4 +239,33 @@ class OptimizerTests: XCTestCase {
         XCTAssertEqual(optimizer.innerState().count, 2)
     }
 
+    func testMuon() {
+        checkShape(optimizer: Muon(learningRate: 0.1))
+
+        // 1D (and 0D) parameters skip the Newton-Schulz orthogonalization and
+        // use a plain momentum/Nesterov update — pin that math exactly.
+        // v = 0.95*0 + 0.05*g = 0.05*g; nesterov update = g*(1-m) + v*m;
+        // param' = param - lr*update.
+        let opt = Muon(learningRate: 0.1, momentum: 0.95, weightDecay: 0)
+        let (p, v) = opt.applySingle(
+            gradient: MLXArray([1.0, 1.0] as [Float]),
+            parameter: MLXArray([1.0, 2.0] as [Float]),
+            state: MLXArray([0.0, 0.0] as [Float]))
+        eval(p, v)
+        // update = 1*0.05 + 0.05*0.95 = 0.0975 ; param0' = 1 - 0.1*0.0975
+        XCTAssertEqual(p[0].item(Float.self), 0.99025, accuracy: 1e-5)
+        XCTAssertEqual(p[1].item(Float.self), 1.99025, accuracy: 1e-5)
+        XCTAssertEqual(v[0].item(Float.self), 0.05, accuracy: 1e-6)
+
+        // 2D parameters take the orthogonalization path: it must run, preserve
+        // shape, and produce finite values that move the parameter.
+        let g2 = MLXArray(converting: [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])
+        let (p2, _) = opt.applySingle(
+            gradient: g2, parameter: MLXArray.zeros([2, 3]), state: MLXArray.zeros([2, 3]))
+        eval(p2)
+        XCTAssertEqual(p2.shape, [2, 3])
+        XCTAssertTrue(p2.sum().item(Float.self).isFinite)
+        XCTAssertGreaterThan(abs(p2).sum().item(Float.self), 0)
+    }
+
 }


### PR DESCRIPTION
## Proposed changes

Adds the **`Muon`** optimizer (MomentUm Orthogonalized by Newton-Schulz) to `MLXOptimizers` — a Swift port of Python [`mlx.optimizers.Muon`](https://github.com/ml-explore/mlx/blob/main/python/mlx/optimizers/optimizers.py).

Muon applies a momentum (optionally Nesterov) update, then for parameters with ≥2 dimensions orthogonalizes the update via a 5-step quintic Newton-Schulz iteration and scales the learning rate by `sqrt(max(1, rows/cols))`. 0D/1D parameters fall back to the plain momentum update (the reference recommends optimizing embeddings / final projections / biases with a different method such as `AdamW`). Parameters with >2 dims have their trailing dims flattened for the orthogonalization.

Mirrors the reference defaults (`momentum=0.95`, `weightDecay=0.01`, `nesterov=true`, `nsSteps=5`).

Tests (`OptimizerTests.testMuon`): pins the 1D momentum/Nesterov update math exactly, and exercises the 2D orthogonalization path (shape preserved, finite, parameter moved). Verified via `xcodebuild test -scheme mlx-swift-Package -only-testing:MLXTests/OptimizerTests/testMuon` → **TEST SUCCEEDED**.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my feature works
- [x] I have updated the necessary documentation (if needed)
