### PR TITLE
Add fp8 conversion utilities

### DIFF
--- a/Source/MLX/Ops.swift
+++ b/Source/MLX/Ops.swift
@@ -1374,6 +1374,28 @@ public func expm1(_ array: MLXArray, stream: StreamOrDevice = .default) -> MLXAr
     return MLXArray(result)
 }
 
+/// Convert an E4M3 FP8 array to the given floating-point ``DType``.
+///
+/// The input array is interpreted as raw FP8 bytes.
+///
+/// - Parameters:
+///   - array: input array containing E4M3 FP8 values
+///   - dtype: data type of the output array
+///   - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - ``toFP8(_:stream:)``
+/// - <doc:conversion>
+public func fromFP8(
+    _ array: MLXArray,
+    dtype: DType = .bfloat16,
+    stream: StreamOrDevice = .default
+) -> MLXArray {
+    var result = mlx_array_new()
+    mlx_from_fp8(&result, array.ctx, dtype.cmlxDtype, stream.ctx)
+    return MLXArray(result)
+}
+
 @available(*, deprecated, renamed: "gatherMM(_:_:lhsIndices:rhsIndices:sortedIndices:stream:)")
 public func gatherMatmul(
     _ a: MLXArray, _ b: MLXArray, lhsIndices: MLXArray? = nil, rhsIndices: MLXArray? = nil,
@@ -3073,6 +3095,21 @@ public func tiled(_ array: MLXArray, repetitions: Int, stream: StreamOrDevice = 
 {
     var result = mlx_array_new()
     mlx_tile(&result, array.ctx, [repetitions.int32], 1, stream.ctx)
+    return MLXArray(result)
+}
+
+/// Convert a floating-point array to E4M3 FP8 bytes.
+///
+/// - Parameters:
+///   - array: input array
+///   - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - ``fromFP8(_:dtype:stream:)``
+/// - <doc:conversion>
+public func toFP8(_ array: MLXArray, stream: StreamOrDevice = .default) -> MLXArray {
+    var result = mlx_array_new()
+    mlx_to_fp8(&result, array.ctx, stream.ctx)
     return MLXArray(result)
 }
 

--- a/Tests/MLXTests/FP8Tests.swift
+++ b/Tests/MLXTests/FP8Tests.swift
@@ -18,13 +18,13 @@ class FP8Tests: XCTestCase {
         XCTAssertEqual(decoded.dtype, .float32)
         XCTAssertEqual(decoded.shape, [256])
 
-        let expected = MLXArray(converting: allBytes.map { e4m3Value($0) })
+        let expected = MLXArray(allBytes.map { e4m3Value($0) })
         assertEqual(decoded, expected)
     }
 
     func testToFP8EncodesE4M3Bytes() {
         let values = MLXArray(
-            converting: [
+            [
                 0.0, -0.0, 1.0, -2.0, 0.125, 0.015625, 448.0, -448.0,
             ] as [Float])
 

--- a/Tests/MLXTests/FP8Tests.swift
+++ b/Tests/MLXTests/FP8Tests.swift
@@ -1,0 +1,54 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import XCTest
+
+class FP8Tests: XCTestCase {
+
+    override class func setUp() {
+        setDefaultDevice()
+    }
+
+    func testFromFP8DecodesE4M3Bytes() {
+        let allBytes = (0 ... 255).map { UInt8($0) }
+        let bytes = MLXArray(allBytes)
+        let decoded = fromFP8(bytes, dtype: .float32)
+
+        XCTAssertEqual(decoded.dtype, .float32)
+        XCTAssertEqual(decoded.shape, [256])
+
+        let expected = MLXArray(converting: allBytes.map { e4m3Value($0) })
+        assertEqual(decoded, expected)
+    }
+
+    func testToFP8EncodesE4M3Bytes() {
+        let values = MLXArray(
+            converting: [
+                0.0, -0.0, 1.0, -2.0, 0.125, 0.015625, 448.0, -448.0,
+            ] as [Float])
+
+        let encoded = toFP8(values)
+
+        XCTAssertEqual(encoded.dtype, .uint8)
+        XCTAssertEqual(encoded.shape, values.shape)
+        XCTAssertEqual(
+            encoded.asArray(UInt8.self),
+            [0x00, 0x80, 0x38, 0xC0, 0x20, 0x08, 0x7E, 0xFE])
+    }
+}
+
+private func e4m3Value(_ value: UInt8) -> Float {
+    let sign: Float = (value & 0x80) == 0 ? 1 : -1
+    let exponent = Int((value >> 3) & 0x0F)
+    let mantissa = Int(value & 0x07)
+
+    if exponent == 0 {
+        if mantissa == 0 {
+            return sign < 0 ? -0.0 : 0.0
+        }
+        return sign * Float(mantissa) / 512
+    }
+
+    return sign * Float(8 + mantissa) * powf(2, Float(exponent - 10))
+}


### PR DESCRIPTION
This adds to/from fp8 conversion ops, which are just wrappers around mlx_to_fp8 / mlx_from_fp8 in Cmlx and are generally useful for (de)quantizing fp8 weights that ship with some models.

## Checklist

Put an `x` in the boxes that apply.

- [X] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [X] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have updated the necessary documentation (if needed)
