### PR TITLE
Nested initializers 

### DIFF
--- a/Source/MLX/Documentation.docc/MLX.md
+++ b/Source/MLX/Documentation.docc/MLX.md
@@ -109,6 +109,7 @@ See <doc:wired-memory> for configuration, best practices, and policy guidance.
 - ``DType``
 - ``HasDType``
 - ``ScalarOrArray``
+- ``NestedArrayElement``
 
 ### Parameter Types
 

--- a/Source/MLX/Documentation.docc/Organization/initialization.md
+++ b/Source/MLX/Documentation.docc/Organization/initialization.md
@@ -87,7 +87,7 @@ let a2 = MLXArray(int64: 500)
 XCTAssertEqual(a2.dtype, .int64)
 ```
 
-All of the `Int` initializers (e.g. `[Int]` and `Sequence<Int>`) work
+All of the `Int` initializers (e.g. `[Int]`, `Sequence<Int>` and nested arrays) work
 the same way and all have the `int64:` variant.
 
 ### Double
@@ -119,6 +119,20 @@ let v1 = MLXArray(0 ..< 12)
 // this works with various types of sequences
 let v2 = MLXArray(stride(from: Float(0.5), to: Float(1.5), by: Float(0.1)))
 ```
+
+Multiple dimensions can be given directly as a nested array, in which case, the
+shape is inferred from the nesting.
+
+```swift
+// create an array of Int32 with shape [2, 3]
+let v1 = MLXArray([[1, 2, 3],
+                   [4, 5, 6]])
+
+// any depth of nesting works -- shape [2, 2, 2]
+let v2 = MLXArray([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+```
+
+Nested arrays must be tensors: every element at a given level must have the same shape.
 
 If you have `Data` or a `UnsafePointer` (of various kinds) you can also create an `MLXArray`
 from that:
@@ -159,7 +173,7 @@ let identity = MLXArray.identity(5)
 
 ### Complex Values
 
-``MLXArray`` supports complex numbers, specifically a real and imaginary `Float32` 
+``MLXArray`` supports complex numbers, specifically a real and imaginary `Float32`
 as ``DType/complex64``.
 MLX uses [swift-numerics](https://github.com/apple/swift-numerics/tree/main)
 to represent the `Complex` type, though there are a few functions for manipulating
@@ -212,9 +226,11 @@ there are specific initializers to request it:
 
 - ``MLXArray/init(_:)-(Int)``
 - ``MLXArray/init(_:_:)-([Int],_)``
-- ``MLXArray/init(int64:)``
+- ``MLXArray/init(_:)-([[N]])``
+- ``MLXArray/init(int64:)-(Int)``
 - ``MLXArray/init(int64:_:)-([Int],_)``
 - ``MLXArray/init(int64:_:)-(Sequence<Int>,_)``
+- ``MLXArray/init(int64:)-([[N]])``
 
 ### MLXArray Array Initializers
 
@@ -224,6 +240,12 @@ there are specific initializers to request it:
 - ``MLXArray/init(converting:_:)``
 - ``MLXArray/init(_:_:type:)-(UnsafeRawBufferPointer,_,_)``
 - ``MLXArray/init(_:_:type:)-(Data,_,_)``
+
+### MLXArray Nested Array Initializers
+
+- ``MLXArray/init(_:)-([[N]])``
+- ``MLXArray/init(int64:)-([[N]])``
+- ``MLXArray/init(converting:)``
 
 ### MLXArray Complex Initializers
 

--- a/Source/MLX/MLXArray+Init.swift
+++ b/Source/MLX/MLXArray+Init.swift
@@ -18,6 +18,17 @@ private func shapePrecondition(shape: (some Collection<Int>)?, byteCount: Int, t
     }
 }
 
