### PR TITLE
Fix a deadlock between `CompiledFunction.lock` and `evalLock`, and a data race on the compiler cache

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -440,6 +440,18 @@ let package = Package(
             path: "Source/Examples",
             sources: ["CustomFunctionExampleSimple.swift"]
         ),
+        // Deterministic reproduction of the CompiledFunction/evalLock
+        // lock-order inversion.  A wedged run deadlocks its threads
+        // permanently, so it is deliberately kept out of the test bundle and
+        // built as its own executable.
+        .executableTarget(
+            name: "CompileLockRepro",
+            dependencies: ["MLX"],
+            path: "Source/CompileLockRepro",
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency")
+            ]
+        ),
     ] + cudaTargets,
     cxxLanguageStandard: .gnucxx20
 )

--- a/Source/CompileLockRepro/CompileLockRepro.swift
+++ b/Source/CompileLockRepro/CompileLockRepro.swift
@@ -1,0 +1,216 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+
+/// Deterministic reproduction of a cross-thread lock-order inversion between
+/// the per-instance `CompiledFunction.lock` and the process-global `evalLock`.
+///
+/// ## The cycle
+///
+/// `CompiledFunction.call` takes the per-instance `lock` (added by #226 to guard
+/// compiled-function state) and then, inside `innerCall`, takes the global
+/// `evalLock` (added by #339 to guard tracing) and holds it across
+/// `mlx_closure_apply`.  On a *cold* cache entry `mlx_closure_apply` runs
+/// `mlx::core::detail::compile_trace`, which calls back into the Swift body of
+/// the function being compiled.  If that body calls a *different* compiled
+/// function — which every `MLXNN` activation does, e.g. `silu` uses the
+/// file-scope `compiledSilu` — the nested `CompiledFunction.call` takes a second
+/// per-instance lock *while already holding `evalLock`*.
+///
+///     Thread H:  L_cf(outer)  -> evalLock     -> wants L_cf(shared)
+///     Thread W:  L_cf(shared) -> wants evalLock
+///
+/// The two acquisition orders are inverted, so H and W deadlock permanently.
+/// `evalLock` being an `NSRecursiveLock` does not help: this is not same-thread
+/// re-entry.
+///
+/// ## Why this is deterministic and not a race we hope to lose
+///
+/// * Fresh `compile()` results per round guarantee a **cold** compiler cache.
+///   The re-entry into Swift only happens while tracing, i.e. on first use, so a
+///   warm instance would simply never open the window.
+/// * A semaphore signalled **from inside the traced Swift body** releases W only
+///   once H is provably inside `compile_trace` holding `evalLock`.
+/// * A `usleep` in that same traced body holds the window open for 200 ms —
+///   roughly a million times longer than the few instructions W needs — so W
+///   always reaches `L_cf(shared)` first.
+/// * Threads are owned here rather than borrowed from a test runner, so nothing
+///   depends on runner parallelism.
+///
+/// ## Why it is its own executable
+///
+/// A wedged round deadlocks the threads permanently and they cannot be
+/// unwedged, so this cannot live in a shared test process without taking the
+/// whole lane down.  The deadline turns the hang into a hard, fast failure.
+///
+/// ## Running it
+///
+///     swift build --product CompileLockRepro
+///     .build/debug/CompileLockRepro           # --device cpu|gpu
+///
+/// SwiftPM (command line) cannot build the Metal shaders, and the MLX scheduler
+/// opens a GPU stream when it is constructed, so a `swift build` product needs a
+/// `mlx.metallib` colocated with the binary even for `--device cpu`.  Copy one
+/// built by `xcodebuild -project xcode/MLX.xcodeproj -scheme MLX` (it lands at
+/// `Build/Products/Debug/Cmlx.framework/Versions/A/Resources/default.metallib`)
+/// into `$(swift build --show-bin-path)/mlx.metallib`.
+///
+/// Exit codes: `0` no deadlock, `1` deadlock (the bug is present), `2`
+/// inconclusive (compilation was disabled, so no trace ever ran).
+@main
+struct CompileLockRepro {
+
+    /// Per-round completion deadline.  A round that has not finished by now is
+    /// wedged: every thread is parked in `__psynch_mutexwait` and no amount of
+    /// further waiting will help.
+    static let deadline: TimeInterval = 10
+
+    /// How long the traced body holds the race window open.
+    static let widenMicroseconds: UInt32 = 200_000
+
+    static let rounds = 20
+
+    /// Minimal thread-safe boolean; the repro must not itself depend on any
+    /// MLX locking.
+    final class Flag: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = false
+        func set() {
+            lock.lock()
+            value = true
+            lock.unlock()
+        }
+        var isSet: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return value
+        }
+    }
+
+    static func die(_ code: Int32, _ message: String) -> Never {
+        print(message)
+        fflush(stdout)
+        // The wedged threads hold `evalLock` and a `CompiledFunction.lock`.
+        // A normal `exit()` would run atexit handlers that can block on exactly
+        // those locks, turning a reported failure back into a hang.
+        _exit(code)
+    }
+
+    static func main() {
+        // The deadlock is entirely in the Swift locking + the backend-independent
+        // `mlx::core::detail::compile` machinery, so the repro runs on either
+        // device.  It defaults to `.cpu` because SwiftPM (command line) cannot
+        // build the Metal shaders, so a plain `swift run` has no metallib.
+        var device = Device.cpu
+        if let index = CommandLine.arguments.firstIndex(of: "--device"),
+            index + 1 < CommandLine.arguments.count
+        {
+            switch CommandLine.arguments[index + 1].lowercased() {
+            case "cpu": device = .cpu
+            case "gpu": device = .gpu
+            default: die(2, "unknown --device \(CommandLine.arguments[index + 1])")
+            }
+        }
+        Device.setDefault(device: device)
+
+        print(
+            "compile-lock repro: device=\(device), \(rounds) rounds, \(Int(deadline))s deadline per round"
+        )
+
+        // Keep every compiled function alive for the whole run: `id` is the
+        // object address and `deinit` erases the cache entry, so recycling an
+        // address could alias two rounds.
+        var keepAlive: [Any] = []
+        var tracedAtLeastOnce = false
+
+        for round in 1 ... rounds {
+            tracedAtLeastOnce = runRound(round, keepAlive: &keepAlive) || tracedAtLeastOnce
+        }
+
+        if !tracedAtLeastOnce {
+            die(
+                2,
+                """
+                INCONCLUSIVE: the traced body never ran, so no compile trace happened \
+                and the deadlock window was never opened. Is MLX_DISABLE_COMPILE set?
+                """)
+        }
+
+        print("PASS: \(rounds) rounds completed, no deadlock")
+    }
+
+    /// Runs one round.  Returns whether the traced body actually executed.
+    static func runRound(_ round: Int, keepAlive: inout [Any]) -> Bool {
+        let gate = DispatchSemaphore(value: 0)  // H (inside the trace) -> W
+        let hDone = DispatchSemaphore(value: 0)
+        let wDone = DispatchSemaphore(value: 0)
+        let traced = Flag()  // the traced Swift body really ran
+        let stop = Flag()  // main -> W: H is finished, you may stop
+
+        // Fresh instances: a cold compiler cache is what makes `compile_trace`
+        // — and therefore the re-entry into Swift under `evalLock` — happen.
+        let shared: @Sendable (MLXArray) -> MLXArray = compile(shapeless: true) { x in
+            x * 2 + 1
+        }
+        let outer: @Sendable (MLXArray) -> MLXArray = compile(shapeless: true) { x in
+            // This body runs on thread H, on the C++ side of
+            // `mlx_closure_apply`, inside `compile_trace`, with `evalLock` held.
+            traced.set()
+            gate.signal()  // W may now take L_cf(shared)
+            usleep(widenMicroseconds)  // hold the window open
+            return shared(x) + 3  // H blocks here on L_cf(shared)
+        }
+        keepAlive.append(shared)
+        keepAlive.append(outer)
+
+        let h = Thread {
+            let a = MLXArray([1.0, 2.0, 3.0] as [Float])
+            let r = outer(a)
+            eval(r)
+            hDone.signal()
+        }
+        h.name = "H-nested-compiled-call"
+
+        let w = Thread {
+            gate.wait()
+            let b = MLXArray([4.0, 5.0, 6.0] as [Float])
+            var iterations = 0
+            repeat {
+                let r = shared(b)  // W takes L_cf(shared), then wants evalLock
+                eval(r)
+                iterations += 1
+            } while !stop.isSet && iterations < 1000
+            wDone.signal()
+        }
+        w.name = "W-plain-compiled-call"
+
+        h.start()
+        w.start()
+
+        if hDone.wait(timeout: .now() + deadline) == .timedOut {
+            die(
+                1,
+                """
+                FAIL: round \(round): thread H did not complete within \(Int(deadline))s.
+                  H holds evalLock (taken in CompiledFunction.innerCall) and is blocked
+                  acquiring the per-instance lock of the nested compiled function;
+                  W holds that per-instance lock and is blocked acquiring evalLock.
+                  enteredTrace=\(traced.isSet)
+                  This is the lock-order inversion; the process is deadlocked.
+                """)
+        }
+        stop.set()
+        if wDone.wait(timeout: .now() + deadline) == .timedOut {
+            die(
+                1,
+                """
+                FAIL: round \(round): thread W did not complete within \(Int(deadline))s \
+                after H finished. Blocked acquiring evalLock.
+                """)
+        }
+
+        print("  round \(round): ok (enteredTrace=\(traced.isSet))")
+        return traced.isSet
+    }
+}

