### PR TITLE
Fix mixed 16-bit quantizedMM promotion

### DIFF
--- a/Source/MLX/Ops.swift
+++ b/Source/MLX/Ops.swift
@@ -2449,6 +2449,11 @@ public func quantizedMatmul(
 ///   - mode: The quantization mode. Default is `.affine`
 ///   - stream: Stream or device to evaluate on
 ///
+/// When `x` and affine quantization parameters use different 16-bit floating-point
+/// formats, the parameters are converted to the input type. This avoids promoting
+/// mixed `float16` and `bfloat16` inputs to `float32`. Parameters already stored in
+/// `float32` retain the usual type-promotion behavior.
+///
 /// ### See Also
 /// - ``dequantized(_:scales:biases:groupSize:bits:mode:globalScale:dtype:stream:)``
 /// - ``quantized(_:groupSize:bits:mode:globalScale:stream:)``
@@ -2460,6 +2465,8 @@ public func quantizedMM(
     stream: StreamOrDevice = .default
 ) -> MLXArray {
     var result = mlx_array_new()
+    let (scales, biases) = alignedQuantizedMMParameters(
+        scales: scales, biases: biases, with: x, mode: mode, stream: stream)
 
     let gs = mlx_optional_int(value: Int32(groupSize ?? 0), has_value: groupSize != nil)
     let bits = mlx_optional_int(value: Int32(bits ?? 0), has_value: bits != nil)
@@ -2472,6 +2479,22 @@ public func quantizedMM(
         stream.ctx
     )
     return MLXArray(result)
+}
+
+private func alignedQuantizedMMParameters(
+    scales: MLXArray, biases: MLXArray?, with input: MLXArray, mode: QuantizationMode,
+    stream: StreamOrDevice
+) -> (MLXArray, MLXArray?) {
+    guard mode == .affine, let biases else { return (scales, biases) }
+    let dtypes = [input.dtype, scales.dtype, biases.dtype]
+    guard dtypes.allSatisfy({ $0 == .float16 || $0 == .bfloat16 }) else {
+        return (scales, biases)
+    }
+
+    return (
+        scales.dtype == input.dtype ? scales : scales.asType(input.dtype, stream: stream),
+        biases.dtype == input.dtype ? biases : biases.asType(input.dtype, stream: stream)
+    )
 }
 
 /// Perform a matrix multiplication using a possibly quantized weight matrix

--- a/Tests/MLXTests/QuantizationTests.swift
+++ b/Tests/MLXTests/QuantizationTests.swift
@@ -6,6 +6,36 @@ import MLXNN
 import XCTest
 
 class QuantizationTests: XCTestCase {
+    func testQuantizedMMPreservesInputDTypeForMixed16BitParameters() {
+        let weight = MLXArray.zeros([8, 8], dtype: .uint32)
+
+        for (inputDType, parameterDType) in [
+            (DType.bfloat16, DType.float16),
+            (DType.float16, DType.bfloat16),
+        ] {
+            let input = MLXArray.zeros([1, 64], dtype: inputDType)
+            let scales = MLXArray.ones([8, 1], dtype: parameterDType)
+            let biases = MLXArray.zeros([8, 1], dtype: parameterDType)
+
+            let result = quantizedMM(
+                input, weight, scales: scales, biases: biases, groupSize: 64, bits: 4)
+
+            XCTAssertEqual(result.dtype, inputDType)
+        }
+    }
+
+    func testQuantizedMMRetainsFloat32ParameterPromotion() {
+        let input = MLXArray.zeros([1, 64], dtype: .bfloat16)
+        let weight = MLXArray.zeros([8, 8], dtype: .uint32)
+        let scales = MLXArray.ones([8, 1], dtype: .float32)
+        let biases = MLXArray.zeros([8, 1], dtype: .float32)
+
+        let result = quantizedMM(
+            input, weight, scales: scales, biases: biases, groupSize: 64, bits: 4)
+
+        XCTAssertEqual(result.dtype, .float32)
+    }
+
     func testQuantizedLinearAppliesNVFP4GlobalScaleOnMetal() {
         let (input, quantizedWeight, scales, biases, globalScale, bias, expected) =
             Device.withDefaultDevice(.cpu) {


### PR DESCRIPTION
## Proposed changes

Fixes #420.

Affine `quantizedMM` uses common dtype promotion for the input, scales, and biases. A `bfloat16` activation combined with `float16` quantization parameters therefore produces `float32`, which changes the intended execution precision and can slow quantized models.

This change aligns affine scales and biases to the activation dtype when all three operands use 16-bit floating-point formats. The rule is deliberately narrow: `float32` parameters keep the existing promotion behavior, and non-affine quantization modes are unchanged. The public documentation now describes this behavior.

Regression tests cover both `bfloat16`/`float16` directions and verify that explicit `float32` parameters still produce `float32`.

Validation:

- `swift build --target MLX`
- `swiftc -parse Tests/MLXTests/QuantizationTests.swift`
- `pre-commit run --all-files`

The local Command Line Tools installation does not provide XCTest or the default Metal library, so the XCTest suite is left to the macOS CI runner.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx-swift/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)