### PR TITLE
Derive the jit-source lists in update-mlx.sh instead of hand-listing them

### DIFF
--- a/tools/update-mlx.sh
+++ b/tools/update-mlx.sh
@@ -10,6 +10,8 @@ then
     exit 1
 fi
 
+mlx_source="$PWD/Source/Cmlx/mlx"
+
 # copy mlx-c headers to build area
 rm -f Source/Cmlx/include/mlx/c/*
 cp Source/Cmlx/mlx-c/mlx/c/*.h Source/Cmlx/include/mlx/c
@@ -22,62 +24,44 @@ cmake ../Source/Cmlx/mlx -DMLX_METAL_JIT=ON -DMACOS_VERSION=14.0
 
 # run the cmake build to generate the source files
 cd mlx/backend/metal
-make \
-    arange \
-    binary \
-    binary_ops \
-    binary_two \
-    conv \
-    copy \
-    fft \
-    fp_quantized \
-    fp_quantized_nax \
-    gather \
-    gather_axis \
-    gather_front \
-    gemm \
-    gemm_nax \
-    gemv_masked \
-    hadamard \
-    logsumexp \
-    masked_scatter \
-    quantized \
-    quantized_nax \
-    quantized_utils \
-    reduce \
-    reduce_utils \
-    scan \
-    scatter \
-    scatter_axis \
-    softmax \
-    sort \
-    steel_attention \
-    steel_attention_nax \
-    steel_conv \
-    steel_conv_3d \
-    steel_conv_general \
-    steel_gemm_fused \
-    steel_gemm_fused_nax \
-    steel_gemm_gather \
-    steel_gemm_gather_nax \
-    steel_gemm_masked \
-    steel_gemm_segmented \
-    steel_gemm_splitk \
-    steel_gemm_splitk_nax \
-    ternary \
-    ternary_ops \
-    unary \
-    unary_ops \
-    utils
+
+# one target per make_jit_source() in mlx/backend/metal/CMakeLists.txt, which is
+# where the set of Metal jit sources is declared
+metal_jit_targets=(${(f)"$(tr '\n' ' ' < "$mlx_source/mlx/backend/metal/CMakeLists.txt" \
+    | grep -oE 'make_jit_source\( *[a-zA-Z_0-9/]+' \
+    | sed -E 's/make_jit_source\( *//' \
+    | sed 's|.*/||' \
+    | sort -u)"})
+
+if (( ! $#metal_jit_targets ))
+then
+    echo "Found no make_jit_source() targets in mlx/backend/metal/CMakeLists.txt"
+    exit 1
+fi
+
+make $metal_jit_targets
 
 cd ../../..
 make cpu_compiled_preamble
 
 # run the command to do the build-time code generation for CUDA
+
+cuda_source="$mlx_source/mlx/backend/cuda"
+
+# the same set that the file(GLOB) in mlx/backend/cuda/CMakeLists.txt embeds
+cuda_jit_sources=(${cuda_source}/device/*.(h|cuh)(N))
+cuda_jit_sources=(${cuda_jit_sources#$cuda_source/})
+
+if (( ! $#cuda_jit_sources ))
+then
+    echo "Found no jit sources in mlx/backend/cuda/device"
+    exit 1
+fi
+
 cmake \
-  -DMLX_SOURCE_ROOT="../Source/Cmlx/mlx/mlx/backend/cuda" \
-  -DMLX_JIT_SOURCES="device/atomic_ops.cuh:device/binary_ops.cuh:device/cast_op.cuh:device/complex.cuh:device/config.h:device/fp16_math.cuh:device/gather.cuh:device/gather_axis.cuh:device/hadamard.cuh:device/indexing.cuh:device/scatter.cuh:device/scatter_axis.cuh:device/scatter_ops.cuh:device/ternary_ops.cuh:device/unary_ops.cuh:device/utils.cuh" \
-  -P "../Source/Cmlx/mlx/mlx/backend/cuda/bin2h.cmake"
+  -DMLX_SOURCE_ROOT="$cuda_source" \
+  -DMLX_JIT_SOURCES="${(j.:.)cuda_jit_sources}" \
+  -P "$cuda_source/bin2h.cmake"
 
 cd ..
 


### PR DESCRIPTION
## Proposed changes

`tools/update-mlx.sh` hand-tracks two lists that `mlx`'s own CMake derives, so each one silently goes stale when the vendored `mlx` submodule gains a jit source. Both failures land during a version bump, and neither points at the script.

**CUDA.** The `MLX_JIT_SOURCES` argument named 16 `device/` headers explicitly, where `mlx/backend/cuda/CMakeLists.txt` uses `file(GLOB)` over `device/*.h` and `device/*.cuh`. A bump that adds one regenerates a `cuda_jit_sources.h` that omits its array, and the build fails later with `use of undeclared identifier 'jit_source_*'`.

**Metal.** The step named 46 `make` targets explicitly, where `mlx/backend/metal/CMakeLists.txt` declares them via `make_jit_source()`. A bump that adds one leaves `jit/includes.h` declaring a `mlx::core::metal::<name>()` that no generated source defines — an undefined symbol at link time on macOS/iOS, not only on the Linux/CUDA path.

Measured against the tags past the current pin:

| vendored mlx | CUDA: needed / frozen list gave | Metal: `includes.h` declares / list built | missing |
|---|---|---|---|
| v0.31.1 (current pin) | 16 / 16 | 46 / 46 | — |
| v0.31.2 | 17 / 16 | 47 / 46 | `jit_source_slice_update`, `steel_gemm_segmented_nax` |
| v0.32.0 | 22 / 16 | 48 / 46 | + `cute_dequant`, `gemm_sm70`, `qmm_naive`, `qmm_sm80`, `qmm_sm90`, `gemv` |

Both lists are now derived from the vendored tree at run time, matching how CMake declares them.

**This is a no-op at the current pin.** Against v0.31.1 the derived values are identical to the removed literals — the CUDA list character-for-character, the Metal set element-for-element — and re-running the CUDA step reproduces the committed `Source/Cmlx/mlx-generated/cuda/cuda_jit_sources.h` byte-for-byte. Verified the derived Metal targets all resolve via `make -n` against a configured `MLX_METAL_JIT=ON` tree.

Each derivation is guarded rather than trusted: under `set -e` an empty result would not fail by itself, and a bare `make` with no targets would quietly build `all` instead of the codegen targets. Silent success is the failure mode being removed here, so it should not be reachable by a different route.

One note on the Metal half for reviewers: deriving those targets means reading `make_jit_source(` calls out of `mlx/backend/metal/CMakeLists.txt` from the shell, which does couple this script to that call formatting. I went with it because the alternative is the hand-listing that caused the bug, because `cmake-format` keeps that file's formatting stable, and because a parse failure surfaces immediately as a nonexistent `make` target rather than as a missing source. Happy to switch to a narrower approach if you would rather not have a CMake parse here.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)

On tests: this changes a maintainer script that runs against whichever `mlx` is vendored, and there is no in-tree harness for `tools/`. The equivalence and drift results above were produced by running the real `bin2h.cmake` and `make -n` against `mlx` trees at v0.31.1/v0.31.2/v0.32.0; I am glad to add whatever form of coverage you would prefer for `tools/` if you want this pinned down in-repo. On docs: `MAINTENANCE.md` step 3 still describes the procedure accurately, so no change was needed.

Verified on macOS (Xcode 26.6, Swift 6.3.3): `pre-commit run --all-files` clean, `./scripts/verify-docs.sh` all builds passed, `xcodebuild build-for-testing -scheme mlx-swift-Package -destination 'platform=macOS'` succeeded with no error lines, `CmlxTests` passed and `MLXTests` 532 passed / 0 failures.

## Related

- #446 — the same hand-tracking pattern in `Package.swift`'s `exclude:` list, which breaks on the same bump. Filed separately since the right fix there depends on the bump itself.