+// flatten a nested array into its shape and its scalars in row major order
+private func flattenNested<N: NestedArrayElement>(_ value: [[N]]) -> (
+    shape: [Int], values: [N.Scalar]
+) {
+    let shape = value.nestedShape
+    var values = [N.Scalar]()
+    values.reserveCapacity(shape.reduce(1, *))
+    value.appendNestedScalars(to: &values)
+    return (shape, values)
+}
+
 // holds reference to `finalizer` as capture state
 private class FinalizerCaptureState {
     let f: () -> Void
@@ -121,11 +132,11 @@ extension MLXArray {
     /// ```
     ///
     /// Note: if the value is out of bounds for an `Int32` the precondition will fail.  If you
-    /// need an `Int` (`Int64`) scalar, please use ``init(int64:)``.
+    /// need an `Int` (`Int64`) scalar, please use ``init(int64:)-(Int)``.
     ///
     /// ### See Also
     /// - <doc:initialization>
-    /// - ``init(int64:)``
+    /// - ``init(int64:)-(Int)``
     public convenience init(_ value: Int) {
         precondition(
             (Int(Int32.min) ... Int(Int32.max)).contains(value),
@@ -449,6 +460,78 @@ extension MLXArray {
     )
     public convenience init(_ value: [Double], _ shape: (some Collection<Int>)? = [Int]?.none) {
         fatalError("unavailable")
+    }
+
+    /// Initializer allowing creation of a multi dimensional `MLXArray` from a nested array of
+    /// `HasDType` values.
+    ///
+    /// The shape is inferred directly from the provided array. Note that the nesting must
+    /// be rectangular (all arrays of a given level must have the same count).
+    /// Failing to meet this constraint will hit a precondition failure.
+    ///
+    /// ```swift
+    /// // shape [2, 3]
+    /// let twoByThree = MLXArray([[1, 2, 3],
+    ///                            [4, 5, 6]])
+    ///
+    /// // shape [2, 2, 2] -- any depth of nesting works
+    /// let cube = MLXArray([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+    /// ```
+    ///
+    /// Note: as with the one dimensional initializers, `Int` values produce a ``DType/int32``
+    /// result and the precondition will fail if a value is out of bounds.  See
+    /// ``init(int64:)-([[N]])`` if `.int64` is required.
+    ///
+    /// ### See Also
+    /// - <doc:initialization>
+    /// - ``init(int64:)-([[N]])``
+    public convenience init<N: NestedArrayElement>(_ value: [[N]]) {
+        let (shape, values) = flattenNested(value)
+        if N.Scalar.self == Int.self {
+            // Similarly to the Sequence<Int> initializer below,
+            // having an override for Int is ambiguous so we
+            // do a runtime check and force it to the [Int] variant
+            self.init(values as! [Int], shape)
+        } else {
+            self.init(values, shape)
+        }
+    }
+
+    /// Initializer allowing creation of a multi dimensional `MLXArray` from a nested array of
+    /// `Int` as a `DType.int64`.
+    ///
+    /// ```swift
+    /// let a = MLXArray(int64: [[1, 2, 3], [4, 5, 6]])
+    /// ```
+    ///
+    /// Note ``init(_:)-([[N]])`` (producing an `int32` result) is preferred.
+    ///
+    /// ### See Also
+    /// - <doc:initialization>
+    /// - ``init(_:)-([[N]])``
+    public convenience init<N: NestedArrayElement>(int64 value: [[N]]) where N.Scalar == Int {
+        let (shape, values) = flattenNested(value)
+        self.init(int64: values, shape)
+    }
+
+    /// Initializer allowing creation of a multi dimensional `MLXArray` from a nested array of
+    /// `Double` values.
+    ///
+    /// Note: this converts the values to `Float`, matching ``init(converting:_:)``.  Unlike the
+    /// one dimensional case, ``init(_:)-([[N]])`` also accepts `[[Double]]` and produces a
+    /// ``DType/float64`` result.
+    ///
+    /// ```swift
+    /// let a = MLXArray(converting: [[0.5, 0.9], [1.5, 1.9]])
+    /// ```
+    ///
+    /// ### See Also
+    /// - <doc:initialization>
+    /// - ``init(_:)-([[N]])``
+    public convenience init<N: NestedArrayElement>(converting value: [[N]])
+    where N.Scalar == Double {
+        let (shape, values) = flattenNested(value)
+        self.init(converting: values, shape)
     }
 
     /// Initializer allowing creation of `MLXArray` from a sequence of `HasDType` values with

--- a/Source/MLX/NestedArrayElement.swift
+++ b/Source/MLX/NestedArrayElement.swift
@@ -40,8 +40,6 @@ public protocol NestedArrayElement {
 }
 
 extension NestedArrayElement where Self: HasDType {
-    public typealias Scalar = Self
-
     public static var nestedRank: Int { 0 }
 
     public var nestedShape: [Int] { [] }

--- a/Source/MLX/NestedArrayElement.swift
+++ b/Source/MLX/NestedArrayElement.swift
@@ -1,0 +1,97 @@
+// Copyright © 2026 Apple Inc.
+
+import Numerics
+
+/// A value that can appear in a nested array used to create an ``MLXArray``.
+///
+/// Conformance is recursive: the built-in ``HasDType`` scalars conform and so does an `Array` of
+/// conforming values, adding one dimension.  A nested array therefore describes both the shape
+/// and the contents of an ``MLXArray``:
+///
+/// ```swift
+/// // shape [2, 3]
+/// let a = MLXArray([[1, 2, 3], [4, 5, 6]])
+/// ```
+///
+/// This exists to express the nested array initializers, e.g. ``MLXArray/init(_:)-([[N]])`` --
+/// there should be no need to conform your own types to it.
+///
+/// ### See Also
+/// - <doc:initialization>
+public protocol NestedArrayElement {
+
+    /// The scalar type at the leaves of the nesting, e.g. `Int` for `[[Int]]`.
+    associatedtype Scalar: HasDType
+
+    /// The number of dimensions this type contributes -- `0` for a scalar, `1` for `[Scalar]`.
+    static var nestedRank: Int { get }
+
+    /// The shape of the receiver.
+    ///
+    /// Note: the nesting must be rectangular -- every element at a given level must have the
+    /// same shape -- or the precondition will fail.
+    ///
+    /// Note: an empty level says nothing about the levels below it, so those are reported as
+    /// `0` -- `[[Int]]()` has shape `[0, 0]`.
+    var nestedShape: [Int] { get }
+
+    /// Append the receiver's scalars to `values` in row major order.
+    func appendNestedScalars(to values: inout [Scalar])
+}
+
+extension NestedArrayElement where Self: HasDType {
+    public typealias Scalar = Self
+
+    public static var nestedRank: Int { 0 }
+
+    public var nestedShape: [Int] { [] }
+
+    public func appendNestedScalars(to values: inout [Self]) {
+        values.append(self)
+    }
+}
+
+// the scalars, providing the base case of the recursion.  HasDType deliberately does not refine
+// this protocol: conditional conformances to HasDType (Complex<Float> is one) would not imply it,
+// so that would break any such conformance outside this package.  Keep this list in sync with
+// the HasDType conformances in DType.swift.
+extension Bool: NestedArrayElement {}
+extension Int: NestedArrayElement {}
+extension Int8: NestedArrayElement {}
+extension Int16: NestedArrayElement {}
+extension Int32: NestedArrayElement {}
+extension Int64: NestedArrayElement {}
+extension UInt8: NestedArrayElement {}
+extension UInt16: NestedArrayElement {}
+extension UInt32: NestedArrayElement {}
+extension UInt64: NestedArrayElement {}
+extension UInt: NestedArrayElement {}
+#if !arch(x86_64)
+    extension Float16: NestedArrayElement {}
+#endif
+extension Float32: NestedArrayElement {}
+extension Float64: NestedArrayElement {}
+extension Complex<Float>: NestedArrayElement {}
+
+extension Array: NestedArrayElement where Element: NestedArrayElement {
+    public typealias Scalar = Element.Scalar
+
+    public static var nestedRank: Int { 1 + Element.nestedRank }
+
+    public var nestedShape: [Int] {
+        // an empty level tells us nothing about the levels below it, but the static rank does
+        let inner = first?.nestedShape ?? [Int](repeating: 0, count: Element.nestedRank)
+        for element in dropFirst() {
+            precondition(
+                element.nestedShape == inner,
+                "nested array is not rectangular: \(element.nestedShape) != \(inner)")
+        }
+        return [count] + inner
+    }
+
+    public func appendNestedScalars(to values: inout [Element.Scalar]) {
+        for element in self {
+            element.appendNestedScalars(to: &values)
+        }
+    }
+}

--- a/Tests/MLXTests/MLXArray+InitTests.swift
+++ b/Tests/MLXTests/MLXArray+InitTests.swift
@@ -150,6 +150,12 @@ class MLXArrayInitTests: XCTestCase {
         // Int64 is a distinct type from Int and must not take the Int -> .int32 path
         XCTAssertEqual(MLXArray([[Int64(1), 2], [3, 4]]).dtype, .int64)
 
+        // casting the literal as a whole is a different inference path than casting the
+        // elements and must stay unambiguous
+        XCTAssertEqual(
+            MLXArray([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]] as [[Float32]]).dtype, .float32)
+        XCTAssertEqual(MLXArray([[[1.0, 2.0]]] as [[[Float32]]]).dtype, .float32)
+
         // as with `MLXArray([Double])` this produces .float64 rather than promoting
         let doubles: [[Double]] = [[1, 2], [3, 4]]
         XCTAssertEqual(MLXArray(doubles).dtype, .float64)

--- a/Tests/MLXTests/MLXArray+InitTests.swift
+++ b/Tests/MLXTests/MLXArray+InitTests.swift
@@ -89,6 +89,105 @@ class MLXArrayInitTests: XCTestCase {
         XCTAssertEqual(a.ndim, 2)
     }
 
+    // MARK: - Nested (multi dimensional) arrays
+
+    func testArrayCreationNested2D() {
+        let a = MLXArray([
+            [1, 2, 3],
+            [4, 5, 6],
+        ])
+        XCTAssertEqual(a.dtype, .int32)
+        XCTAssertEqual(a.shape, [2, 3])
+        XCTAssertEqual(a.ndim, 2)
+        XCTAssertEqual(a.size, 6)
+
+        // count is the size of dimension 0
+        XCTAssertEqual(a.count, 2)
+
+        assertEqual(a, MLXArray(1 ... 6, [2, 3]))
+    }
+
+    func testArrayCreationNested3D() {
+        // literal nesting and the flat + shape form must agree
+        let a = MLXArray([
+            [[0, 1], [2, 3], [4, 5]],
+            [[6, 7], [8, 9], [10, 11]],
+        ])
+        XCTAssertEqual(a.dtype, .int32)
+        XCTAssertEqual(a.shape, [2, 3, 2])
+        assertEqual(a, MLXArray(0 ..< 12, [2, 3, 2]))
+
+        // also works with a computed (non literal) nested array
+        let nested = (0 ..< 2).map { i in
+            (0 ..< 3).map { j in
+                (0 ..< 4).map { k in i * 12 + j * 4 + k }
+            }
+        }
+        let b = MLXArray(nested)
+        XCTAssertEqual(b.shape, [2, 3, 4])
+        assertEqual(b, MLXArray(0 ..< 24, [2, 3, 4]))
+    }
+
+    func testArrayCreationNested4D() {
+        let a = MLXArray([
+            [[[0, 1], [2, 3]], [[4, 5], [6, 7]]],
+            [[[8, 9], [10, 11]], [[12, 13], [14, 15]]],
+        ])
+        XCTAssertEqual(a.shape, [2, 2, 2, 2])
+        XCTAssertEqual(a.ndim, 4)
+        assertEqual(a, MLXArray(0 ..< 16, [2, 2, 2, 2]))
+    }
+
+    func testArrayCreationNestedDTypes() {
+        // the dtype of a nested array matches the 1d initializers for the same leaf type
+        XCTAssertEqual(MLXArray([[1, 2], [3, 4]]).dtype, .int32)
+        XCTAssertEqual(MLXArray([[Int32(1), 2], [3, 4]]).dtype, .int32)
+        XCTAssertEqual(MLXArray([[Int16(1), 2], [3, 4]]).dtype, .int16)
+        XCTAssertEqual(MLXArray([[UInt8(1), 2], [3, 4]]).dtype, .uint8)
+        XCTAssertEqual(MLXArray([[Float(1), 2], [3, 4]]).dtype, .float32)
+        XCTAssertEqual(MLXArray([[true, false], [false, true]]).dtype, .bool)
+
+        // Int64 is a distinct type from Int and must not take the Int -> .int32 path
+        XCTAssertEqual(MLXArray([[Int64(1), 2], [3, 4]]).dtype, .int64)
+
+        // as with `MLXArray([Double])` this produces .float64 rather than promoting
+        let doubles: [[Double]] = [[1, 2], [3, 4]]
+        XCTAssertEqual(MLXArray(doubles).dtype, .float64)
+
+        let complex: [[Complex<Float>]] = [[Complex(2, 7)], [Complex(3, 8)]]
+        let c = MLXArray(complex)
+        XCTAssertEqual(c.dtype, .complex64)
+        XCTAssertEqual(c.shape, [2, 1])
+        assertEqual(c, MLXArray([Complex<Float>(2, 7), Complex<Float>(3, 8)], [2, 1]))
+    }
+
+    func testArrayCreationNestedInt64() {
+        // a value that does not fit in an Int32 -- the whole point of the int64: variant
+        let big = Int(Int32.max) + 10
+        let a = MLXArray(int64: [[1, 2, 3], [4, 5, big]])
+        XCTAssertEqual(a.dtype, .int64)
+        XCTAssertEqual(a.shape, [2, 3])
+        assertEqual(a, MLXArray(int64: [1, 2, 3, 4, 5, big], [2, 3]))
+    }
+
+    func testArrayCreationNestedConverting() {
+        // non square so a transposed flattening could not pass
+        let a = MLXArray(converting: [[0.1, 0.5, 0.9], [1.3, 1.7, 2.1]])
+        XCTAssertEqual(a.dtype, .float32)
+        XCTAssertEqual(a.shape, [2, 3])
+        assertEqual(a, MLXArray(converting: [0.1, 0.5, 0.9, 1.3, 1.7, 2.1], [2, 3]))
+    }
+
+    func testArrayCreationNestedEmpty() {
+        let a = MLXArray([[Int](), [Int]()])
+        XCTAssertEqual(a.shape, [2, 0])
+        XCTAssertEqual(a.size, 0)
+
+        let b = MLXArray([[Int]]())
+        XCTAssertEqual(b.shape, [0, 0])
+        XCTAssertEqual(b.size, 0)
+    }
+
     func testArrayCreationClosedRange() {
         let a = MLXArray(Int16(3) ... Int16(6))
         XCTAssertEqual(a.dtype, .int16)

--- a/skills/mlx-swift/SKILL.md
+++ b/skills/mlx-swift/SKILL.md
@@ -62,8 +62,12 @@ import MLX
 // Create arrays
 let a = MLXArray([1, 2, 3, 4])
 let b = MLXArray(0 ..< 12, [3, 4])  // Shape [3, 4]
-let c = MLXArray.zeros([2, 3])
-let d = MLXArray.ones([4, 4], dtype: .float32)
+
+// Nested arrays give the shape directly (any depth)
+let c = MLXArray([[1, 2, 3], [4, 5, 6]])  // Shape [2, 3]
+
+let d = MLXArray.zeros([2, 3])
+let e = MLXArray.ones([4, 4], dtype: .float32)
 
 // Random arrays (use MLXRandom namespace or free functions)
 let uniform = MLXRandom.uniform(0.0 ..< 1.0, [3, 3])

--- a/skills/mlx-swift/references/arrays.md
+++ b/skills/mlx-swift/references/arrays.md
@@ -22,6 +22,10 @@ let c = MLXArray(0 ..< 10)
 let d = MLXArray(0 ..< 12, [3, 4])  // 3 rows, 4 columns
 let e = MLXArray([1, 2, 3, 4, 5, 6], [2, 3])
 
+// Multi-dimensional from a nested array -- the nesting gives the shape
+let f = MLXArray([[1, 2, 3], [4, 5, 6]])            // shape [2, 3]
+let g = MLXArray([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])  // shape [2, 2, 2]
+
 // Complex numbers
 let complex = MLXArray(real: 1.0, imaginary: 2.0)
 ```


### PR DESCRIPTION
## Proposed changes

This PR adds a convenience that I have wanted for a while in MLX-swift: nested array initializers
Support for nested array literals is available directly in the initializer for `MLXArray`.

closes #161  

```swift
let sigma1 = MLXArray([[0, 1], [1, 0]])
```
bringing the same kind numpy-like nd-array construction available in python mlx:
```python
sigma1 = mx.array([[0,1], [1,0]])
```

Nested arrays of any depth are supported, e.g. this works: 
```swift
let array5d = MLXArray(
[[
  [[[1,2], [3,4]], [[5,6],[7,8]]],
  [[[1,2], [3,4]], [[5,6],[7,8]]]
]])
print(array5d.shape) // [1, 2, 2, 2, 2]
```
It works with literals and variables, for example
```swift
let eijk =  (0..<3).map { i in  (0..<3).map { j in  (0..<3).map { k in
    (i - j) * (j - k) * (k - i) / 2
}}}

let levicivita = MLXArray(eijk) // shape: [3, 3, 3]
```

## Limitations & Implementation details

Obviously, nested arrays that don't map to tensors cannot be made into MLXArray. The choice was made to use `precondition` failure in this case, similar to other MLX array initialization failure (e.g. when the shape doesn't match the array). 
```swift
let fail = MLXArray([[1,2],[3, 4, 5]])
// -> Precondition failed: nested array is not rectangular: [3] != [2]
```

The machinery to make this work is rather simple but requires the addition of a new protocol `NestedArrayElement` 
that works recursively (all `HasDType` scalars conform, and all arrays of `NestedArrayElement` conform).

The `convenience init` functions added to  the public API thus accept any `[[NestedAarrayElement]]` as argument, flatten the array to a 1D array ad compute its shape recursively, and pass them down to the regular array initializer.

The main annoyance is that the explicit conformance of `NestedArrayElement` for all `HasDType` types can't be automatically enforced. This means that 
- we will have to maintain the two lists in sync if we ever add / remove `HasDType` types
- users defining their own scar types  already have to conform to `HasDType`. They will now have to also conform to `NestedArrayElement` if they want to use the nested array initializers. 


## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
