### PR TITLE
Condition CUDA build plugin on Linux hosts

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -83,6 +83,9 @@ jobs:
         shell: bash
         run: xcodebuild -showComponent MetalToolchain
 
+      - name: Verify SwiftPM manifest CUDA containment
+        run: scripts/verify-spm-manifest.py
+
       - name: Setup cmake
         shell: sh
         run: |

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,35 @@
 
 import PackageDescription
 
+#if os(Linux)
+    let cudaBuildPlugins: [Target.PluginUsage] = [
+        .plugin(name: "CudaBuild")
+    ]
+    let cudaPackageDependencies: [Package.Dependency] = [
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0")
+    ]
+    let cudaTargets: [Target] = [
+        .executableTarget(
+            name: "encuda",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
+            ],
+            path: "Source/Encuda",
+        ),
+        .plugin(
+            name: "CudaBuild",
+            capability: .buildTool(),
+            dependencies: [
+                .target(name: "encuda")
+            ],
+        ),
+    ]
+#else
+    let cudaBuildPlugins: [Target.PluginUsage] = []
+    let cudaPackageDependencies: [Package.Dependency] = []
+    let cudaTargets: [Target] = []
+#endif
+
 let noMetalCmlxExcludes = [
     // Exclude Metal backend files, but keep no_metal.cpp for stubs
     // "mlx/mlx/backend/metal/no_metal.cpp",
@@ -289,9 +318,7 @@ let cmlx = Target.target(
         .define("MLX_VERSION", to: "\"0.31.1\""),
     ],
     linkerSettings: linkerSettings,
-    plugins: [
-        .plugin(name: "CudaBuild")
-    ],
+    plugins: cudaBuildPlugins,
 )
 
 let package = Package(
@@ -316,9 +343,8 @@ let package = Package(
     ],
     dependencies: [
         // for Complex type
-        .package(url: "https://github.com/apple/swift-numerics", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
-    ],
+        .package(url: "https://github.com/apple/swift-numerics", from: "1.0.0")
+    ] + cudaPackageDependencies,
     targets: [
         cmlx,
         .testTarget(
@@ -414,21 +440,7 @@ let package = Package(
             path: "Source/Examples",
             sources: ["CustomFunctionExampleSimple.swift"]
         ),
-        .executableTarget(
-            name: "encuda",
-            dependencies: [
-                .product(name: "ArgumentParser", package: "swift-argument-parser")
-            ],
-            path: "Source/Encuda",
-        ),
-        .plugin(
-            name: "CudaBuild",
-            capability: .buildTool(),
-            dependencies: [
-                .target(name: "encuda")
-            ],
-        ),
-    ],
+    ] + cudaTargets,
     cxxLanguageStandard: .gnucxx20
 )
 

--- a/scripts/verify-spm-manifest.py
+++ b/scripts/verify-spm-manifest.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+import json
+import platform
+import subprocess
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(message)
+
+
+manifest = json.loads(
+    subprocess.run(
+        ["swift", "package", "dump-package"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+)
+
+targets = {target["name"]: target for target in manifest["targets"]}
+dependencies = {
+    dependency["sourceControl"][0]["identity"]
+    for dependency in manifest["dependencies"]
+    if "sourceControl" in dependency
+}
+
+cuda_targets = {"CudaBuild", "encuda"}
+cuda_plugin_usages = targets["Cmlx"].get("pluginUsages") or []
+
+if platform.system() == "Linux":
+    require(
+        cuda_targets <= targets.keys(), "Linux manifest is missing CUDA build targets"
+    )
+    require(
+        "swift-argument-parser" in dependencies,
+        "Linux manifest is missing the CUDA helper dependency",
+    )
+    require(
+        cuda_plugin_usages,
+        "Linux Cmlx target is missing the CUDA build plugin",
+    )
+else:
+    require(
+        cuda_targets.isdisjoint(targets),
+        "non-Linux manifest unexpectedly contains CUDA build targets",
+    )
+    require(
+        "swift-argument-parser" not in dependencies,
+        "non-Linux manifest unexpectedly contains the CUDA helper dependency",
+    )
+    require(
+        not cuda_plugin_usages,
+        "non-Linux Cmlx target unexpectedly uses the CUDA build plugin",
+    )
+
+print(f"SwiftPM manifest CUDA containment passed for {platform.system()}.")


### PR DESCRIPTION
## Proposed changes

SwiftPM currently attaches `CudaBuild` to `Cmlx` on every build host, even
though the plugin itself returns no commands outside Linux. When MLX Swift is a
remote Xcode dependency, package-plugin validation happens before that runtime
guard, so macOS consumers must enable a CUDA build plugin that cannot do work on
their platform.

This change:

- retains the existing plugin, `encuda` helper, and ArgumentParser dependency on
  Linux;
- omits the complete CUDA build-tool graph from non-Linux manifests; and
- adds a macOS CI assertion over the normalized SwiftPM manifest.

The CUDA source-selection and linker behavior on Linux are unchanged. This is a
focused follow-up to #413.

## Validation

- `scripts/verify-spm-manifest.py`
- `xcodebuild build-for-testing -scheme mlx-swift-Package -destination 'platform=macOS,arch=arm64'`
- `CmlxTests.xctest`: 1 test passed
- `MLXTests.xctest`: 532 tests passed
- clean remote Xcode consumer build with normal package-plugin validation; only
  MLX Swift and Swift Numerics were resolved, with no `CudaBuild` or `encuda`
  build artifact
- `pre-commit run --all-files`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (no public API or user-facing documentation change is required)
