### PR TITLE
Fix StreamOrDevice.stream(_:) ignoring its argument

### DIFF
--- a/Source/MLX/Stream.swift
+++ b/Source/MLX/Stream.swift
@@ -52,7 +52,7 @@ public struct StreamOrDevice: Sendable, CustomStringConvertible, Equatable {
     public static let gpu = device(.gpu)
 
     public static func stream(_ stream: Stream) -> StreamOrDevice {
-        StreamOrDevice(Device.defaultStream())
+        StreamOrDevice(stream)
     }
 
     /// Internal context -- used with Cmlx calls.

--- a/Tests/MLXTests/StreamTests.swift
+++ b/Tests/MLXTests/StreamTests.swift
@@ -74,6 +74,16 @@ class StreamTests: XCTestCase {
         print("here")
     }
 
+    func testStreamOrDeviceStreamUsesGivenStream() {
+        // StreamOrDevice.stream(_:) used to ignore its argument and return
+        // the default stream instead
+        let stream = Stream(.cpu)
+        XCTAssertEqual(StreamOrDevice.stream(stream).stream, stream)
+
+        XCTAssertEqual(StreamOrDevice.stream(.cpu).stream, Stream.cpu)
+        XCTAssertEqual(StreamOrDevice.stream(.gpu).stream, Stream.gpu)
+    }
+
     func disabledTestCreateStream() {
         // see https://github.com/ml-explore/mlx/issues/2118
         for _ in 1 ..< 10000 {


### PR DESCRIPTION
## Proposed changes

Follow up for https://github.com/ml-explore/mlx-swift-lm/pull/575 


### The bug

`StreamOrDevice.stream(_:)` discards the stream it is given and returns the default stream of the default device instead:

```swift
public static func stream(_ stream: Stream) -> StreamOrDevice {
    StreamOrDevice(Device.defaultStream())   // `stream` is never used
}
```

So any code that builds a `StreamOrDevice` this way to run an operation on an explicit stream — e.g. `matmul(a, b, stream: .stream(myCpuStream))` — silently runs on the default stream of the default device instead. There's no error and no warning; the work just executes somewhere other than where the caller asked.

### The fix

Return the stream that was passed in:

```swift
public static func stream(_ stream: Stream) -> StreamOrDevice {
    StreamOrDevice(stream)
}
```


## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
