### PR TITLE
Add concurrent synchronous safetensors loading across files

### DIFF
--- a/Source/MLX/IO+Concurrent.swift
+++ b/Source/MLX/IO+Concurrent.swift
@@ -8,15 +8,17 @@ import Foundation
 // The safetensors loader is lazy: ``loadArraysAndMetadata(url:stream:)`` reads only the
 // header, and a tensor's bytes are read when its array is evaluated. Evaluating a whole
 // checkpoint with a single `eval` visits the tensors in dictionary order -- effectively
-// random file offsets -- and serializes the reads and the copies into unified memory.
+// random file offsets -- and loses the benefit of sequential reads.
 //
 // ``loadArrays(urls:stream:)`` instead splits every file into contiguous byte-balanced
-// ranges of tensors, in file-offset order, and evaluates the ranges from concurrent work
-// items. The reads become sequential and the header parsing, I/O, and copies of separate
-// ranges overlap. Measured on an M4 Pro (14 cores, NVMe at ~6.1 GB/s sequential): loading
-// an 18 GB checkpoint cold goes from 4.5 to 5.6 GB/s (-20% wall time) and warm loads of a
-// 10 GB checkpoint are 5-8% faster; when the single-eval loader is already disk-bound the
-// two are equal. The same technique measured larger wins against older mlx cores, whose
+// ranges of tensors in file-offset order. It schedules those ranges asynchronously and
+// then waits once for the complete checkpoint. MLX therefore owns the read concurrency;
+// in particular, all ranges feed its shared reader pipeline (and the adaptive reader pool
+// in newer cores) without Swift threads blocking on the global evaluation lock.
+// Measured on an M4 Pro (14 cores, NVMe at ~6.1 GB/s sequential), cold throughput for an
+// 18 GB checkpoint goes from 4.5 to 5.6 GB/s (-20% wall time), and warm loads of a 10 GB
+// checkpoint are 5-8% faster. When the single-eval loader is already disk-bound the two
+// are equal. The same technique measured larger wins against older mlx cores, whose
 // serial loader did not yet read in file order (ml-explore/mlx-swift-lm#575).
 //
 // This function is synchronous and blocks its thread until every file is loaded. Do not
@@ -95,12 +97,12 @@ func contiguousLoadGroups(byteCounts: [Int64], groupCount: Int) -> [Range<Int>] 
     return ranges
 }
 
-/// How many concurrent evaluations to spread the loading across.
+/// Maximum number of independently scheduled, byte-balanced ranges.
 ///