--- a/Source/MLX/Device.swift
+++ b/Source/MLX/Device.swift
@@ -185,7 +185,7 @@ extension Device: CustomStringConvertible {
     public var description: String {
         var s = mlx_string_new()
         defer { mlx_string_free(s) }
-        _ = evalLock.withLock {
+        _ = withEvalLock {
             mlx_device_tostring(&s, ctx)
         }
         return String(cString: mlx_string_data(s), encoding: .utf8)!

--- a/Source/MLX/IO.swift
+++ b/Source/MLX/IO.swift
@@ -36,7 +36,7 @@ public func save(array: MLXArray, url: URL, stream: StreamOrDevice = .default) t
     switch url.pathExtension {
     case "npy":
         _ = try withError {
-            _ = evalLock.withLock {
+            _ = withEvalLock {
                 mlx_save(path.cString(using: .utf8), array.ctx)
             }
         }
@@ -74,7 +74,7 @@ public func save(
     switch url.pathExtension {
     case "safetensors":
         _ = try withError {
-            _ = evalLock.withLock {
+            _ = withEvalLock {
                 mlx_save_safetensors(path.cString(using: .utf8), mlx_arrays, mlx_metadata)
             }
         }
@@ -288,7 +288,7 @@ public func saveToData(
     defer { mlx_io_writer_free(writer) }
 
     _ = try withError {
-        _ = evalLock.withLock {
+        _ = withEvalLock {
             mlx_save_safetensors_writer(writer, mlx_arrays, mlx_metadata)
         }
     }

--- a/Source/MLX/MLXArray.swift
+++ b/Source/MLX/MLXArray.swift
@@ -554,7 +554,7 @@ public final class MLXArray {
     /// MLX is lazy and arrays are not fully realized until they are evaluated.  This method is typically
     /// not needed as all reads ensure the contents are evaluated.
     public func eval() {
-        _ = evalLock.withLock {
+        _ = withEvalLock {
             mlx_array_eval(ctx)
         }
     }
@@ -617,7 +617,7 @@ extension MLXArray: CustomStringConvertible {
     public var description: String {
         var s = mlx_string_new()
         defer { mlx_string_free(s) }
-        _ = evalLock.withLock {
+        _ = withEvalLock {
             mlx_array_tostring(&s, ctx)
         }
         return String(cString: mlx_string_data(s), encoding: .utf8)!

--- a/Source/MLX/Memory.swift
+++ b/Source/MLX/Memory.swift
@@ -354,7 +354,7 @@ public enum Memory {
 
     /// Cause all cached buffers to be deallocated.
     public static func clearCache() {
-        _ = evalLock.withLock {
+        _ = withEvalLock {
             mlx_clear_cache()
         }
     }

--- a/Source/MLX/Stream.swift
+++ b/Source/MLX/Stream.swift
@@ -118,7 +118,7 @@ public final class Stream: @unchecked Sendable, Equatable {
 
     @available(*, deprecated, message: "use init(Device) -- index not supported")
     public init(index: Int32, _ device: Device) {
-        self.ctx = evalLock.withLock {
+        self.ctx = withEvalLock {
             mlx_stream_new_device(device.ctx)
         }
     }
@@ -127,20 +127,20 @@ public final class Stream: @unchecked Sendable, Equatable {
     ///
     /// See also ``withNewDefaultStream(device:_:)-5bwc3``
     public init(_ device: Device) {
-        self.ctx = evalLock.withLock {
+        self.ctx = withEvalLock {
             mlx_stream_new_device(device.ctx)
         }
     }
 
     deinit {
-        _ = evalLock.withLock {
+        _ = withEvalLock {
             mlx_stream_free(ctx)
         }
     }
 
     /// Synchronize with the given stream
     public func synchronize() {
-        _ = evalLock.withLock {
+        _ = withEvalLock {
             mlx_synchronize(ctx)
         }
     }
@@ -162,7 +162,7 @@ extension Stream: CustomStringConvertible {
     public var description: String {
         var s = mlx_string_new()
         defer { mlx_string_free(s) }
-        _ = evalLock.withLock {
+        _ = withEvalLock {
             mlx_stream_tostring(&s, ctx)
         }
         return String(cString: mlx_string_data(s), encoding: .utf8)!

--- a/Source/MLX/Transforms+Compile.swift
+++ b/Source/MLX/Transforms+Compile.swift
@@ -76,7 +76,7 @@ final class CompiledFunction: @unchecked (Sendable) {
     /// -- so this only moves the acquisition earlier by the state gathering and
     /// closure creation at the top of ``innerCall(_:)``.
     func call(_ arguments: [MLXArray]) -> [MLXArray] {
-        evalLock.withLock {
+        withEvalLock {
             // ``lock`` exists only to guard the observed state (#226): the
             // `_updateInternal` swaps in `innerCall` are the sole mutation of
             // anything reachable from `self` -- every other stored property is
@@ -89,10 +89,25 @@ final class CompiledFunction: @unchecked (Sendable) {
             if inputs.isEmpty && outputs.isEmpty {
                 return innerCall(arguments)
             }
-            return lock.withLock {
+            return withInstanceLock {
                 innerCall(arguments)
             }
         }
+    }
+
+    /// Acquire ``lock``, checking the ordering invariant first.
+    ///
+    /// The check is where the invariant actually lives, not in ``call(_:)``: a
+    /// change that moved the per-instance lock back outside `evalLock` -- the
+    /// shape that produced the deadlock -- trips this on the first compiled
+    /// call, deterministically and without needing to lose a race.
+    private func withInstanceLock<R>(_ body: () throws -> R) rethrows -> R {
+        #if DEBUG
+            EvalLockOwnership.requireHeldByCurrentThread(
+                "CompiledFunction.lock was acquired without holding evalLock; "
+                    + "that is the lock-order inversion, see CompiledFunction.call")
+        #endif
+        return try lock.withLock(body)
     }
 
     /// - Precondition: `evalLock` is held by the caller, and ``lock`` is held

--- a/Source/MLX/Transforms+Compile.swift
+++ b/Source/MLX/Transforms+Compile.swift
@@ -77,14 +77,27 @@ final class CompiledFunction: @unchecked (Sendable) {
     /// closure creation at the top of ``innerCall(_:)``.
     func call(_ arguments: [MLXArray]) -> [MLXArray] {
         evalLock.withLock {
-            lock.withLock {
+            // ``lock`` exists only to guard the observed state (#226): the
+            // `_updateInternal` swaps in `innerCall` are the sole mutation of
+            // anything reachable from `self` -- every other stored property is
+            // `let`, and `id` is written once at init.  With no state there is
+            // nothing to guard, and `evalLock` above already serializes the
+            // compiler cache and every other caller.
+            //
+            // This is the common case: every compiled function in `MLXNN` is
+            // stateless.
+            if inputs.isEmpty && outputs.isEmpty {
+                return innerCall(arguments)
+            }
+            return lock.withLock {
                 innerCall(arguments)
             }
         }
     }
 
-    /// - Precondition: `evalLock` and ``lock`` are held by the caller; see
-    ///   ``call(_:)``, which is the only caller.
+    /// - Precondition: `evalLock` is held by the caller, and ``lock`` is held
+    ///   too unless this function has no observed state; see ``call(_:)``,
+    ///   which is the only caller.
     func innerCall(_ arguments: [MLXArray]) -> [MLXArray] {
         let stateInputs = inputs.flatMap { $0.innerState() }
         let argumentsCount = arguments.count

--- a/Source/MLX/Transforms+Compile.swift
+++ b/Source/MLX/Transforms+Compile.swift
@@ -9,7 +9,14 @@ final class CompiledFunction: @unchecked (Sendable) {
     /// unique (for the lifetime of the object) identifier for the compiled function
     private var id: UInt!
 
-    let lock = NSLock()
+    /// guards the observed state (``inputs`` / ``outputs``) -- see #226
+    ///
+    /// This is always acquired *inside* `evalLock`; see ``call(_:)`` for the
+    /// ordering rule.  It is recursive because a compiled function's body can
+    /// legitimately re-enter that same compiled function on the same thread
+    /// while it is being traced (a nested call with tracer inputs bypasses the
+    /// cache and simply runs the body again).
+    let lock = NSRecursiveLock()
 
     /// the function to compile
     let f: ([MLXArray]) -> [MLXArray]
@@ -36,12 +43,48 @@ final class CompiledFunction: @unchecked (Sendable) {
         mlx_detail_compile_erase(id)
     }
 
+    /// Evaluate the compiled function.
+    ///
+    /// ### Lock ordering
+    ///
+    /// `evalLock` is acquired **outermost**, before the per-instance ``lock``.
+    /// That order is not a preference, it is forced:
+    ///
+    /// - Tracing mutates process-global state that has no synchronization of its
+    ///   own -- `mlx::core::detail::CompilerCache` is an unguarded singleton and
+    ///   `detail::InTracing::trace_stack()` is a plain function-local `static`,
+    ///   not `thread_local` -- so `evalLock` has to span the whole trace (#339).
+    /// - The trace calls back into Swift, and the traced body routinely calls
+    ///   *other* compiled functions: every `MLXNN` activation is a file-scope
+    ///   `CompiledFunction`, so e.g. `silu` inside a traced body enters
+    ///   `compiledSilu.call` and takes *its* per-instance lock.
+    ///
+    /// So `evalLock` → ``lock`` happens whether or not we ask for it.  Taking
+    /// ``lock`` first here would add the reverse order ``lock`` → `evalLock` for
+    /// any thread entering from the top, and two threads -- one nested inside a
+    /// trace, one not -- would deadlock on a cold compiler cache:
+    ///
+    ///     thread H:  L_cf(outer)  -> evalLock     -> wants L_cf(shared)
+    ///     thread W:  L_cf(shared) -> wants evalLock
+    ///
+    /// Acquiring `evalLock` here gives the process a single global order, which
+    /// makes the inversion impossible.  `Source/CompileLockRepro` reproduces the
+    /// deadlock deterministically without this.
+    ///
+    /// The cost is small: ``innerCall(_:)`` used to take `evalLock` itself and
+    /// hold it through `mlx_closure_apply` -- i.e. across the actual evaluation
+    /// -- so this only moves the acquisition earlier by the state gathering and
+    /// closure creation at the top of ``innerCall(_:)``.
     func call(_ arguments: [MLXArray]) -> [MLXArray] {
-        lock.withLock {
-            innerCall(arguments)
+        evalLock.withLock {
+            lock.withLock {
+                innerCall(arguments)
+            }
         }
     }
 
+    /// - Precondition: `evalLock` and ``lock`` are held by the caller; see
+    ///   ``call(_:)``, which is the only caller.
     func innerCall(_ arguments: [MLXArray]) -> [MLXArray] {
         let stateInputs = inputs.flatMap { $0.innerState() }
         let argumentsCount = arguments.count
@@ -86,12 +129,13 @@ final class CompiledFunction: @unchecked (Sendable) {
 
         // note: this will use the cached compile (via the id)
         // but will be able to re-evaluate with fresh state if needed
-        evalLock.lock()
+        //
+        // evalLock is already held by call(_:) and covers everything through
+        // mlx_closure_apply below, which is where the trace runs.
         var compiled = mlx_closure_new()
         let compileStatus = mlx_detail_compile(&compiled, innerClosure, id, shapeless, [], 0)
         defer {
             mlx_closure_free(compiled)
-            evalLock.unlock()
         }
 
         // mlx_error was already dispatched on failure:

--- a/Source/MLX/Transforms+Compile.swift
+++ b/Source/MLX/Transforms+Compile.swift
@@ -38,9 +38,67 @@ final class CompiledFunction: @unchecked (Sendable) {
         self.id = UInt(bitPattern: Unmanaged.passUnretained(self).toOpaque())
     }
 
+    /// Remove the compiled structure from the back end.
+    ///
+    /// ### Why this takes `evalLock`
+    ///
+    /// `mlx_detail_compile_erase` is `compiler_cache().erase(fun_id)`, i.e.
+    /// `std::unordered_map::erase` on the *same* process-global
+    /// `mlx::core::detail::CompilerCache` that ``innerCall(_:)`` reads and
+    /// inserts into via `CompilerCache::find` (`cache_[fun_id]`, which itself
+    /// can insert and rehash, followed by `entries.push_back`).  That cache has
+    /// no synchronization of its own, and `find` hands back a *reference* to an
+    /// entry that the caller then fills in and reads from across the whole
+    /// trace.  An unlocked erase can therefore rehash the map out from under a
+    /// concurrent `find`, or destroy the very entry another thread is compiling
+    /// into.
+    ///
+    /// Every other use of that cache happens under `evalLock`, so the erase has
+    /// to as well; otherwise the lock does not actually make the cache
+    /// single-threaded, it only makes most of it single-threaded.
+    ///
+    /// ### Why blocking here is safe
+    ///
+    /// `deinit` runs on whichever thread drops the last reference:
+    ///
+    /// - A thread that holds no MLX lock simply waits for the current eval or
+    ///   compiled call to finish.  Bounded, since `evalLock` is only ever held
+    ///   for the duration of one call.
+    /// - A thread already inside a compiled call or an `eval` -- for instance a
+    ///   traced body that drops the last reference to some other compiled
+    ///   function -- already holds `evalLock`, and it is an `NSRecursiveLock`,
+    ///   so re-entry is free.
+    /// - A thread holding some other ``CompiledFunction``'s ``lock`` also holds
+    ///   `evalLock` already (see ``call(_:)``), so that is the same case; no new
+    ///   edge is added to the lock graph.
+    ///
+    /// Within this library the only releases of a ``CompiledFunction`` are the
+    /// caller's own (the closure returned by ``compile(inputs:outputs:shapeless:_:)-([Updatable],[Updatable],Bool,([MLXArray])->[MLXArray])``
+    /// holds the sole strong reference) and the `mlx_closure_free` of the
+    /// closure built in ``innerCall(_:)``, which runs on the calling thread with
+    /// `evalLock` already held.  Nothing hands a reference to a back-end worker
+    /// thread, so the erase can never be the thing an `evalLock` holder is
+    /// waiting for.
+    ///
+    /// The erase stays synchronous rather than being deferred to a queue on
+    /// purpose: ``id`` is the object's own address, so once this object is
+    /// freed a new ``CompiledFunction`` can be allocated at the same address and
+    /// receive the same id.  A deferred erase could delete that new function's
+    /// cache entries.
     deinit {
-        // remove the compiled structure from the back end
-        mlx_detail_compile_erase(id)
+        let functionID = id!
+        withEvalLock {
+            #if DEBUG
+                // Trivially true two lines below the acquisition -- it is here to
+                // catch a future change that moves the erase back out from under
+                // the lock, the same way `withInstanceLock` guards `call(_:)`.
+                EvalLockOwnership.requireHeldByCurrentThread(
+                    "the compiler cache was erased without holding evalLock; "
+                        + "see CompiledFunction.deinit")
+                EvalLockOwnership.recordCompileErase()
+            #endif
+            _ = mlx_detail_compile_erase(functionID)
+        }
     }
 
     /// Evaluate the compiled function.

--- a/Source/MLX/Transforms+Eval.swift
+++ b/Source/MLX/Transforms+Eval.swift
@@ -54,6 +54,7 @@ let evalLock = NSRecursiveLock()
         private static let counterLock = NSLock()
         nonisolated(unsafe) private static var checkCount = 0
         nonisolated(unsafe) private static var violationCount = 0
+        nonisolated(unsafe) private static var compileEraseCount = 0
 
         /// Records, and in debug builds asserts, that `evalLock` is held by the
         /// current thread at a point where an inner lock is about to be taken.
@@ -66,15 +67,28 @@ let evalLock = NSRecursiveLock()
             assert(held, message())
         }
 
+        /// Records a `CompiledFunction.deinit` erase of the compiler cache, so a
+        /// test can tell "the erase ran under the lock" from "the deinit never
+        /// fired".
+        static func recordCompileErase() {
+            counterLock.withLock { compileEraseCount += 1 }
+        }
+
         /// (checks, violations) since ``resetCounters()``.
         static var counters: (checks: Int, violations: Int) {
             counterLock.withLock { (checkCount, violationCount) }
+        }
+
+        /// Compiler-cache erases since ``resetCounters()``.
+        static var compileErases: Int {
+            counterLock.withLock { compileEraseCount }
         }
 
         static func resetCounters() {
             counterLock.withLock {
                 checkCount = 0
                 violationCount = 0
+                compileEraseCount = 0
             }
         }
     }

--- a/Source/MLX/Transforms+Eval.swift
+++ b/Source/MLX/Transforms+Eval.swift
@@ -6,7 +6,100 @@ import Foundation
 /// lock to be held while doing any eval or asyncEval.  This is
 /// a recursive lock to handle any cases where a closure might
 /// call back into eval.
+///
+/// Acquire it through ``withEvalLock(_:)`` rather than directly: debug builds
+/// record ownership there so that the `evalLock` → `CompiledFunction.lock`
+/// ordering can be checked.
+///
+/// `evalLock` is the outermost lock in the library.  Nothing may be acquired
+/// before it and then be waited on from inside it; see `CompiledFunction.call`.
 let evalLock = NSRecursiveLock()
+
+#if DEBUG
+
+    /// Per-thread `evalLock` ownership, recorded so the ordering invariant in
+    /// `CompiledFunction.call` can be checked in debug builds.
+    ///
+    /// Explicit bookkeeping is required: `evalLock` is recursive, so a
+    /// successful `try()` cannot distinguish "this thread owns it" from "nobody
+    /// owns it".  The depth is thread-local, so it needs no lock of its own --
+    /// which matters, because this runs while holding `evalLock`.
+    enum EvalLockOwnership {
+
+        private static let depthKey: pthread_key_t = {
+            var key = pthread_key_t()
+            pthread_key_create(&key, nil)
+            return key
+        }()
+
+        static var isHeldByCurrentThread: Bool {
+            depth > 0
+        }
+
+        static var depth: Int {
+            Int(bitPattern: pthread_getspecific(depthKey))
+        }
+
+        static func entered() {
+            pthread_setspecific(depthKey, UnsafeRawPointer(bitPattern: depth + 1))
+        }
+
+        static func exited() {
+            pthread_setspecific(depthKey, UnsafeRawPointer(bitPattern: depth - 1))
+        }
+
+        // Counters, so a test can assert both that the invariant held and that
+        // it was actually exercised -- a check count of zero would mean the test
+        // proved nothing.
+        private static let counterLock = NSLock()
+        nonisolated(unsafe) private static var checkCount = 0
+        nonisolated(unsafe) private static var violationCount = 0
+
+        /// Records, and in debug builds asserts, that `evalLock` is held by the
+        /// current thread at a point where an inner lock is about to be taken.
+        static func requireHeldByCurrentThread(_ message: @autoclosure () -> String) {
+            let held = isHeldByCurrentThread
+            counterLock.withLock {
+                checkCount += 1
+                if !held { violationCount += 1 }
+            }
+            assert(held, message())
+        }
+
+        /// (checks, violations) since ``resetCounters()``.
+        static var counters: (checks: Int, violations: Int) {
+            counterLock.withLock { (checkCount, violationCount) }
+        }
+
+        static func resetCounters() {
+            counterLock.withLock {
+                checkCount = 0
+                violationCount = 0
+            }
+        }
+    }
+
+#endif
+
+/// Acquire ``evalLock`` for the duration of `body`.
+///
+/// This is the single choke point for ``evalLock``; debug builds record
+/// ownership here so that `CompiledFunction` can check that its per-instance
+/// lock is never taken outside it.
+@inline(__always)
+func withEvalLock<R>(_ body: () throws -> R) rethrows -> R {
+    evalLock.lock()
+    #if DEBUG
+        EvalLockOwnership.entered()
+    #endif
+    defer {
+        #if DEBUG
+            EvalLockOwnership.exited()
+        #endif
+        evalLock.unlock()
+    }
+    return try body()
+}
 
 /// Evaluate one or more `MLXArray`
 ///
@@ -14,7 +107,7 @@ let evalLock = NSRecursiveLock()
 /// - <doc:lazy-evaluation>
 public func eval(_ arrays: MLXArray...) {
     let vector_array = new_mlx_vector_array(arrays)
-    _ = evalLock.withLock {
+    _ = withEvalLock {
         mlx_eval(vector_array)
     }
     mlx_vector_array_free(vector_array)
@@ -26,7 +119,7 @@ public func eval(_ arrays: MLXArray...) {
 /// - <doc:lazy-evaluation>
 public func eval(_ arrays: some Collection<MLXArray>) {
     let vector_array = new_mlx_vector_array(arrays)
-    _ = evalLock.withLock {
+    _ = withEvalLock {
         mlx_eval(vector_array)
     }
     mlx_vector_array_free(vector_array)
@@ -39,7 +132,7 @@ public func eval(_ arrays: some Collection<MLXArray>) {
 /// - ``asyncEval(_:)-(Collection<MLXArray>)``
 public func asyncEval(_ arrays: some Collection<MLXArray>) {
     let vector_array = new_mlx_vector_array(arrays)
-    _ = evalLock.withLock {
+    _ = withEvalLock {
         mlx_async_eval(vector_array)
     }
     mlx_vector_array_free(vector_array)

--- a/Source/MLX/Transforms+Internal.swift
+++ b/Source/MLX/Transforms+Internal.swift
@@ -16,7 +16,7 @@ private func valueAndGradient(
     var r0 = mlx_vector_array_new()
     var r1 = mlx_vector_array_new()
 
-    _ = evalLock.withLock {
+    _ = withEvalLock {
         mlx_closure_value_and_grad_apply(&r0, &r1, valueAndGrad, input_vector)
     }
 

--- a/Source/MLX/Transforms+Vmap.swift
+++ b/Source/MLX/Transforms+Vmap.swift
@@ -29,7 +29,7 @@ public func vmap(
         var traceInputs = mlx_vector_array_new()
         var traceOutputs = mlx_vector_array_new()
 
-        evalLock.withLock {
+        withEvalLock {
             let closure = new_mlx_closure(f)
             _ = inAxes32.withUnsafeBufferPointer { inAxesBuf in
                 mlx_detail_vmap_trace(

--- a/Source/MLX/Transforms.swift
+++ b/Source/MLX/Transforms.swift
@@ -28,7 +28,7 @@ public func jvp(
 
     let closure = new_mlx_closure(f)
 
-    _ = evalLock.withLock {
+    _ = withEvalLock {
         mlx_jvp(&r0, &r1, closure, primals_mlx, tangents_mlx)
     }
 
@@ -65,7 +65,7 @@ public func vjp(
 
     let closure = new_mlx_closure(f)
 
-    _ = evalLock.withLock {
+    _ = withEvalLock {
         mlx_vjp(&r0, &r1, closure, primals_mlx, cotangents_mlx)
     }
 

--- a/Source/MLX/WiredMemory.swift
+++ b/Source/MLX/WiredMemory.swift
@@ -24,7 +24,7 @@ private enum WiredMemoryBackend {
         guard isSupported else { return false }
         guard limit >= 0 else { return false }
         var previous: size_t = 0
-        let result = evalLock.withLock {
+        let result = withEvalLock {
             mlx_set_wired_limit(&previous, size_t(limit))
         }
         return result == 0

--- a/Tests/MLXTests/CompileLockOrderingTests.swift
+++ b/Tests/MLXTests/CompileLockOrderingTests.swift
@@ -129,6 +129,224 @@ import XCTest
                 counters.violations, 0,
                 "a nested CompiledFunction.lock was taken without evalLock held")
         }
+
+        // MARK: - CompiledFunction.deinit vs. a concurrent compiled call
+
+        /// A `CompiledFunction` whose only strong reference is `release()`-able
+        /// on demand, so a test can make its `deinit` -- and therefore the
+        /// compiler-cache erase -- happen at a chosen instant on a chosen
+        /// thread.
+        private final class Victim: @unchecked Sendable {
+            private var compiled: (@Sendable (MLXArray) -> MLXArray)?
+
+            init() {
+                // A fresh compile() per instance, so the erase has a populated
+                // cache entry to remove.  The unique constant keeps this from
+                // sharing an entry with anything else.
+                let bias = MLXArray(Float.random(in: 1 ... 2))
+                compiled = MLX.compile { (x: MLXArray) in x * 3 + bias }
+            }
+
+            /// Populate the cache entry that `deinit` will erase.
+            func warm() {
+                let r = compiled!(MLXArray(1))
+                eval(r)
+            }
+
+            /// Drop the last reference.  Returns once `deinit` has completed.
+            func release() {
+                compiled = nil
+            }
+        }
+
+        /// The interleaving this is about: thread R's `deinit` erase lands while
+        /// thread C is provably inside `compile_trace`, holding `evalLock` and
+        /// holding a live reference into the cache entry it is filling in.
+        ///
+        /// Unlike `Source/CompileLockRepro`, this is safe in the shared test
+        /// process: with the fix there is a single lock order, `evalLock` is
+        /// only ever held for the duration of one call, and R's `deinit` cannot
+        /// be what C is waiting for -- so R blocks for the length of the traced
+        /// body and no longer.  The deadline turns a regression into a failure
+        /// rather than a hung lane.
+        func testDeinitEraseSerializesAgainstATraceInFlight() {
+            EvalLockOwnership.resetCounters()
+
+            final class Shared: @unchecked Sendable {
+                let lock = NSLock()
+                private var _insideTrace = false
+                var insideTrace: Bool {
+                    get { lock.withLock { _insideTrace } }
+                    set { lock.withLock { _insideTrace = newValue } }
+                }
+                var tracedRan = false
+                var insideTraceAfterErase = true
+                var erasesAroundRelease = 0
+                var result: Float = .nan
+            }
+            let shared = Shared()
+
+            // Signalled from *inside* the traced body, so R only starts its
+            // release once C is known to be inside the trace holding evalLock.
+            let cIsInsideTrace = DispatchSemaphore(value: 0)
+            let cDone = DispatchSemaphore(value: 0)
+            let rDone = DispatchSemaphore(value: 0)
+
+            // Built on this thread; released on R.
+            let victim = Victim()
+            victim.warm()
+
+            // C's own compiled function is created and retained *here*, not on
+            // C, so that C never destroys a `CompiledFunction` of its own --
+            // the erase counted around `release()` below can then only be the
+            // victim's.  Compiling does not trace; the trace happens on the
+            // first call, which is on C.
+            let state = MLXArray(Float(4))
+            func body(_ x: [MLXArray]) -> [MLXArray] {
+                shared.tracedRan = true
+                shared.insideTrace = true
+                cIsInsideTrace.signal()
+                // Hold the window open long enough that R is certainly parked
+                // in its erase rather than merely scheduled.
+                usleep(50_000)
+                shared.insideTrace = false
+                return [x[0] + state]
+            }
+            let cCompiled = compile(inputs: [state], outputs: [state], body(_:))
+
+            let c = Thread {
+                let r = cCompiled([MLXArray(Float(6))])
+                eval(r)
+                shared.result = r[0].item(Float.self)
+                cDone.signal()
+            }
+
+            let r = Thread {
+                // Only proceed once C is inside the trace.
+                guard cIsInsideTrace.wait(timeout: .now() + 30) == .success else {
+                    rDone.signal()
+                    return
+                }
+                let before = EvalLockOwnership.compileErases
+                victim.release()
+                let after = EvalLockOwnership.compileErases
+                // Read the flag the instant the erase returns.  With the erase
+                // under `evalLock` this can only be observed false: R cannot
+                // have acquired the lock until C left the traced body.
+                shared.insideTraceAfterErase = shared.insideTrace
+                shared.erasesAroundRelease = after - before
+                rDone.signal()
+            }
+
+            c.start()
+            r.start()
+
+            XCTAssertEqual(cDone.wait(timeout: .now() + 60), .success, "the compiled call wedged")
+            XCTAssertEqual(rDone.wait(timeout: .now() + 60), .success, "the deinit erase wedged")
+
+            XCTAssertTrue(shared.tracedRan, "the traced body never ran, so nothing was interleaved")
+            XCTAssertEqual(
+                shared.erasesAroundRelease, 1,
+                "dropping the last reference did not run CompiledFunction.deinit, "
+                    + "so no erase was interleaved with the trace")
+            XCTAssertFalse(
+                shared.insideTraceAfterErase,
+                "the compiler-cache erase completed while another thread was still inside "
+                    + "compile_trace -- the erase is not serialized against find/insert")
+
+            XCTAssertEqual(shared.result, 10)
+            withExtendedLifetime(cCompiled) {}
+
+            let counters = EvalLockOwnership.counters
+            XCTAssertGreaterThan(counters.checks, 0)
+            XCTAssertEqual(
+                counters.violations, 0,
+                "the compiler cache was mutated without evalLock held")
+        }
+
+        /// The same hazard without choreography: a stream of `deinit` erases
+        /// against a stream of cold compiles, so erase runs against `find`'s
+        /// `cache_[fun_id]` insert-and-rehash as well as against tracing.
+        ///
+        /// This one is a stress loop, so a pass is not by itself proof.  What it
+        /// adds is that it cannot pass *vacuously*: the counters assert the
+        /// erases happened and that every checked acquisition held `evalLock`.
+        func testConcurrentDeinitErasesAndCompiledCalls() {
+            EvalLockOwnership.resetCounters()
+
+            let rounds = 200
+            let start = DispatchSemaphore(value: 0)
+            let ready = DispatchSemaphore(value: 0)
+            let done = DispatchSemaphore(value: 0)
+
+            final class Outcome: @unchecked Sendable {
+                var callerValues = [Float]()
+                var releases = 0
+            }
+            let outcome = Outcome()
+
+            let caller = Thread {
+                ready.signal()
+                start.wait()
+                var values = [Float]()
+                for i in 0 ..< rounds {
+                    // A fresh compile each round keeps the cache cold, so every
+                    // round really performs an insert.
+                    let compiled = MLX.compile { (x: MLXArray) in x * 2 + MLXArray(Float(i)) }
+                    let r = compiled(MLXArray(Float(1)))
+                    eval(r)
+                    values.append(r.item(Float.self))
+                }
+                outcome.callerValues = values
+                done.signal()
+            }
+
+            let releaser = Thread {
+                ready.signal()
+                start.wait()
+                var released = 0
+                for _ in 0 ..< rounds {
+                    let victim = Victim()
+                    victim.warm()
+                    victim.release()
+                    released += 1
+                }
+                outcome.releases = released
+                done.signal()
+            }
+
+            caller.start()
+            releaser.start()
+            ready.wait()
+            ready.wait()
+            start.signal()
+            start.signal()
+
+            XCTAssertEqual(done.wait(timeout: .now() + 300), .success, "a thread wedged")
+            XCTAssertEqual(done.wait(timeout: .now() + 300), .success, "a thread wedged")
+
+            XCTAssertEqual(outcome.releases, rounds)
+            XCTAssertEqual(outcome.callerValues.count, rounds)
+            // Results must survive the erase traffic: a clobbered cache entry
+            // would show up as a wrong value rather than only as a crash.
+            for (i, value) in outcome.callerValues.enumerated() {
+                XCTAssertEqual(value, Float(2 + i), "round \(i) produced \(value)")
+            }
+
+            XCTAssertGreaterThanOrEqual(
+                EvalLockOwnership.compileErases, rounds,
+                "the deinit erase path was never exercised")
+
+            // Everything compiled here is stateless, so it skips the
+            // per-instance lock: these checks all come from the erase path.
+            let counters = EvalLockOwnership.counters
+            XCTAssertGreaterThan(
+                counters.checks, 0,
+                "no erase was checked for evalLock ownership, so this proves nothing")
+            XCTAssertEqual(
+                counters.violations, 0,
+                "the compiler cache was mutated without evalLock held")
+        }
     }
 
 #endif

--- a/Tests/MLXTests/CompileLockOrderingTests.swift
+++ b/Tests/MLXTests/CompileLockOrderingTests.swift
@@ -1,0 +1,134 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import XCTest
+
+@testable import MLX
+
+// The ownership bookkeeping these tests read is debug-only.
+#if DEBUG
+
+    /// The `evalLock` → `CompiledFunction.lock` ordering invariant.
+    ///
+    /// `Source/CompileLockRepro` shows that the reverse order deadlocks.  It
+    /// lives in its own executable because a failure wedges the process, and a
+    /// passing run of it only shows that the race did not fire -- not that the
+    /// ordering is right.  These tests assert the ordering itself, cannot hang,
+    /// and are safe to run in the shared test process.
+    ///
+    /// A violation trips an `assert` at the point of acquisition, so a
+    /// regression traps there rather than reaching the counter assertions
+    /// below.  The counters are what make a *pass* meaningful: they show the
+    /// check was reached at all, rather than the code path never running.
+    class CompileLockOrderingTests: XCTestCase {
+
+        override class func setUp() {
+            setDefaultDevice()
+        }
+
+        /// The instrumentation must be able to report "not held", otherwise a
+        /// violation count of zero would mean nothing.
+        func testOwnershipTrackingIsNotVacuous() {
+            XCTAssertFalse(EvalLockOwnership.isHeldByCurrentThread)
+            XCTAssertEqual(EvalLockOwnership.depth, 0)
+
+            withEvalLock {
+                XCTAssertTrue(EvalLockOwnership.isHeldByCurrentThread)
+                XCTAssertEqual(EvalLockOwnership.depth, 1)
+
+                // evalLock is recursive; nesting is expected and must be counted
+                withEvalLock {
+                    XCTAssertEqual(EvalLockOwnership.depth, 2)
+                }
+                XCTAssertEqual(EvalLockOwnership.depth, 1)
+            }
+
+            XCTAssertFalse(EvalLockOwnership.isHeldByCurrentThread)
+            XCTAssertEqual(EvalLockOwnership.depth, 0)
+        }
+
+        /// Ownership is per thread: another thread must not believe it holds the
+        /// lock this one is holding.  (The other thread only reads its own
+        /// bookkeeping -- it never waits on `evalLock` -- so this cannot hang.)
+        func testOwnershipIsPerThread() {
+            final class Result: @unchecked Sendable {
+                var heldOnOtherThread = true
+            }
+            let result = Result()
+            let done = DispatchSemaphore(value: 0)
+
+            withEvalLock {
+                let thread = Thread {
+                    result.heldOnOtherThread = EvalLockOwnership.isHeldByCurrentThread
+                    done.signal()
+                }
+                thread.start()
+                XCTAssertEqual(done.wait(timeout: .now() + 10), .success)
+            }
+
+            XCTAssertFalse(result.heldOnOtherThread)
+        }
+
+        /// A compiled function with observed state really takes the per-instance
+        /// lock -- a stateless one has nothing to guard and skips it -- so this
+        /// exercises the checked acquisition.
+        func testEvalLockIsHeldWhenTheInstanceLockIsTaken() {
+            EvalLockOwnership.resetCounters()
+
+            let state = MLXArray(2)
+            func body(_ x: [MLXArray]) -> [MLXArray] {
+                [x[0] + state]
+            }
+            let compiled = compile(inputs: [state], outputs: [state], body(_:))
+
+            let r = compiled([MLXArray(5)])
+            eval(r)
+            XCTAssertEqual(r[0].item(Float.self), 7)
+
+            let counters = EvalLockOwnership.counters
+            XCTAssertGreaterThan(
+                counters.checks, 0,
+                "the ordering invariant was never checked, so this test proves nothing")
+            XCTAssertEqual(
+                counters.violations, 0,
+                "CompiledFunction.lock was taken without evalLock held")
+        }
+
+        /// The deadlock shape, single threaded: one compiled function called
+        /// from inside another's trace.  The nested acquisition happens while an
+        /// outer `evalLock` is already held, which is exactly the ordering the
+        /// invariant describes.
+        func testNestedCompiledCallKeepsTheOrdering() {
+            EvalLockOwnership.resetCounters()
+
+            let innerState = MLXArray(1)
+            func innerBody(_ x: [MLXArray]) -> [MLXArray] {
+                [x[0] * 2 + innerState]
+            }
+            let inner = compile(inputs: [innerState], outputs: [innerState], innerBody(_:))
+
+            let outerState = MLXArray(3)
+            nonisolated(unsafe) var tracedNested = false
+            func outerBody(_ x: [MLXArray]) -> [MLXArray] {
+                tracedNested = true
+                return [inner([x[0]])[0] + outerState]
+            }
+            let outer = compile(inputs: [outerState], outputs: [outerState], outerBody(_:))
+
+            let r = outer([MLXArray(5)])
+            eval(r)
+            XCTAssertEqual(r[0].item(Float.self), 14)
+
+            XCTAssertTrue(
+                tracedNested,
+                "the traced body never ran, so no nested compiled call was exercised")
+
+            let counters = EvalLockOwnership.counters
+            XCTAssertGreaterThan(counters.checks, 0)
+            XCTAssertEqual(
+                counters.violations, 0,
+                "a nested CompiledFunction.lock was taken without evalLock held")
+        }
+    }
+
+#endif


### PR DESCRIPTION
## Summary

Two threads calling compiled functions can deadlock permanently the first time a
trace runs. The per-instance `CompiledFunction.lock` and the process-global
`evalLock` are acquired in opposite orders on different threads. This makes
`evalLock` the outermost lock so there is only one order.

It is not a rare interleaving: with a cold compiler cache and one thread inside
`compile_trace`, any second thread entering a compiled function is enough. The
included reproduction wedges on round 1, every run, on both `.cpu` and `.gpu`.

While establishing that rule the PR also closes the one place that broke it:
`CompiledFunction.deinit` mutated the compiler cache without holding `evalLock`.
That is a data race rather than a deadlock, and it predates both commits below,
but it is the same cache and the same lock, so it is fixed here as its own
commit — see [The compiler-cache erase in `deinit`](#the-compiler-cache-erase-in-deinit).

## The lock graph

`CompiledFunction.call` takes the per-instance `lock`, and then `innerCall`
takes the global `evalLock` and holds it through `mlx_closure_apply`. That gives
**`lock` → `evalLock`**. `evalLock` genuinely has to span that region: the
compiler cache it protects is a process-global singleton with no mutex
(`mlx::core::detail::CompilerCache`, `compile.cpp`), and the tracing flag is not
even per-thread — `detail::InTracing::trace_stack()` is a plain function-local
`static`, not `thread_local` (`transforms.cpp`), so while any thread traces,
`in_tracing()` is true for the whole process. Narrowing `evalLock` is not an
option.

But `mlx_closure_apply` on a cold cache entry runs `compile_trace`, which calls
back into the Swift body being compiled — and that body routinely calls *other*
compiled functions. Every `MLXNN` activation is a file-scope `CompiledFunction`,
so `silu(x)` inside any traced body enters `compiledSilu.call` and takes a second
per-instance lock while `evalLock` is held. That is **`evalLock` → `lock`**. The
two orders are inverted and close a cycle:

```
thread H (nested)                          thread W (plain)
  call(outer)                                call(shared)
    acquire L_cf(outer)                        acquire L_cf(shared)
    acquire evalLock
    mlx_closure_apply -> compile_trace
      -> back into Swift, body calls shared
    want L_cf(shared)  <-- held by W           want evalLock  <-- held by H
```

Note the per-instance lock is taken *unconditionally*, before C++ gets a chance
to short-circuit: `detail::compile` returns `fun(inputs)` immediately when any
input `is_tracer()`, so the nested call would not have touched the cache at all.
The Swift-side lock is the sole cause of the cycle.

This is first-use-only. `compile_trace` runs only when the cache entry is empty,
so once every trace is warm the window closes — and any new shape, dtype, stream
or constant set re-opens it.

## Provenance

Neither commit is wrong on its own; the pair is.

* `1f1f9220` — "CompiledFunction is not thread safe (#226)", Apr 2025 — added the
  per-instance `NSLock` to guard the observed state. Outer lock.
* `b058edaa` — "guard compile and vmap tracing calls (#339)", Jan 2026 — added
  `evalLock.lock()` inside `innerCall` because tracing mutates global state.
  Inner lock. This created the inversion.

`Transforms+Vmap.swift` has the same shape — `evalLock` held across a trace that
calls back into Swift — so it is on the `evalLock` → `lock` side too, and is
consistent with the ordering after this change.

## Reproduction

New executable target `CompileLockRepro` (`Source/CompileLockRepro`). It is a
separate executable on purpose: a wedged round cannot be recovered and would take
a shared test process down with it.

It is deterministic rather than a race that has to be lost:

* fresh `compile()` results per round, so the compiler cache is cold and the
  callback into Swift actually happens;
* a semaphore signalled **from inside the traced body**, so the second thread is
  released only once the first is provably inside `compile_trace` holding
  `evalLock`;
* a `usleep` in that same traced body holding the window open for 200 ms;
* threads owned by the repro, so nothing depends on test-runner parallelism;
* a 10 s per-round deadline, so a hang is a fast hard failure rather than a
  stuck CI job. Exit 1 means deadlock, exit 2 means the trace never ran (e.g.
  `MLX_DISABLE_COMPILE`), so a pass cannot be a false negative.

```
swift build --product CompileLockRepro
.build/debug/CompileLockRepro          # --device cpu|gpu
```

SwiftPM (command line) does not build the Metal shaders and the MLX scheduler
opens a GPU stream when constructed, so a `swift build` product needs an
`mlx.metallib` beside the binary even for `--device cpu`; one built by
`xcodebuild -project xcode/MLX.xcodeproj -scheme MLX` works.

Before:

```
compile-lock repro: device=Device(gpu, 0), 20 rounds, 10s deadline per round
FAIL: round 1: thread H did not complete within 10s.
  ...
  enteredTrace=true
  This is the lock-order inversion; the process is deadlocked.
```

`sample(1)` of the wedged process, 1572/1572 samples in identical frames:

```
Thread H-nested-compiled-call
  CompiledFunction.call                Transforms+Compile.swift:40   holds L_cf(outer)
  CompiledFunction.innerCall           Transforms+Compile.swift:112  holds evalLock (:89)
  mlx_closure_apply -> detail::compile compile.cpp:1180 -> :1126
  detail::compile_trace                compile.cpp:408
  [back into Swift] inner (tracers:)   Transforms+Compile.swift:70
  <traced body> -> CompiledFunction.call  Transforms+Compile.swift:40
  NSLocking.withLock -> __psynch_mutexwait

Thread W-plain-compiled-call
  CompiledFunction.call                Transforms+Compile.swift:40   holds L_cf(shared)
  CompiledFunction.innerCall           Transforms+Compile.swift:89
  -[NSRecursiveLock lock] -> __psynch_mutexwait
```

After: `PASS: 20 rounds completed, no deadlock` (exit 0), on `.cpu` and `.gpu`.

## The fix

Four commits.

**1. Take `evalLock` outermost in `CompiledFunction.call`** and drop the
acquisition inside `innerCall`. One global order, `evalLock` → `lock`, so the
inversion cannot form. `evalLock` is recursive, so the nested acquisition from
inside a trace is free.

The cost is small: `innerCall` already acquired `evalLock` before doing any real
work and held it through `mlx_closure_apply` — that is, across the evaluation
itself — so this widens the held region only by the state gathering and closure
creation at the top of `innerCall`.

`lock` also becomes an `NSRecursiveLock`, so a compiled function whose body
re-enters that same compiled function on one thread no longer self-deadlocks on
a non-recursive `NSLock`.

**2. Skip the per-instance lock when the function has no state.** The
`_updateInternal` swaps in `innerCall` are the only mutation of anything
reachable from `self` — every other stored property is `let` and `id` is written
once at init — so with `inputs` and `outputs` both empty there is nothing for
`lock` to guard, and `evalLock` (held by commit 1) already serializes every
caller. This is the common case: every compiled function in `MLXNN` is stateless.
Optional; the deadlock is fixed without it. Happy to drop it if you would rather
keep the change minimal.

**3. Check the ordering in debug builds.** A passing repro only shows the race
did not fire. `evalLock` is recursive, so a successful `try()` cannot tell "this
thread owns it" from "nobody owns it"; ownership is recorded explicitly instead.
`withEvalLock(_:)` is now the single choke point for `evalLock` and keeps a
per-thread depth (pthread-specific, so the bookkeeping needs no lock of its own —
it runs while holding `evalLock`). `CompiledFunction` acquires its lock through
`withInstanceLock`, which requires that depth to be non-zero. All of it compiles
out of release builds.

Moving the per-instance lock back outside `evalLock` trips it on the first
compiled call, deterministically. Verified by doing exactly that locally:

```
MLX/Transforms+Eval.swift:66: Assertion failed: CompiledFunction.lock was
acquired without holding evalLock; that is the lock-order inversion, see
CompiledFunction.call
```

**4. Erase the compiler cache under `evalLock` in `deinit`.** See below.

## The compiler-cache erase in `deinit`

`CompiledFunction.deinit` called `mlx_detail_compile_erase(id)` with no lock
held. That is `compiler_cache().erase(fun_id)` — a `std::unordered_map::erase` on
the same unguarded process-global cache that `innerCall` reads and inserts into
through `CompilerCache::find`, whose first statement is `cache_[fun_id]` (itself
an insert that can rehash) and whose slow path is `entries.push_back`. Worse,
`find` hands back a *reference* to an entry that the caller then fills in and
reads from across the entire trace and `compile_replace`. An unlocked erase can
rehash the map out from under a concurrent `find`, or destroy the very entry
another thread is compiling into.

This is a pre-existing data race — it is older than either commit in
[Provenance](#provenance) — and it is not the deadlock. It is in this PR because
it is the same cache and the same lock: with commits 1–3 the rule is "every use
of the compiler cache happens under `evalLock`", and `deinit` was the one site
that broke it. Leaving it out would land a debug ordering checker that
deliberately does not check one of the two sites that mutate the cache.

It is commit 4 and touches nothing the first three touch beyond the same file, so
it can be dropped or split without disturbing them.

### `deinit` runs on the releasing thread — what can that thread be holding?

Taking a lock in a `deinit` deserves the enumeration, since `deinit` fires
wherever the last reference happens to be dropped:

* **A thread holding no MLX lock.** It waits for the eval or compiled call in
  flight and then erases. Bounded — `evalLock` is only ever held for the duration
  of one call — but it *is* new blocking; see the note on cost below.
* **A thread already inside a compiled call or an `eval`.** A traced body that
  drops the last reference to some *other* compiled function is the realistic
  case. That thread already holds `evalLock`, which is an `NSRecursiveLock`, so
  the acquisition is free and cannot self-deadlock.
* **A thread holding some `CompiledFunction`'s per-instance `lock`.** After
  commit 1 that implies it holds `evalLock` too, so this is the previous case. No
  new edge is added to the lock graph.
* **A back-end worker thread, while an `evalLock` holder waits for it.** This
  would be a genuine deadlock, and it does not arise: nothing in mlx-swift hands
  a `CompiledFunction` reference to one. The only strong reference is the closure
  returned by `compile(...)`, and the only other retain is the
  `ClosureCaptureState` built by `new_mlx_closure` in `innerCall`, whose
  `mlx_closure_free` runs in that same function's `defer`, on the calling thread,
  with `evalLock` held. Nothing Swift-owned is stored in a `CacheEntry` — on the
  `mlx_detail_compile` path `entry.extra` is always `nullptr` — nor in the tape.
* **Process teardown.** Unchanged in kind: a thread wedged holding `evalLock`
  already hangs `atexit`, which is why the repro uses `_exit`. `MLXNN`'s
  file-scope compiled functions are Swift globals and are not destroyed at exit.

The residual hazard is on the caller's side, and it is worth stating: after this
change, *releasing a compiled function is a call into MLX*. Dropping one while
holding a lock that an `evalLock` holder needs is an inversion, exactly as
calling `eval()` there would be. That is the existing discipline for this library,
but a `nil` assignment advertises it much less loudly than `eval()` does.

### Why the erase stays synchronous

The obvious way to avoid the blocking would be to hand the erase to a queue. That
is not safe here: `id` is the object's own address
(`Unmanaged.passUnretained(self).toOpaque()`), so once the object is freed a new
`CompiledFunction` can be allocated at the same address and receive the same id.
A deferred erase could delete the new function's cache entries. Doing it in
`deinit`, before the memory is released, is what keeps the id unambiguous.

Note also that `detail::compile_erase` has a second caller in `compile.cpp` — the
`shared_ptr` deleter in the public `mlx::core::compile()` — which is likewise
unlocked and can run on any thread. mlx-swift never reaches it (it calls only
`mlx_detail_compile`), so `CompiledFunction.deinit` is the only erase site this
package can fix from Swift. If you would rather have the lock inside
`CompilerCache` itself, that is a change on the C++ side and would cover both.

## Tests

`Tests/MLXTests/CompileLockOrderingTests.swift` — none of these can hang, all are
safe in the shared test process:

* the ownership bookkeeping can report "not held", and is per thread — otherwise
  a violation count of zero would prove nothing;
* a stateful compiled function really reaches the checked acquisition (the
  counters also assert the check ran at all, so a pass is not vacuous);
* the nested case, one compiled function called from inside another's trace;
* **the erase interleaving**: one thread is parked inside `compile_trace` holding
  `evalLock` — it signals a semaphore from inside the traced body and then holds
  the window open — while a second thread drops the last reference to a warmed
  compiled function at that instant. The test asserts that the second thread
  observes the traced body to have *finished* by the time its erase returns,
  which is what "serialized against `find`" means, and that exactly one erase
  happened at that point. Reverting `deinit` to the unlocked form fails it on the
  intended assertion, deterministically:

  ```
  CompileLockOrderingTests.swift:252: error: testDeinitEraseSerializesAgainstATraceInFlight
  XCTAssertFalse failed - the compiler-cache erase completed while another thread
  was still inside compile_trace -- the erase is not serialized against find/insert
  ```

* **the erase under load**: 200 deinit-erases against 200 cold compiles on two
  owned threads, covering the `cache_[fun_id]` insert-and-rehash window as well
  as tracing, asserting the results stay correct and that the erase path ran.

What that pair does and does not establish, plainly: mutual exclusion here is
structural, not statistical. Every `find`/insert is inside `withEvalLock` (from
`call`, the only caller of `innerCall`), and after commit 4 every erase is too;
the tests show the erase path really is reached with `evalLock` held under the
exact interleaving that used to race, and that adding the acquisition does not
wedge. The load test is a stress loop, so a green run of *it* alone is not proof
— which is why its assertions are the counters rather than the absence of a
crash.

No sanitizer run is included. TSan works on this toolchain, but `swift test
--sanitize=thread` rebuilds the ~300 vendored MLX C++ translation units under it,
and at the vendored 0.31.1 it would report the pre-existing unsynchronized
globals in `transforms.cpp` (`trace_stack`, `grad_counter`) throughout, which
buries rather than sharpens the signal for this one line. That reasoning stops
holding after a bump to mlx 0.32.x, where those globals are `thread_local`: with
the background noise gone a TSan run becomes considerably *more* attractive, and
is the natural way to re-check this lane against a bumped core.

`swift test`: **541 → 547 tests, 0 failures** before and after (541 existing on upstream main plus
the 6 new). `CompileLockRepro`: fails on round 1 before, 20/20 rounds after, on
`.cpu` and `.gpu`.

There were previously no concurrency tests in the package
(`grep -rn concurrentPerform Tests/ Source/` is empty), which is presumably why
this went unnoticed.

## Not fixed here

By design rather than by bug: because `evalLock` covers `mlx_closure_apply`,
every compiled call serializes against every other compiled call and every
`eval`/`asyncEval` in the process. This PR does not change that — it only moves
the acquisition a few statements earlier — but it does put a ceiling on
concurrent multi-stream use that is worth being explicit about. Commit 4 extends
the same serialization to the release of a compiled function.

The package vendors mlx 0.31.1, where the compiler cache and the tracing state
are process-global: `CompilerCache` has no mutex and
`detail::InTracing::trace_stack()` is a plain function-local `static` rather than
`thread_local`. `evalLock` is a Swift-side workaround for both, which is why it
has to span the whole trace rather than just the evaluation. That is no longer
the upstream shape. mlx 0.32.0 made the tracing stack, `InTracing::grad_counter`,
`RetainGraph::tracing_counter` and the compiler-cache singleton itself
`thread_local`, and 0.32.1 redesigned the cache — `detail::CompileCache`, an
`unordered_map<uintptr_t, shared_ptr<vector<CacheEntry>>>`, a `find` that returns
the entry reference together with an owning `shared_ptr` that keeps it alive
across the trace, and `compile_erase(const weak_ptr<CompileCache>&, uintptr_t)`
so a deleter erases from the cache of the thread that compiled, or from none at
all if that thread is gone. After a core bump to 0.32.x, `evalLock` would no
longer need to cover the trace for correctness and could shrink back to guarding
evaluation.

None of that supersedes this PR. The lock-order inversion fixed here is entirely
Swift-side — two Swift locks taken in opposite orders on different threads — and
it stands at any core version: a per-thread cache removes the C++ data race but
not the cycle. As context rather than a request, one cost of the thread-local
design is that nothing is reused across threads, so N worker threads pay N traces
and hold N tapes — which is why a shared cache under a mutex would still interest
embedders whose compiled functions are process-wide singletons, as every `MLXNN`
activation is.

Noted separately while reading the same package, and **not fixed in this PR**:
`StreamOrDevice.stream(_:)` (`Source/MLX/Stream.swift:54-56`) discards its
argument — `public static func stream(_ stream: Stream) -> StreamOrDevice { StreamOrDevice(Device.defaultStream()) }`
— so every caller that names a stream explicitly silently gets the device's
default stream instead. It is upstream-report shaped: a one-line fix
(`StreamOrDevice(stream)`), no relationship to the lock inversion, and its own
behavioural blast radius, since any code that has been *relying* on the observed
behaviour would start running where it asked to. Worth filing beside this PR
rather than inside it.

Related issue on ml-explore/mlx: https://github.com/ml-explore/mlx/issues/4377
