### PR TITLE
Fix FinalizerCaptureState leak in MLXArray(rawPointer:_:dtype:finalizer:)

### DIFF
--- a/Source/MLX/MLXArray+Init.swift
+++ b/Source/MLX/MLXArray+Init.swift
@@ -31,7 +31,16 @@ private class FinalizerCaptureState {
 func finalizerTrampoline(
     payload: UnsafeMutableRawPointer?
 ) {
-    let state = Unmanaged<FinalizerCaptureState>.fromOpaque(payload!).takeUnretainedValue()
+    // `takeRetainedValue` consumes the +1 from the `passRetained` in
+    // `init(rawPointer:_:dtype:finalizer:)`. mlx-c documents this dtor as
+    // "Callback for when the buffer is no longer needed" and invokes it exactly
+    // once, so consuming the reference here balances the retain exactly.
+    //
+    // Using `takeUnretainedValue` would read the box without consuming it,
+    // leaking the `FinalizerCaptureState` and permanently pinning everything the
+    // finalizer closure captured — the `IOSurface` in the initializer's own
+    // documented example, for instance.
+    let state = Unmanaged<FinalizerCaptureState>.fromOpaque(payload!).takeRetainedValue()
     state.f()
 }
 
@@ -80,10 +89,8 @@ extension MLXArray {
         _ shape: (some Collection<Int>)? = [Int]?.none, dtype: DType,
         finalizer: @escaping () -> Void
     ) {
-        func free(ptr: UnsafeMutableRawPointer?) {
-            Unmanaged<FinalizerCaptureState>.fromOpaque(ptr!).release()
-        }
-
+        // Balanced by the `takeRetainedValue` in `finalizerTrampoline`, which
+        // mlx-c invokes once when the buffer is no longer needed.
         let payload = Unmanaged.passRetained(FinalizerCaptureState(finalizer)).toOpaque()
 
         self.init(

--- a/Tests/MLXTests/MLXArray+InitTests.swift
+++ b/Tests/MLXTests/MLXArray+InitTests.swift
@@ -267,6 +267,73 @@ class MLXArrayInitTests: XCTestCase {
         XCTAssertEqual(e.dtype, .float64)
     }
 
+    /// The finalizer's captures must be released once mlx has called it.
+    ///
+    /// `init(rawPointer:_:dtype:finalizer:)` retains a box holding the closure and
+    /// hands it to mlx as an opaque payload; `finalizerTrampoline` is the only
+    /// thing that can release it. If the trampoline reads the box without
+    /// consuming the reference, the closure — and everything it captured — is
+    /// pinned for the lifetime of the process, once per adopted buffer.
+    ///
+    /// `testIOSurface` below documents the intended behaviour in a comment
+    /// ("implicitly releases it when it returns") but never asserts it, which is
+    /// what let this go unnoticed.
+    func testFinalizerCapturesAreReleasedAfterFinalizerRuns() {
+        // mlx may invoke the dtor from its own thread, so the counters cannot be
+        // plain locals read across that boundary.
+        final class Counter: @unchecked Sendable {
+            private let lock = NSLock()
+            private var value = 0
+            func increment() {
+                lock.lock()
+                value += 1
+                lock.unlock()
+            }
+            var current: Int {
+                lock.lock()
+                defer { lock.unlock() }
+                return value
+            }
+        }
+        final class Witness {
+            let onDeinit: () -> Void
+            init(_ onDeinit: @escaping () -> Void) { self.onDeinit = onDeinit }
+            deinit { onDeinit() }
+        }
+
+        let finalizerRuns = Counter()
+        let witnessReleases = Counter()
+
+        do {
+            let buffer = UnsafeMutableRawPointer.allocate(
+                byteCount: 4 * MemoryLayout<Float>.stride, alignment: 16)
+            buffer.initializeMemory(as: Float.self, repeating: 1, count: 4)
+
+            let witness = Witness { witnessReleases.increment() }
+            let array = MLXArray(rawPointer: buffer, [4], dtype: .float32) {
+                [witness] in
+                // Holds the witness exactly the way the IOSurface example holds
+                // its surface.
+                _ = witness
+                finalizerRuns.increment()
+                buffer.deallocate()
+            }
+            XCTAssertEqual(array.sum().item(Float.self), 4)
+        }
+
+        // mlx keeps freed buffers in its allocator cache, so the dtor has not
+        // necessarily run at scope exit.
+        Memory.clearCache()
+        let deadline = Date().addingTimeInterval(5)
+        while finalizerRuns.current == 0, Date() < deadline { usleep(1_000) }
+
+        XCTAssertEqual(finalizerRuns.current, 1, "mlx must call the finalizer exactly once")
+        XCTAssertEqual(
+            witnessReleases.current, 1,
+            "the finalizer's captures must be released along with it — otherwise every adopted "
+                + "buffer permanently pins whatever the closure held")
+    }
+
     #if canImport(IOSurface)
         func testIOSurface() {
             let height = 100


### PR DESCRIPTION
## The bug

`MLXArray.init(rawPointer:_:dtype:finalizer:)` retains a box holding the finalizer closure and hands it to mlx as an opaque payload, but the trampoline that mlx calls back never consumes that reference — so the box, and everything the closure captured, is leaked once per adopted buffer.

`Source/MLX/MLXArray+Init.swift`:

```swift
func finalizerTrampoline(payload: UnsafeMutableRawPointer?) {
    let state = Unmanaged<FinalizerCaptureState>.fromOpaque(payload!).takeUnretainedValue()
    state.f()                                            // ← reads, never consumes
}

// …in the initializer:
    func free(ptr: UnsafeMutableRawPointer?) {            // ← dead code, never referenced
        Unmanaged<FinalizerCaptureState>.fromOpaque(ptr!).release()
    }

    let payload = Unmanaged.passRetained(FinalizerCaptureState(finalizer)).toOpaque()   // ← +1
```

The `+1` from `passRetained` has no matching release. The local `free(ptr:)` that would have balanced it is never passed anywhere — only `finalizerTrampoline` is — so it is dead code. `takeUnretainedValue()` reads the box without taking ownership, so the box is never deallocated.

The consequence is not just a small box: the box owns the closure, and the closure owns its captures. The initializer's own documented example captures an `IOSurface`:

```swift
let array = MLXArray(rawPointer: ioSurface.baseAddress, [height, width, 4], dtype: .uint8) {
    [ioSurface] in
    // this holds reference to the ioSurface and implicitly releases it when it returns
    _ = ioSurface
}
```

That comment describes the intent exactly — and it does not currently happen. The `IOSurface` is pinned for the lifetime of the process. `testIOSurface` exercises this path but only `print`s, so nothing caught it.

## The fix

`takeRetainedValue()` instead of `takeUnretainedValue()`, which consumes the `+1` exactly once. mlx-c documents the callback as *"Callback for when the buffer is no longer needed"* (`mlx/c/array.h`) and invokes it once per buffer, so a single consume is correct. `finalizerTrampoline` has exactly one caller — this initializer — so there is no other payload whose ownership could differ.

The now-provably-dead `free(ptr:)` is removed.

## Evidence

A differential test, `testFinalizerCapturesAreReleasedAfterFinalizerRuns`, holds a witness object in the finalizer closure the same way the documented example holds its `IOSurface`, and asserts the witness is released once mlx has called the finalizer:

| | `finalizerRuns` | `witnessReleases` |
|---|---|---|
| before this change | 1 | **0** — finalizer runs, captures never released |
| after | 1 | 1 |

Exactly one assertion flips, which is what makes it a regression test for this specific bug rather than for buffer lifetime in general.

Two details the test needs to be sound, both learned the hard way:

- **mlx keeps freed buffers in its allocator cache**, so the dtor has not necessarily run when the array goes out of scope. The test calls `Memory.clearCache()` and then polls with a deadline.
- **mlx may invoke the dtor from its own thread.** With plain captured `var` counters the reads race and give incoherent results — one counter appeared updated while the other did not. The test uses lock-guarded counters.

No regressions: the full `swift test` run gives **534 tests, 0 failures**, and `--filter MLXArrayInitTests` gives 28/28 including `testIOSurface`. Verified on an M4 / macOS with a colocated `mlx.metallib` built from the vendored mlx submodule (`ce45c52`), since `swift test` cannot otherwise load it.

## One note, not part of this PR

While tracing the ownership contract I noticed `mlx/c/array.h` documents `mlx_array_new_data_managed_payload` (and its `_managed` sibling) with `@param data A buffer which will be copied.` These are the adopt-ownership constructors — the buffer is explicitly *not* copied, which is the whole point of the `dtor` parameter. That is in the vendored `mlx-c` submodule rather than this repo, so I have left it alone; happy to send it to `ml-explore/mlx-c` separately if that is useful.