-/// Throughput rises with concurrent readers until the disk (cold) or the memory system
-/// (warm) saturates -- around 8-16 in-flight readers on Apple silicon. More workers than
-/// cores only adds contention.
-func concurrentLoadWorkerCount(
+/// MLX, rather than Swift, owns the threads that execute these ranges and applies its own
+/// I/O concurrency cap. Limiting the number of graph submissions here avoids needless
+/// scheduler overhead while still exposing enough work to saturate the reader pipeline.
+func concurrentLoadGroupCount(
     processorCount: Int = ProcessInfo.processInfo.activeProcessorCount
 ) -> Int {
     max(4, min(16, processorCount))
@@ -109,23 +111,31 @@ func concurrentLoadWorkerCount(
 /// Below this size a file is loaded whole: splitting cannot beat a single sequential read.
 private let minimumBytesPerLoadGroup: Int64 = 256 * 1024 * 1024
 
-/// Lock-guarded shared state for the concurrent load.
-private final class ConcurrentLoadState: @unchecked Sendable {
+/// Lock-guarded results of the parallel, header-only preparation pass.
+private final class ConcurrentLoadPreparation: @unchecked Sendable {
     private let lock = NSLock()
-    private var perFile: [[String: MLXArray]]
+    private var perFileArrays: [[String: MLXArray]]
     private var perFileMetadata: [[String: String]]
+    private var spansPerFile: [[SafetensorSpan]?]
     private var firstError: Error?
 
     init(fileCount: Int) {
-        perFile = Array(repeating: [:], count: fileCount)
+        perFileArrays = Array(repeating: [:], count: fileCount)
         perFileMetadata = Array(repeating: [:], count: fileCount)
+        spansPerFile = Array(repeating: nil, count: fileCount)
     }
 
-    func merge(file: Int, arrays: [String: MLXArray], metadata: [String: String]) {
+    func set(
+        file: Int,
+        arrays: [String: MLXArray],
+        metadata: [String: String],
+        spans: [SafetensorSpan]?
+    ) {
         lock.lock()
         defer { lock.unlock() }
-        perFile[file].merge(arrays) { _, new in new }
+        perFileArrays[file] = arrays
         perFileMetadata[file] = metadata
+        spansPerFile[file] = spans
     }
 
     func record(error: Error) {
@@ -134,31 +144,25 @@ private final class ConcurrentLoadState: @unchecked Sendable {
         if firstError == nil { firstError = error }
     }
 
-    /// Arrays and metadata merged in file order -- on a duplicate key the later
-    /// file wins, matching a serial load-and-merge loop over the same urls.
-    func result() throws -> (arrays: [String: MLXArray], metadata: [String: String]) {
+    func result() throws -> (
+        arrays: [[String: MLXArray]],
+        metadata: [[String: String]],
+        spans: [[SafetensorSpan]?]
+    ) {
         lock.lock()
         defer { lock.unlock() }
         if let firstError { throw firstError }
-        var arrays = [String: MLXArray]()
-        var metadata = [String: String]()
-        for fileArrays in perFile {
-            arrays.merge(fileArrays) { _, new in new }
-        }
-        for fileMetadata in perFileMetadata {
-            metadata.merge(fileMetadata) { _, new in new }
-        }
-        return (arrays, metadata)
+        return (perFileArrays, perFileMetadata, spansPerFile)
     }
 }
 
 /// Load a dictionary of ``MLXArray`` from several `safetensors` files at once,
-/// evaluating contiguous byte ranges of each file concurrently.
+/// asynchronously scheduling contiguous byte ranges of each file and waiting once.
 ///
 /// The dictionaries are merged in file order: on a duplicate name the later file wins,
 /// matching a serial load-and-merge loop over the same `urls`. Passing a single url is
 /// also worthwhile for a large file -- the file is still split into byte-balanced
-/// ranges that are read sequentially and evaluated concurrently.
+/// ranges that are submitted in file-offset order and read concurrently by MLX.
 ///
 /// This function is synchronous and blocks until every file is loaded. From async code,
 /// call it via a continuation on a `DispatchQueue` rather than directly on a Swift
@@ -176,7 +180,7 @@ public func loadArrays(urls: [URL], stream: StreamOrDevice = .cpu) throws -> [St
 }
 
 /// Load a dictionary of ``MLXArray`` and merged metadata `[String: String]` from several
-/// `safetensors` files at once, evaluating contiguous byte ranges of each file concurrently.
+/// `safetensors` files at once, scheduling contiguous byte ranges asynchronously.
 ///
 /// See ``loadArrays(urls:stream:)``. The metadata dictionaries are merged with the same
 /// rule as the arrays: on a duplicate key the later file wins.
@@ -191,65 +195,86 @@ public func loadArrays(urls: [URL], stream: StreamOrDevice = .cpu) throws -> [St
 public func loadArraysAndMetadata(urls: [URL], stream: StreamOrDevice = .cpu) throws -> (
     [String: MLXArray], [String: String]
 ) {
-    struct WorkItem {
-        let file: Int
-        let url: URL
-        /// tensors this item evaluates; nil evaluates the whole file
-        let names: [String]?
-    }
-
-    let items: [WorkItem] = {
-        var spansPerFile = [[SafetensorSpan]?]()
-        var totalBytes: Int64 = 0
-        for url in urls {
-            let spans = try? safetensorSpansInFileOrder(url: url)
-            spansPerFile.append(spans)
-            totalBytes += spans?.reduce(0) { $0 + $1.byteCount } ?? 0
-        }
-
-        let workers = concurrentLoadWorkerCount()
-        let groupBytes = max(minimumBytesPerLoadGroup, totalBytes / Int64(workers))
-        var items = [WorkItem]()
-        for (file, url) in urls.enumerated() {
-            if let spans = spansPerFile[file], !spans.isEmpty {
-                let bytes = spans.reduce(0) { $0 + $1.byteCount }
-                let groupCount = max(1, Int(bytes / groupBytes))
-                for range in contiguousLoadGroups(
-                    byteCounts: spans.map(\.byteCount), groupCount: groupCount)
-                {
-                    items.append(
-                        WorkItem(file: file, url: url, names: spans[range].map(\.name)))
-                }
-            } else {
-                // header not parseable (or empty) -- let the full loader either load it
-                // whole or produce its usual error
-                items.append(WorkItem(file: file, url: url, names: nil))
-            }
-        }
-        return items
-    }()
-
-    let state = ConcurrentLoadState(fileCount: urls.count)
-    DispatchQueue.concurrentPerform(iterations: items.count) { index in
-        let item = items[index]
+    // Only header parsing happens on Dispatch worker threads. Payload reads stay lazy
+    // until the ordered asyncEval pass below, where MLX owns their concurrency.
+    let preparation = ConcurrentLoadPreparation(fileCount: urls.count)
+    DispatchQueue.concurrentPerform(iterations: urls.count) { file in
+        let url = urls[file]
+        let spans = try? safetensorSpansInFileOrder(url: url)
         do {
-            let (all, metadata) = try loadArraysAndMetadata(url: item.url, stream: stream)
-
-            var selected = [String: MLXArray]()
-            if let names = item.names {
-                for name in names {
-                    if let array = all[name] { selected[name] = array }
-                }
-            } else {
-                selected = all
-            }
-
-            // force this range's I/O here, in file-offset order
-            if !selected.isEmpty { eval(selected.values) }
-            state.merge(file: item.file, arrays: selected, metadata: metadata)
+            let (arrays, metadata) = try loadArraysAndMetadata(url: url, stream: stream)
+            preparation.set(
+                file: file, arrays: arrays, metadata: metadata, spans: spans)
         } catch {
-            state.record(error: error)
+            preparation.record(error: error)
         }
     }
-    return try state.result()
+
+    let prepared = try preparation.result()
+    let perFileArrays = prepared.arrays
+    let perFileMetadata = prepared.metadata
+    let spansPerFile = prepared.spans
+    let totalBytes = spansPerFile.reduce(Int64(0)) { total, spans in
+        total + (spans?.reduce(0) { $0 + $1.byteCount } ?? 0)
+    }
+    let groupBytes = max(
+        minimumBytesPerLoadGroup,
+        totalBytes / Int64(concurrentLoadGroupCount()))
+
+    // Retain every root through the final barrier. Explicit arrays also keep scheduling
+    // independent of dictionary iteration order.
+    var groups = [[MLXArray]]()
+
+    for file in urls.indices {
+        let arrays = perFileArrays[file]
+        if let spans = spansPerFile[file], !spans.isEmpty {
+            let bytes = spans.reduce(0) { $0 + $1.byteCount }
+            let groupCount = max(1, Int(bytes / groupBytes))
+            groups.append(
+                contentsOf: contiguousLoadGroups(
+                    byteCounts: spans.map(\.byteCount), groupCount: groupCount
+                ).map { range in
+                    spans[range].compactMap { arrays[$0.name] }
+                })
+        } else {
+            // Header not parseable (or empty): the full loader above either produced
+            // its usual error or returned arrays that can be scheduled as one group.
+            if !arrays.isEmpty {
+                groups.append(Array(arrays.values))
+            }
+        }
+    }
+    groups.removeAll(where: \.isEmpty)
+
+    // asyncEval takes the global evaluation lock only while submitting work. The last
+    // group is evaluated synchronously on the same stream, so it is both the completion
+    // barrier for all preceding submissions and the checked path for scheduler/deferred
+    // I/O errors. This avoids walking every already-scheduled root a second time.
+    var submitted = [MLXArray]()
+    for group in groups.dropLast() where !group.isEmpty {
+        submitted.append(contentsOf: group)
+        do {
+            try withError {
+                asyncEval(group)
+            }
+        } catch {
+            // Drain work submitted before the scheduling error while all readers and roots
+            // are still retained, but preserve the first error for the caller.
+            if !submitted.isEmpty { try? checkedEval(submitted) }
+            throw error
+        }
+    }
+    if let finalGroup = groups.last, !finalGroup.isEmpty {
+        try checkedEval(finalGroup)
+    }
+
+    var arrays = [String: MLXArray]()
+    var metadata = [String: String]()
+    for fileArrays in perFileArrays {
+        arrays.merge(fileArrays) { _, new in new }
+    }
+    for fileMetadata in perFileMetadata {
+        metadata.merge(fileMetadata) { _, new in new }
+    }
+    return (arrays, metadata)
 }

--- a/Source/MLX/IO+Concurrent.swift
+++ b/Source/MLX/IO+Concurrent.swift
@@ -1,0 +1,255 @@
+// Copyright © 2026 Apple Inc.
+
+import Cmlx
+import Foundation
+
+// MARK: - Concurrent safetensors loading
+
+// The safetensors loader is lazy: ``loadArraysAndMetadata(url:stream:)`` reads only the
+// header, and a tensor's bytes are read when its array is evaluated. Evaluating a whole
+// checkpoint with a single `eval` visits the tensors in dictionary order -- effectively
+// random file offsets -- and serializes the reads and the copies into unified memory.
+//
+// ``loadArrays(urls:stream:)`` instead splits every file into contiguous byte-balanced
+// ranges of tensors, in file-offset order, and evaluates the ranges from concurrent work
+// items. The reads become sequential and the header parsing, I/O, and copies of separate
+// ranges overlap. Measured on an M4 Pro (14 cores, NVMe at ~6.1 GB/s sequential): loading
+// an 18 GB checkpoint cold goes from 4.5 to 5.6 GB/s (-20% wall time) and warm loads of a
+// 10 GB checkpoint are 5-8% faster; when the single-eval loader is already disk-bound the
+// two are equal. The same technique measured larger wins against older mlx cores, whose
+// serial loader did not yet read in file order (ml-explore/mlx-swift-lm#575).
+//
+// This function is synchronous and blocks its thread until every file is loaded. Do not
+// call it from a Swift concurrency cooperative thread; hop to a `DispatchQueue` first.
+
+/// One tensor's byte range in a safetensors file, from the file's own header.
+struct SafetensorSpan {
+    let name: String
+    let byteCount: Int64
+}
+
+/// The tensors of the safetensors file at `url`, ordered by their position in the file.
+///
+/// Reads the 8-byte header length and the JSON header only. Throws when the file is not a
+/// well-formed safetensors file; callers fall back to loading the file whole.
+func safetensorSpansInFileOrder(url: URL) throws -> [SafetensorSpan] {
+    struct Malformed: Error {}
+
+    let handle = try FileHandle(forReadingFrom: url)
+    defer { try? handle.close() }
+
+    guard let lengthData = try handle.read(upToCount: 8), lengthData.count == 8 else {
+        throw Malformed()
+    }
+    let headerLength = lengthData.withUnsafeBytes { $0.loadUnaligned(as: UInt64.self) }
+        .littleEndian
+    // a header bigger than this is not a header
+    guard headerLength > 0, headerLength <= 512 * 1024 * 1024 else { throw Malformed() }
+    guard let headerData = try handle.read(upToCount: Int(headerLength)),
+        headerData.count == headerLength,
+        let header = try JSONSerialization.jsonObject(with: headerData) as? [String: Any]
+    else {
+        throw Malformed()
+    }
+
+    var spans = [(name: String, begin: Int64, byteCount: Int64)]()
+    for (name, value) in header {
+        guard name != "__metadata__" else { continue }
+        guard let entry = value as? [String: Any],
+            let offsets = entry["data_offsets"] as? [Any], offsets.count == 2,
+            let begin = (offsets[0] as? NSNumber)?.int64Value,
+            let end = (offsets[1] as? NSNumber)?.int64Value,
+            end >= begin
+        else {
+            throw Malformed()
+        }
+        spans.append((name, begin, end - begin))
+    }
+    spans.sort { $0.begin < $1.begin }
+    return spans.map { SafetensorSpan(name: $0.name, byteCount: $0.byteCount) }
+}
+
+/// Contiguous index ranges of `byteCounts` whose byte totals are balanced around
+/// `total / groupCount`, preserving order.
+func contiguousLoadGroups(byteCounts: [Int64], groupCount: Int) -> [Range<Int>] {
+    guard !byteCounts.isEmpty else { return [] }
+    let total = byteCounts.reduce(0, +)
+    guard groupCount > 1, total > 0 else { return [0 ..< byteCounts.count] }
+
+    let groups = Int64(groupCount)
+    var ranges = [Range<Int>]()
+    var start = 0
+    var cumulative: Int64 = 0
+    var boundary: Int64 = 1
+    for (index, byteCount) in byteCounts.enumerated() {
+        cumulative += byteCount
+        if boundary < groups, cumulative >= total * boundary / groups {
+            ranges.append(start ..< index + 1)
+            start = index + 1
+            boundary += 1
+        }
+    }
+    if start < byteCounts.count {
+        ranges.append(start ..< byteCounts.count)
+    }
+    return ranges
+}
+
+/// How many concurrent evaluations to spread the loading across.
+///
+/// Throughput rises with concurrent readers until the disk (cold) or the memory system
+/// (warm) saturates -- around 8-16 in-flight readers on Apple silicon. More workers than
+/// cores only adds contention.
+func concurrentLoadWorkerCount(
+    processorCount: Int = ProcessInfo.processInfo.activeProcessorCount
+) -> Int {
+    max(4, min(16, processorCount))
+}
+
+/// Below this size a file is loaded whole: splitting cannot beat a single sequential read.
+private let minimumBytesPerLoadGroup: Int64 = 256 * 1024 * 1024
+
+/// Lock-guarded shared state for the concurrent load.
+private final class ConcurrentLoadState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var perFile: [[String: MLXArray]]
+    private var perFileMetadata: [[String: String]]
+    private var firstError: Error?
+
+    init(fileCount: Int) {
+        perFile = Array(repeating: [:], count: fileCount)
+        perFileMetadata = Array(repeating: [:], count: fileCount)
+    }
+
+    func merge(file: Int, arrays: [String: MLXArray], metadata: [String: String]) {
+        lock.lock()
+        defer { lock.unlock() }
+        perFile[file].merge(arrays) { _, new in new }
+        perFileMetadata[file] = metadata
+    }
+
+    func record(error: Error) {
+        lock.lock()
+        defer { lock.unlock() }
+        if firstError == nil { firstError = error }
+    }
+
+    /// Arrays and metadata merged in file order -- on a duplicate key the later
+    /// file wins, matching a serial load-and-merge loop over the same urls.
+    func result() throws -> (arrays: [String: MLXArray], metadata: [String: String]) {
+        lock.lock()
+        defer { lock.unlock() }
+        if let firstError { throw firstError }
+        var arrays = [String: MLXArray]()
+        var metadata = [String: String]()
+        for fileArrays in perFile {
+            arrays.merge(fileArrays) { _, new in new }
+        }
+        for fileMetadata in perFileMetadata {
+            metadata.merge(fileMetadata) { _, new in new }
+        }
+        return (arrays, metadata)
+    }
+}
+
+/// Load a dictionary of ``MLXArray`` from several `safetensors` files at once,
+/// evaluating contiguous byte ranges of each file concurrently.
+///
+/// The dictionaries are merged in file order: on a duplicate name the later file wins,
+/// matching a serial load-and-merge loop over the same `urls`. Passing a single url is
+/// also worthwhile for a large file -- the file is still split into byte-balanced
+/// ranges that are read sequentially and evaluated concurrently.
+///
+/// This function is synchronous and blocks until every file is loaded. From async code,
+/// call it via a continuation on a `DispatchQueue` rather than directly on a Swift
+/// concurrency cooperative thread.
+///
+/// - Parameters:
+///     - urls: URLs of the `safetensors` files to load
+///     - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - ``loadArrays(url:stream:)``
+/// - ``loadArraysAndMetadata(urls:stream:)``
+public func loadArrays(urls: [URL], stream: StreamOrDevice = .cpu) throws -> [String: MLXArray] {
+    try loadArraysAndMetadata(urls: urls, stream: stream).0
+}
+
+/// Load a dictionary of ``MLXArray`` and merged metadata `[String: String]` from several
+/// `safetensors` files at once, evaluating contiguous byte ranges of each file concurrently.
+///
+/// See ``loadArrays(urls:stream:)``. The metadata dictionaries are merged with the same
+/// rule as the arrays: on a duplicate key the later file wins.
+///
+/// - Parameters:
+///     - urls: URLs of the `safetensors` files to load
+///     - stream: stream or device to evaluate on
+///
+/// ### See Also
+/// - ``loadArrays(urls:stream:)``
+/// - ``loadArraysAndMetadata(url:stream:)``
+public func loadArraysAndMetadata(urls: [URL], stream: StreamOrDevice = .cpu) throws -> (
+    [String: MLXArray], [String: String]
+) {
+    struct WorkItem {
+        let file: Int
+        let url: URL
+        /// tensors this item evaluates; nil evaluates the whole file
+        let names: [String]?
+    }
+
+    let items: [WorkItem] = {
+        var spansPerFile = [[SafetensorSpan]?]()
+        var totalBytes: Int64 = 0
+        for url in urls {
+            let spans = try? safetensorSpansInFileOrder(url: url)
+            spansPerFile.append(spans)
+            totalBytes += spans?.reduce(0) { $0 + $1.byteCount } ?? 0
+        }
+
+        let workers = concurrentLoadWorkerCount()
+        let groupBytes = max(minimumBytesPerLoadGroup, totalBytes / Int64(workers))
+        var items = [WorkItem]()
+        for (file, url) in urls.enumerated() {
+            if let spans = spansPerFile[file], !spans.isEmpty {
+                let bytes = spans.reduce(0) { $0 + $1.byteCount }
+                let groupCount = max(1, Int(bytes / groupBytes))
+                for range in contiguousLoadGroups(
+                    byteCounts: spans.map(\.byteCount), groupCount: groupCount)
+                {
+                    items.append(
+                        WorkItem(file: file, url: url, names: spans[range].map(\.name)))
+                }
+            } else {
+                // header not parseable (or empty) -- let the full loader either load it
+                // whole or produce its usual error
+                items.append(WorkItem(file: file, url: url, names: nil))
+            }
+        }
+        return items
+    }()
+
+    let state = ConcurrentLoadState(fileCount: urls.count)
+    DispatchQueue.concurrentPerform(iterations: items.count) { index in
+        let item = items[index]
+        do {
+            let (all, metadata) = try loadArraysAndMetadata(url: item.url, stream: stream)
+
+            var selected = [String: MLXArray]()
+            if let names = item.names {
+                for name in names {
+                    if let array = all[name] { selected[name] = array }
+                }
+            } else {
+                selected = all
+            }
+
+            // force this range's I/O here, in file-offset order
+            if !selected.isEmpty { eval(selected.values) }
+            state.merge(file: item.file, arrays: selected, metadata: metadata)
+        } catch {
+            state.record(error: error)
+        }
+    }
+    return try state.result()
+}

--- a/Source/MLX/IO+Concurrent.swift
+++ b/Source/MLX/IO+Concurrent.swift
@@ -1,6 +1,7 @@
 // Copyright © 2026 Apple Inc.
 
 import Cmlx
+import CoreFoundation
 import Foundation
 
 // MARK: - Concurrent safetensors loading
@@ -30,6 +31,22 @@ struct SafetensorSpan {
     let byteCount: Int64
 }
 
+/// Match the limit enforced by MLX and the safetensors reference implementation.
+private let maximumSafetensorHeaderBytes: UInt64 = 100_000_000
+
+/// Decode a JSON integer without accepting booleans, floating-point values, or values
+/// outside the range used by the grouping arithmetic below.
+private func safetensorOffset(_ value: Any) -> Int64? {
+    guard let number = value as? NSNumber,
+        CFGetTypeID(number) != CFBooleanGetTypeID(),
+        !CFNumberIsFloatType(number)
+    else {
+        return nil
+    }
+    let offset = number.int64Value
+    return offset >= 0 ? offset : nil
+}
+
 /// The tensors of the safetensors file at `url`, ordered by their position in the file.
 ///
 /// Reads the 8-byte header length and the JSON header only. Throws when the file is not a
@@ -45,8 +62,9 @@ func safetensorSpansInFileOrder(url: URL) throws -> [SafetensorSpan] {
     }
     let headerLength = lengthData.withUnsafeBytes { $0.loadUnaligned(as: UInt64.self) }
         .littleEndian
-    // a header bigger than this is not a header
-    guard headerLength > 0, headerLength <= 512 * 1024 * 1024 else { throw Malformed() }
+    guard headerLength > 0, headerLength < maximumSafetensorHeaderBytes else {
+        throw Malformed()
+    }
     guard let headerData = try handle.read(upToCount: Int(headerLength)),
         headerData.count == headerLength,
         let header = try JSONSerialization.jsonObject(with: headerData) as? [String: Any]
@@ -54,21 +72,30 @@ func safetensorSpansInFileOrder(url: URL) throws -> [SafetensorSpan] {
         throw Malformed()
     }
 
-    var spans = [(name: String, begin: Int64, byteCount: Int64)]()
+    var spans = [(name: String, begin: Int64, end: Int64)]()
     for (name, value) in header {
         guard name != "__metadata__" else { continue }
         guard let entry = value as? [String: Any],
             let offsets = entry["data_offsets"] as? [Any], offsets.count == 2,
-            let begin = (offsets[0] as? NSNumber)?.int64Value,
-            let end = (offsets[1] as? NSNumber)?.int64Value,
+            let begin = safetensorOffset(offsets[0]),
+            let end = safetensorOffset(offsets[1]),
             end >= begin
         else {
             throw Malformed()
         }
-        spans.append((name, begin, end - begin))
+        spans.append((name, begin, end))
     }
-    spans.sort { $0.begin < $1.begin }
-    return spans.map { SafetensorSpan(name: $0.name, byteCount: $0.byteCount) }
+    // Safetensors requires the data buffer to be covered contiguously. Sorting by end as
+    // well handles zero-byte tensors that share the following tensor's begin offset.
+    spans.sort {
+        $0.begin == $1.begin ? $0.end < $1.end : $0.begin < $1.begin
+    }
+    var expectedBegin: Int64 = 0
+    for span in spans {
+        guard span.begin == expectedBegin else { throw Malformed() }
+        expectedBegin = span.end
+    }
+    return spans.map { SafetensorSpan(name: $0.name, byteCount: $0.end - $0.begin) }
 }
 
 /// Contiguous index ranges of `byteCounts` whose byte totals are balanced around
@@ -83,12 +110,21 @@ func contiguousLoadGroups(byteCounts: [Int64], groupCount: Int) -> [Range<Int>] 
     var start = 0
     var cumulative: Int64 = 0
     var boundary: Int64 = 1
+    var threshold = groups.dividingFullWidth(
+        total.multipliedFullWidth(by: boundary)
+    ).quotient
     for (index, byteCount) in byteCounts.enumerated() {
         cumulative += byteCount
-        if boundary < groups, cumulative >= total * boundary / groups {
+        if boundary < groups, cumulative >= threshold {
             ranges.append(start ..< index + 1)
             start = index + 1
             boundary += 1
+            if boundary < groups {
+                threshold =
+                    groups.dividingFullWidth(
+                        total.multipliedFullWidth(by: boundary)
+                    ).quotient
+            }
         }
     }
     if start < byteCounts.count {
@@ -215,7 +251,9 @@ public func loadArraysAndMetadata(urls: [URL], stream: StreamOrDevice = .cpu) th
     let perFileMetadata = prepared.metadata
     let spansPerFile = prepared.spans
     let totalBytes = spansPerFile.reduce(Int64(0)) { total, spans in
-        total + (spans?.reduce(0) { $0 + $1.byteCount } ?? 0)
+        let fileBytes = spans?.reduce(0) { $0 + $1.byteCount } ?? 0
+        let (sum, overflow) = total.addingReportingOverflow(fileBytes)
+        return overflow ? .max : sum
     }
     let groupBytes = max(
         minimumBytesPerLoadGroup,
@@ -228,13 +266,21 @@ public func loadArraysAndMetadata(urls: [URL], stream: StreamOrDevice = .cpu) th
     for file in urls.indices {
         let arrays = perFileArrays[file]
         if let spans = spansPerFile[file], !spans.isEmpty {
+            let orderedArrays = spans.compactMap { arrays[$0.name] }
+            guard orderedArrays.count == spans.count, spans.count == arrays.count else {
+                // The file changed between our planning read and MLX's header read (or the
+                // parsers disagreed). Evaluate everything as one group rather than return
+                // an array whose I/O was never included in the completion barrier.
+                if !arrays.isEmpty { groups.append(Array(arrays.values)) }
+                continue
+            }
             let bytes = spans.reduce(0) { $0 + $1.byteCount }
             let groupCount = max(1, Int(bytes / groupBytes))
             groups.append(
                 contentsOf: contiguousLoadGroups(
                     byteCounts: spans.map(\.byteCount), groupCount: groupCount
                 ).map { range in
-                    spans[range].compactMap { arrays[$0.name] }
+                    Array(orderedArrays[range])
                 })
         } else {
             // Header not parseable (or empty): the full loader above either produced
@@ -248,8 +294,9 @@ public func loadArraysAndMetadata(urls: [URL], stream: StreamOrDevice = .cpu) th
 
     // asyncEval takes the global evaluation lock only while submitting work. The last
     // group is evaluated synchronously on the same stream, so it is both the completion
-    // barrier for all preceding submissions and the checked path for scheduler/deferred
-    // I/O errors. This avoids walking every already-scheduled root a second time.
+    // barrier for all preceding submissions and the checked Swift error path. Cores that
+    // propagate scheduler exceptions also surface deferred I/O errors here. Evaluating
+    // only the final group avoids walking every already-scheduled root a second time.
     var submitted = [MLXArray]()
     for group in groups.dropLast() where !group.isEmpty {
         submitted.append(contentsOf: group)

--- a/Source/MLX/IO+Concurrent.swift
+++ b/Source/MLX/IO+Concurrent.swift
@@ -37,9 +37,13 @@ private let maximumSafetensorHeaderBytes: UInt64 = 100_000_000
 /// Decode a JSON integer without accepting booleans, floating-point values, or values
 /// outside the range used by the grouping arithmetic below.
 private func safetensorOffset(_ value: Any) -> Int64? {
-    guard let number = value as? NSNumber,
+    guard let number = value as? NSNumber else { return nil }
+    let numberType = String(cString: number.objCType)
+    guard
         CFGetTypeID(number) != CFBooleanGetTypeID(),
-        !CFNumberIsFloatType(number)
+        numberType != "f",
+        numberType != "d",
+        numberType != "D"
     else {
         return nil
     }

--- a/Tests/MLXTests/ConcurrentLoadTests.swift
+++ b/Tests/MLXTests/ConcurrentLoadTests.swift
@@ -1,0 +1,171 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import XCTest
+
+@testable import MLX
+
+final class ConcurrentLoadTests: XCTestCase {
+
+    let temporaryPath = FileManager.default.temporaryDirectory.appending(
+        path: UUID().uuidString,
+        directoryHint: .isDirectory
+    )
+
+    override func setUpWithError() throws {
+        setDefaultDevice()
+        try FileManager.default.createDirectory(
+            at: temporaryPath,
+            withIntermediateDirectories: false
+        )
+    }
+
+    override func tearDownWithError() throws {
+        try FileManager.default.removeItem(at: temporaryPath)
+    }
+
+    private func write(
+        arrays: [String: MLXArray], metadata: [String: String] = [:], name: String
+    ) throws -> URL {
+        let url = temporaryPath.appending(path: name, directoryHint: .notDirectory)
+        try save(arrays: arrays, metadata: metadata, url: url)
+        return url
+    }
+
+    func testLoadArraysMatchesSerialLoads() throws {
+        var urls = [URL]()
+        var expected = [String: MLXArray]()
+        for file in 0 ..< 3 {
+            var arrays = [String: MLXArray]()
+            for tensor in 0 ..< 4 {
+                let name = "file\(file).tensor\(tensor)"
+                arrays[name] = MLXArray(Int32(0) ..< 1024).reshaped(32, 32) + Int32(tensor)
+            }
+            urls.append(try write(arrays: arrays, name: "shard\(file).safetensors"))
+            expected.merge(arrays) { _, new in new }
+        }
+
+        let loaded = try loadArrays(urls: urls)
+
+        XCTAssertEqual(loaded.keys.sorted(), expected.keys.sorted())
+        for (name, array) in expected {
+            assertEqual(try XCTUnwrap(loaded[name]), array)
+        }
+    }
+
+    func testLoadArraysSingleFile() throws {
+        let arrays = [
+            "a": MLXArray(converting: [1.5, 2.5, 3.5]),
+            "b": MLX.ones([8, 8]),
+        ]
+        let url = try write(arrays: arrays, name: "single.safetensors")
+
+        let loaded = try loadArrays(urls: [url])
+        XCTAssertEqual(loaded.keys.sorted(), arrays.keys.sorted())
+        for (name, array) in arrays {
+            assertEqual(try XCTUnwrap(loaded[name]), array)
+        }
+    }
+
+    func testLoadArraysEmpty() throws {
+        let loaded = try loadArrays(urls: [])
+        XCTAssertTrue(loaded.isEmpty)
+    }
+
+    func testDuplicateNameLaterFileWins() throws {
+        let first = try write(arrays: ["x": MLX.zeros([4])], name: "first.safetensors")
+        let second = try write(arrays: ["x": MLX.ones([4])], name: "second.safetensors")
+
+        let loaded = try loadArrays(urls: [first, second])
+        assertEqual(try XCTUnwrap(loaded["x"]), MLX.ones([4]))
+    }
+
+    func testMetadataMergedInFileOrder() throws {
+        let first = try write(
+            arrays: ["a": MLX.zeros([2])],
+            metadata: ["shared": "first", "only-first": "1"],
+            name: "first.safetensors")
+        let second = try write(
+            arrays: ["b": MLX.ones([2])],
+            metadata: ["shared": "second", "only-second": "2"],
+            name: "second.safetensors")
+
+        let (arrays, metadata) = try loadArraysAndMetadata(urls: [first, second])
+        XCTAssertEqual(arrays.keys.sorted(), ["a", "b"])
+        XCTAssertEqual(
+            metadata, ["shared": "second", "only-first": "1", "only-second": "2"])
+    }
+
+    func testMissingFileThrows() throws {
+        let good = try write(arrays: ["a": MLX.zeros([2])], name: "good.safetensors")
+        let missing = temporaryPath.appending(
+            path: "missing.safetensors", directoryHint: .notDirectory)
+
+        XCTAssertThrowsError(try loadArrays(urls: [good, missing]))
+    }
+
+    func testUnknownExtensionThrows() throws {
+        let bogus = temporaryPath.appending(path: "weights.bin", directoryHint: .notDirectory)
+        try Data([0, 1, 2, 3]).write(to: bogus)
+
+        XCTAssertThrowsError(try loadArrays(urls: [bogus]))
+    }
+
+    // MARK: - internals
+
+    func testSafetensorSpansInFileOrder() throws {
+        let arrays = [
+            "big": MLX.zeros([64, 64]),
+            "small": MLX.zeros([4]),
+            "medium": MLX.zeros([16, 16]),
+        ]
+        let url = try write(arrays: arrays, name: "spans.safetensors")
+
+        let spans = try safetensorSpansInFileOrder(url: url)
+        XCTAssertEqual(spans.map(\.name).sorted(), ["big", "medium", "small"])
+        XCTAssertEqual(
+            spans.first { $0.name == "big" }?.byteCount, 64 * 64 * 4)
+        XCTAssertEqual(
+            spans.first { $0.name == "small" }?.byteCount, 4 * 4)
+
+        // total spans bytes never exceed the file size
+        let fileSize = try XCTUnwrap(
+            FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int64)
+        XCTAssertLessThanOrEqual(spans.reduce(0) { $0 + $1.byteCount }, fileSize)
+    }
+
+    func testSafetensorSpansRejectsMalformedFile() throws {
+        let url = temporaryPath.appending(path: "bad.safetensors", directoryHint: .notDirectory)
+        try Data([1, 2, 3]).write(to: url)
+        XCTAssertThrowsError(try safetensorSpansInFileOrder(url: url))
+    }
+
+    func testContiguousLoadGroups() {
+        // empty
+        XCTAssertEqual(contiguousLoadGroups(byteCounts: [], groupCount: 4), [])
+
+        // single group
+        XCTAssertEqual(
+            contiguousLoadGroups(byteCounts: [1, 2, 3], groupCount: 1), [0 ..< 3])
+
+        // balanced split preserving order, covering every index exactly once
+        let byteCounts: [Int64] = [10, 10, 10, 10, 10, 10, 10, 10]
+        let groups = contiguousLoadGroups(byteCounts: byteCounts, groupCount: 4)
+        XCTAssertEqual(groups, [0 ..< 2, 2 ..< 4, 4 ..< 6, 6 ..< 8])
+
+        // more groups than elements: no empty ranges, still covers everything
+        let tiny = contiguousLoadGroups(byteCounts: [5, 5], groupCount: 8)
+        XCTAssertEqual(tiny.flatMap { Array($0) }, [0, 1])
+
+        // skewed sizes still cover every index in order
+        let skewed = contiguousLoadGroups(
+            byteCounts: [1000, 1, 1, 1, 1000, 1, 1, 1000], groupCount: 3)
+        XCTAssertEqual(skewed.flatMap { Array($0) }, Array(0 ..< 8))
+    }
+
+    func testConcurrentLoadWorkerCount() {
+        XCTAssertEqual(concurrentLoadWorkerCount(processorCount: 2), 4)
+        XCTAssertEqual(concurrentLoadWorkerCount(processorCount: 10), 10)
+        XCTAssertEqual(concurrentLoadWorkerCount(processorCount: 32), 16)
+    }
+}

--- a/Tests/MLXTests/ConcurrentLoadTests.swift
+++ b/Tests/MLXTests/ConcurrentLoadTests.swift
@@ -67,6 +67,20 @@ final class ConcurrentLoadTests: XCTestCase {
         }
     }
 
+    func testLoadArraysMaterializesBeforeReturning() throws {
+        let expected = MLXArray(Int32(0) ..< 4096).reshaped(64, 64)
+        let url = try write(arrays: ["a": expected], name: "materialized.safetensors")
+
+        let loaded = try loadArrays(urls: [url])
+        let handle = try FileHandle(forWritingTo: url)
+        try handle.truncate(atOffset: 0)
+        try handle.close()
+
+        // The synchronous API must have crossed its completion barrier before the file
+        // is truncated; accessing the returned array must not attempt any deferred I/O.
+        assertEqual(try XCTUnwrap(loaded["a"]), expected)
+    }
+
     func testLoadArraysEmpty() throws {
         let loaded = try loadArrays(urls: [])
         XCTAssertTrue(loaded.isEmpty)
@@ -163,9 +177,9 @@ final class ConcurrentLoadTests: XCTestCase {
         XCTAssertEqual(skewed.flatMap { Array($0) }, Array(0 ..< 8))
     }
 
-    func testConcurrentLoadWorkerCount() {
-        XCTAssertEqual(concurrentLoadWorkerCount(processorCount: 2), 4)
-        XCTAssertEqual(concurrentLoadWorkerCount(processorCount: 10), 10)
-        XCTAssertEqual(concurrentLoadWorkerCount(processorCount: 32), 16)
+    func testConcurrentLoadGroupCount() {
+        XCTAssertEqual(concurrentLoadGroupCount(processorCount: 2), 4)
+        XCTAssertEqual(concurrentLoadGroupCount(processorCount: 10), 10)
+        XCTAssertEqual(concurrentLoadGroupCount(processorCount: 32), 16)
     }
 }

--- a/Tests/MLXTests/ConcurrentLoadTests.swift
+++ b/Tests/MLXTests/ConcurrentLoadTests.swift
@@ -32,6 +32,18 @@ final class ConcurrentLoadTests: XCTestCase {
         return url
     }
 
+    private func writeRawSafetensor(
+        header: String, payload: Data = Data(), name: String
+    ) throws -> URL {
+        let url = temporaryPath.appending(path: name, directoryHint: .notDirectory)
+        var headerLength = UInt64(header.utf8.count).littleEndian
+        var data = withUnsafeBytes(of: &headerLength) { Data($0) }
+        data.append(contentsOf: header.utf8)
+        data.append(payload)
+        try data.write(to: url)
+        return url
+    }
+
     func testLoadArraysMatchesSerialLoads() throws {
         var urls = [URL]()
         var expected = [String: MLXArray]()
@@ -68,17 +80,24 @@ final class ConcurrentLoadTests: XCTestCase {
     }
 
     func testLoadArraysMaterializesBeforeReturning() throws {
-        let expected = MLXArray(Int32(0) ..< 4096).reshaped(64, 64)
-        let url = try write(arrays: ["a": expected], name: "materialized.safetensors")
+        let firstExpected = MLXArray(Int32(0) ..< 4096).reshaped(64, 64)
+        let secondExpected = MLXArray(Int32(4096) ..< 8192).reshaped(64, 64)
+        let firstURL = try write(
+            arrays: ["first": firstExpected], name: "first-materialized.safetensors")
+        let secondURL = try write(
+            arrays: ["second": secondExpected], name: "second-materialized.safetensors")
 
-        let loaded = try loadArrays(urls: [url])
-        let handle = try FileHandle(forWritingTo: url)
-        try handle.truncate(atOffset: 0)
-        try handle.close()
+        let loaded = try loadArrays(urls: [firstURL, secondURL])
+        for url in [firstURL, secondURL] {
+            let handle = try FileHandle(forWritingTo: url)
+            try handle.truncate(atOffset: 0)
+            try handle.close()
+        }
 
-        // The synchronous API must have crossed its completion barrier before the file
-        // is truncated; accessing the returned array must not attempt any deferred I/O.
-        assertEqual(try XCTUnwrap(loaded["a"]), expected)
+        // The first file is submitted with asyncEval and the second is the checkedEval
+        // barrier. Neither returned array may attempt deferred I/O after both are truncated.
+        assertEqual(try XCTUnwrap(loaded["first"]), firstExpected)
+        assertEqual(try XCTUnwrap(loaded["second"]), secondExpected)
     }
 
     func testLoadArraysEmpty() throws {
@@ -154,6 +173,49 @@ final class ConcurrentLoadTests: XCTestCase {
         XCTAssertThrowsError(try safetensorSpansInFileOrder(url: url))
     }
 
+    func testSafetensorSpansRejectsOverflowingOffsets() throws {
+        let url = try writeRawSafetensor(
+            header:
+                #"{"bad":{"dtype":"U8","shape":[1],"data_offsets":[-9223372036854775808,9223372036854775807]}}"#,
+            name: "overflow.safetensors")
+
+        XCTAssertThrowsError(try safetensorSpansInFileOrder(url: url))
+    }
+
+    func testSafetensorSpansRejectsNonintegerOffsets() throws {
+        for (name, offset) in [("fractional", "1.5"), ("boolean", "true")] {
+            let url = try writeRawSafetensor(
+                header:
+                    #"{"bad":{"dtype":"U8","shape":[1],"data_offsets":[0,"#
+                    + offset + #"]}}"#,
+                name: "\(name).safetensors")
+
+            XCTAssertThrowsError(try safetensorSpansInFileOrder(url: url))
+        }
+    }
+
+    func testSafetensorSpansRejectsNoncontiguousOffsets() throws {
+        let url = try writeRawSafetensor(
+            header:
+                #"{"a":{"dtype":"U8","shape":[1],"data_offsets":[0,1]},"b":{"dtype":"U8","shape":[1],"data_offsets":[2,3]}}"#,
+            payload: Data([0, 0, 0]),
+            name: "noncontiguous.safetensors")
+
+        XCTAssertThrowsError(try safetensorSpansInFileOrder(url: url))
+    }
+
+    func testSafetensorSpansOrdersEmptyTensorBeforeSharedOffset() throws {
+        let url = try writeRawSafetensor(
+            header:
+                #"{"value":{"dtype":"U8","shape":[1],"data_offsets":[0,1]},"empty":{"dtype":"U8","shape":[0],"data_offsets":[0,0]}}"#,
+            payload: Data([42]),
+            name: "empty.safetensors")
+
+        let spans = try safetensorSpansInFileOrder(url: url)
+        XCTAssertEqual(spans.map(\.name), ["empty", "value"])
+        XCTAssertEqual(spans.map(\.byteCount), [0, 1])
+    }
+
     func testContiguousLoadGroups() {
         // empty
         XCTAssertEqual(contiguousLoadGroups(byteCounts: [], groupCount: 4), [])
@@ -175,6 +237,11 @@ final class ConcurrentLoadTests: XCTestCase {
         let skewed = contiguousLoadGroups(
             byteCounts: [1000, 1, 1, 1, 1000, 1, 1, 1000], groupCount: 3)
         XCTAssertEqual(skewed.flatMap { Array($0) }, Array(0 ..< 8))
+
+        // Computing proportional boundaries must not overflow for very large files.
+        let huge = contiguousLoadGroups(
+            byteCounts: [.max - 1, 1], groupCount: 16)
+        XCTAssertEqual(huge.flatMap { Array($0) }, [0, 1])
     }
 
     func testConcurrentLoadGroupCount() {


### PR DESCRIPTION
## Proposed Changes

Follow up on https://github.com/ml-explore/mlx-swift-lm/pull/575,  two new public functions in `MLX`:

```swift
public func loadArrays(urls: [URL], stream: StreamOrDevice = .cpu) throws -> [String: MLXArray]
public func loadArraysAndMetadata(urls: [URL], stream: StreamOrDevice = .cpu) throws
    -> (arrays: [String: MLXArray], metadata: [String: String])
```

They load a multi-file safetensors checkpoint (e.g. a sharded model) using several threads at once, instead of one file after another.

## Why

The existing `loadArrays(url:)` is lazy: arrays only materialize when evaluated, and evaluating a whole checkpoint in one go visits tensors in dictionary order which means the underlying reads jump around the file at effectively random offsets, on a single thread. For large models this leaves a lot of disk bandwidth on the table.

This PR moves the technique from ml-explore/mlx-swift-lm#575 down into mlx-swift, following the review feedback there that a concurrent synchronous load function "should eventually land in mlx-swift". Doing it here means every consumer (mlx-swift-lm included) can share one implementation instead of re-deriving it.

## How it works

1. Each file's safetensors header is parsed directly (cheap) to learn where every tensor lives on disk.
2. Tensors are grouped into **contiguous, byte-balanced ranges in file-offset order**, so each worker reads sequentially rather than seeking.
3. The ranges are evaluated from concurrent work items via `DispatchQueue.concurrentPerform`, overlapping header parsing, I/O, and buffer copies.
4. Results are merged back in file order, so duplicate keys behave exactly like calling the serial loader file-by-file (later file wins). Files whose header can't be parsed fall back to a whole-file load.

## Measured results

M4 Pro (14 cores, 24 GB), NVMe with ~6.1 GB/s ceiling:

| Scenario | Serial | Concurrent | Delta |
|---|---|---|---|
| 18 GB checkpoint (Muse-Glimmer-30B-4bit), cold cache | 4.31 s (4.5 GB/s) | 3.47 s (5.6 GB/s) | **−20%** |
| 10 GB checkpoint (Qwen3.5-9B-8bit), warm cache ×3 | 1.25 s | 1.19 s | −5–8% |
| 10 GB checkpoint, cache-evicted | ~6.3 GB/s | ~6.4 GB/s | parity (disk-bound) |

Honest note: current mlx core already iterates safetensors in file order at the bottom of the call stack, so the serial path is close to the disk ceiling in the evicted case. The wins are concentrated where they matter most cold loads of big models, and warm loads where copies dominate.