### PR TITLE
fix(Stream): preserve stream argument in StreamOrDevice.stream(_:)

### DIFF
--- a/Source/MLX/Stream.swift
+++ b/Source/MLX/Stream.swift
@@ -52,7 +52,7 @@ public struct StreamOrDevice: Sendable, CustomStringConvertible, Equatable {
     public static let gpu = device(.gpu)
 
     public static func stream(_ stream: Stream) -> StreamOrDevice {
-        StreamOrDevice(Device.defaultStream())
+        StreamOrDevice(stream)
     }
 
     /// Internal context -- used with Cmlx calls.

--- a/Tests/MLXTests/StreamTests.swift
+++ b/Tests/MLXTests/StreamTests.swift
@@ -28,6 +28,16 @@ class StreamTests: XCTestCase {
         XCTAssertEqual(s3.deviceType, .cpu)
     }
 
+    func testStreamOrDevice() {
+        let cpuStream = Stream(.cpu)
+        let streamOrDevice = StreamOrDevice.stream(cpuStream)
+        XCTAssertEqual(streamOrDevice.stream, cpuStream)
+
+        let gpuStream = Stream(.gpu)
+        let gpuStreamOrDevice = StreamOrDevice.stream(gpuStream)
+        XCTAssertEqual(gpuStreamOrDevice.stream, gpuStream)
+    }
+
     func testUsingDevice() {
         let defaultDevice = Device.defaultDevice()
 


### PR DESCRIPTION
### Summary
In `Source/MLX/Stream.swift`, `StreamOrDevice.stream(_ stream: Stream)` took a `Stream` parameter but silently discarded it and returned `StreamOrDevice(Device.defaultStream())`:

```swift
// Before
public static func stream(_ stream: Stream) -> StreamOrDevice {
    StreamOrDevice(Device.defaultStream())
}
```

This caused any caller explicitly specifying a custom stream via `StreamOrDevice.stream(customStream)` to silently execute operations on the device's default stream instead.

### Fix
Pass the provided `stream` parameter to `StreamOrDevice(stream)`:

```swift
// After
public static func stream(_ stream: Stream) -> StreamOrDevice {
    StreamOrDevice(stream)
}
```

### Tests
- Added unit test `testStreamOrDevice()` in `Tests/MLXTests/StreamTests.swift` asserting that passing an explicit `Stream` preserves the stream identity.
- Validated code style with `swift-format lint --strict`.