### PR TITLE
compile and vmap can produce Sendable closures from Sendable inputs

### DIFF
--- a/Source/MLX/Documentation.docc/Articles/vmap.md
+++ b/Source/MLX/Documentation.docc/Articles/vmap.md
@@ -44,3 +44,15 @@ Here `x` is mapped over its first axis while `y` is used as a broadcast value.
 You can nest calls to `vmap` to map over multiple axes.
 Each nested `vmap` introduces another batch dimension in the result.
 
+## Sendable
+
+If the function being transformed is `Sendable` (typically meaning it
+does not capture any MLXArray values, it only uses its inputs) you can use
+``vmapPure(_:inAxes:outAxes:)->(MLXArray)->MLXArray`` (and variants) to
+produce a `Sendable` result closure:
+
+```swift
+@Sendable
+func add(_ x: MLXArray, _ y: MLXArray) -> MLXArray { x + y }
+let vf = vmapPure(add, inAxes: (0, nil))
+```

--- a/Source/MLX/Transforms+Compile.swift
+++ b/Source/MLX/Transforms+Compile.swift
@@ -3,7 +3,10 @@
 import Cmlx
 import Foundation
 
-// Note: this is all immutable state -- the `id` property is only set at init time
+// Note: this is all immutable state -- the `id` property is only set at init time.
+// Also: this is marked as Sendable even though it may capture non-Sendable state
+// in inputs/outputs.  The functions that create it will not return a Sendable
+// type in that case -- see compile(inputs:)
 final class CompiledFunction: @unchecked (Sendable) {
 
     /// unique (for the lifetime of the object) identifier for the compiled function
@@ -34,6 +37,17 @@ final class CompiledFunction: @unchecked (Sendable) {
         self.f = f
         self.inputs = inputs
         self.outputs = outputs
+        self.shapeless = shapeless
+        self.id = UInt(bitPattern: Unmanaged.passUnretained(self).toOpaque())
+    }
+
+    init(
+        shapeless: Bool,
+        _ f: @escaping @Sendable ([MLXArray]) -> [MLXArray]
+    ) {
+        self.f = f
+        self.inputs = []
+        self.outputs = []
         self.shapeless = shapeless
         self.id = UInt(bitPattern: Unmanaged.passUnretained(self).toOpaque())
     }
@@ -285,10 +299,35 @@ final class CompiledFunction: @unchecked (Sendable) {
 /// ### See Also
 /// - <doc:compilation>
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f: @escaping ([MLXArray]) -> [MLXArray]
-) -> @Sendable ([MLXArray]) -> [MLXArray] {
+) -> ([MLXArray]) -> [MLXArray] {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless, f)
+
+    return { arrays in
+        compileState.call(arrays)
+    }
+}
+
+/// Returns a compiled function that produces the same output as `f()`.
+///
+/// - Parameters:
+///   - shapeless: A function compiled with the `shapeless`
+///     option enabled will not be recompiled when the input shape changes. Not all
+///     functions can be compiled with `shapeless` enabled. Attempting to compile
+///     such functions with shapeless enabled will throw. Note, changing the number
+///     of dimensions or type of any input will result in a recompilation even with
+///     `shapeless` set to `true`
+///   - f: function to compile
+/// - Returns: a new function that produces the same output as `f()`
+///
+/// ### See Also
+/// - <doc:compilation>
+public func compile(
+    shapeless: Bool = false,
+    _ f: @escaping @Sendable ([MLXArray]) -> [MLXArray]
+) -> @Sendable ([MLXArray]) -> [MLXArray] {
+    let compileState = CompiledFunction(shapeless: shapeless, f)
 
     return { arrays in
         compileState.call(arrays)
@@ -302,10 +341,33 @@ public func compile(
 /// - <doc:compilation>
 /// - ``compile(inputs:outputs:shapeless:_:)-([Updatable],[Updatable],Bool,([MLXArray])->[MLXArray])``
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f: @escaping (MLXArray) -> MLXArray
-) -> @Sendable (MLXArray) -> MLXArray {
+) -> (MLXArray) -> MLXArray {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
+        [f($0[0])]
+    }
+
+    return { a in
+        let r = compileState.call([a])
+        // r is empty only when an MLX error fired inside a withError scope — the
+        // error is already stored in the ErrorBox.  Return a placeholder so that
+        // withError can throw instead of crashing with "Index out of range".
+        return r.isEmpty ? MLXArray(0) : r[0]
+    }
+}
+
+/// Overload of ``compile(shapeless:_:)-(Bool,([MLXArray])->[MLXArray])`` that takes a single ``MLXArray`` and
+/// produces a single ``MLXArray``.
+///
+/// ### See Also
+/// - <doc:compilation>
+/// - ``compile(shapeless:_:)-(Bool,([MLXArray])->[MLXArray])``
+public func compile(
+    shapeless: Bool = false,
+    _ f: @escaping @Sendable (MLXArray) -> MLXArray
+) -> @Sendable (MLXArray) -> MLXArray {
+    let compileState = CompiledFunction(shapeless: shapeless) {
         [f($0[0])]
     }
 
@@ -325,12 +387,34 @@ public func compile(
 /// - <doc:compilation>
 /// - ``compile(inputs:outputs:shapeless:_:)-([Updatable],[Updatable],Bool,([MLXArray])->[MLXArray])``
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f: @escaping (MLXArray, MLXArray) -> MLXArray
+)
+    -> (MLXArray, MLXArray) -> MLXArray
+{
+    let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
+        [f($0[0], $0[1])]
+    }
+
+    return { a, b in
+        let r = compileState.call([a, b])
+        return r.isEmpty ? MLXArray(0) : r[0]
+    }
+}
+
+/// Overload of ``compile(shapeless:_:)-(Bool,([MLXArray])->[MLXArray])`` that takes two ``MLXArray`` and
+/// produces a single ``MLXArray``.
+///
+/// ### See Also
+/// - <doc:compilation>
+/// - ``compile(shapeless:_:)-(Bool,([MLXArray])->[MLXArray])``
+public func compile(
+    shapeless: Bool = false,
+    _ f: @escaping @Sendable (MLXArray, MLXArray) -> MLXArray
 )
     -> @Sendable (MLXArray, MLXArray) -> MLXArray
 {
-    let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
+    let compileState = CompiledFunction(shapeless: shapeless) {
         [f($0[0], $0[1])]
     }
 
@@ -347,12 +431,34 @@ public func compile(
 /// - <doc:compilation>
 /// - ``compile(inputs:outputs:shapeless:_:)-([Updatable],[Updatable],Bool,([MLXArray])->[MLXArray])``
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
+    _ f: @escaping (MLXArray, MLXArray, MLXArray) -> MLXArray
+)
+    -> (MLXArray, MLXArray, MLXArray) -> MLXArray
+{
+    let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
+        [f($0[0], $0[1], $0[2])]
+    }
+
+    return { a, b, c in
+        let r = compileState.call([a, b, c])
+        return r.isEmpty ? MLXArray(0) : r[0]
+    }
+}
+
+/// Overload of ``compile(shapeless:_:)-(Bool,([MLXArray])->[MLXArray])`` that takes three ``MLXArray`` and
+/// produces a single ``MLXArray``.
+///
+/// ### See Also
+/// - <doc:compilation>
+/// - ``compile(shapeless:_:)-(Bool,([MLXArray])->[MLXArray])``
+public func compile(
+    shapeless: Bool = false,
     _ f: @Sendable @escaping (MLXArray, MLXArray, MLXArray) -> MLXArray
 )
     -> @Sendable (MLXArray, MLXArray, MLXArray) -> MLXArray
 {
-    let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
+    let compileState = CompiledFunction(shapeless: shapeless) {
         [f($0[0], $0[1], $0[2])]
     }
 

--- a/Source/MLX/Transforms+CompileOverloads.swift
+++ b/Source/MLX/Transforms+CompileOverloads.swift
@@ -2,11 +2,13 @@
 
 import Cmlx
 
+// MARK: - inputs:/outputs:/not Sendable
+
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f: @escaping (MLXArray) -> (MLXArray, MLXArray)
-) -> @Sendable (MLXArray) -> (MLXArray, MLXArray) {
+) -> (MLXArray) -> (MLXArray, MLXArray) {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
         args in
         let r = f(args[0])
@@ -20,9 +22,9 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f: @escaping (MLXArray) -> (MLXArray, MLXArray, MLXArray)
-) -> @Sendable (MLXArray) -> (MLXArray, MLXArray, MLXArray) {
+) -> (MLXArray) -> (MLXArray, MLXArray, MLXArray) {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
         args in
         let r = f(args[0])
@@ -36,9 +38,9 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f: @escaping (MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray)
-) -> @Sendable (MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray) {
+) -> (MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray) {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
         args in
         let r = f(args[0])
@@ -52,9 +54,9 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f: @escaping (MLXArray, MLXArray) -> (MLXArray, MLXArray)
-) -> @Sendable (MLXArray, MLXArray) -> (MLXArray, MLXArray) {
+) -> (MLXArray, MLXArray) -> (MLXArray, MLXArray) {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
         args in
         let r = f(args[0], args[1])
@@ -68,9 +70,9 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f: @escaping (MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray)
-) -> @Sendable (MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray) {
+) -> (MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray) {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
         args in
         let r = f(args[0], args[1])
@@ -84,9 +86,9 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f: @escaping (MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray)
-) -> @Sendable (MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray) {
+) -> (MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray) {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
         args in
         let r = f(args[0], args[1])
@@ -100,9 +102,9 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f: @escaping (MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray)
-) -> @Sendable (MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray) {
+) -> (MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray) {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
         args in
         let r = f(args[0], args[1], args[2])
@@ -116,9 +118,9 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f: @escaping (MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray)
-) -> @Sendable (MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray) {
+) -> (MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray) {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
         args in
         let r = f(args[0], args[1], args[2])
@@ -132,9 +134,12 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
-    _ f: @escaping (MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray)
-) -> @Sendable (MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray) {
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
+    _ f:
+        @escaping (MLXArray, MLXArray, MLXArray) -> (
+            MLXArray, MLXArray, MLXArray, MLXArray
+        )
+) -> (MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray) {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
         args in
         let r = f(args[0], args[1], args[2])
@@ -148,9 +153,9 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f: @escaping (MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray
-) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray {
+) -> (MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
         args in
         [f(args[0], args[1], args[2], args[3])]
@@ -162,9 +167,9 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f: @escaping (MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray)
-) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray) {
+) -> (MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray) {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
         args in
         let r = f(args[0], args[1], args[2], args[3])
@@ -178,9 +183,12 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
-    _ f: @escaping (MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray)
-) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray) {
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
+    _ f:
+        @escaping (MLXArray, MLXArray, MLXArray, MLXArray) -> (
+            MLXArray, MLXArray, MLXArray
+        )
+) -> (MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray) {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
         args in
         let r = f(args[0], args[1], args[2], args[3])
@@ -194,13 +202,12 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f:
         @escaping (MLXArray, MLXArray, MLXArray, MLXArray) -> (
             MLXArray, MLXArray, MLXArray, MLXArray
         )
-) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray)
-{
+) -> (MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray) {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
         args in
         let r = f(args[0], args[1], args[2], args[3])
@@ -214,9 +221,9 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f: @escaping (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray
-) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray {
+) -> (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
         args in
         [f(args[0], args[1], args[2], args[3], args[4])]
@@ -228,9 +235,12 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
-    _ f: @escaping (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray)
-) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray) {
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
+    _ f:
+        @escaping (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+            MLXArray, MLXArray
+        )
+) -> (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray) {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
         args in
         let r = f(args[0], args[1], args[2], args[3], args[4])
@@ -244,13 +254,12 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f:
         @escaping (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
             MLXArray, MLXArray, MLXArray
         )
-) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray)
-{
+) -> (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray) {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
         args in
         let r = f(args[0], args[1], args[2], args[3], args[4])
@@ -264,13 +273,13 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f:
         @escaping (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
             MLXArray, MLXArray, MLXArray, MLXArray
         )
 )
-    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+    -> (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
         MLXArray, MLXArray, MLXArray, MLXArray
     )
 {
@@ -287,9 +296,10 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
-    _ f: @escaping (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray
-) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray {
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
+    _ f:
+        @escaping (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray
+) -> (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
         args in
         [f(args[0], args[1], args[2], args[3], args[4], args[5])]
@@ -301,13 +311,12 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f:
         @escaping (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
             MLXArray, MLXArray
         )
-) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray)
-{
+) -> (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray) {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
         args in
         let r = f(args[0], args[1], args[2], args[3], args[4], args[5])
@@ -321,13 +330,13 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f:
         @escaping (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
             MLXArray, MLXArray, MLXArray
         )
 )
-    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+    -> (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
         MLXArray, MLXArray, MLXArray
     )
 {
@@ -344,13 +353,13 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f:
         @escaping (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
             MLXArray, MLXArray, MLXArray, MLXArray
         )
 )
-    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+    -> (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
         MLXArray, MLXArray, MLXArray, MLXArray
     )
 {
@@ -367,10 +376,11 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f:
-        @escaping (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray
-) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray {
+        @escaping (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray)
+        -> MLXArray
+) -> (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
         args in
         [f(args[0], args[1], args[2], args[3], args[4], args[5], args[6])]
@@ -382,13 +392,14 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f:
-        @escaping (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+        @escaping (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray)
+        -> (
             MLXArray, MLXArray
         )
 )
-    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+    -> (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
         MLXArray, MLXArray
     )
 {
@@ -405,13 +416,14 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f:
-        @escaping (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+        @escaping (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray)
+        -> (
             MLXArray, MLXArray, MLXArray
         )
 )
-    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+    -> (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
         MLXArray, MLXArray, MLXArray
     )
 {
@@ -428,13 +440,14 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f:
-        @escaping (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+        @escaping (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray)
+        -> (
             MLXArray, MLXArray, MLXArray, MLXArray
         )
 )
-    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+    -> (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
         MLXArray, MLXArray, MLXArray, MLXArray
     )
 {
@@ -451,12 +464,14 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f:
-        @escaping (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray)
+        @escaping (
+            MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray
+        )
         -> MLXArray
 )
-    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) ->
+    -> (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) ->
     MLXArray
 {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
@@ -470,12 +485,14 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f:
-        @escaping (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray)
+        @escaping (
+            MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray
+        )
         -> (MLXArray, MLXArray)
 )
-    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) ->
+    -> (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) ->
     (MLXArray, MLXArray)
 {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
@@ -491,12 +508,14 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f:
-        @escaping (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray)
+        @escaping (
+            MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray
+        )
         -> (MLXArray, MLXArray, MLXArray)
 )
-    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) ->
+    -> (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) ->
     (MLXArray, MLXArray, MLXArray)
 {
     let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
@@ -512,15 +531,570 @@ public func compile(
 
 @_documentation(visibility: internal)
 public func compile(
-    inputs: [any Updatable] = [], outputs: [any Updatable] = [], shapeless: Bool = false,
+    inputs: [any Updatable], outputs: [any Updatable] = [], shapeless: Bool = false,
     _ f:
-        @escaping (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray)
+        @escaping (
+            MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray
+        )
+        -> (MLXArray, MLXArray, MLXArray, MLXArray)
+)
+    -> (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) ->
+    (MLXArray, MLXArray, MLXArray, MLXArray)
+{
+    let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
+        args in
+        let r = f(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7])
+        return [r.0, r.1, r.2, r.3]
+    }
+    return { a, b, c, d, e, g, h, i in
+        let r = compileState.call([a, b, c, d, e, g, h, i])
+        return (r[0], r[1], r[2], r[3])
+    }
+}
+
+// MARK: - no state/Sendable
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f: @escaping @Sendable (MLXArray) -> (MLXArray, MLXArray)
+) -> @Sendable (MLXArray) -> (MLXArray, MLXArray) {
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        let r = f(args[0])
+        return [r.0, r.1]
+    }
+    return { a in
+        let r = compileState.call([a])
+        return (r[0], r[1])
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f: @escaping @Sendable (MLXArray) -> (MLXArray, MLXArray, MLXArray)
+) -> @Sendable (MLXArray) -> (MLXArray, MLXArray, MLXArray) {
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        let r = f(args[0])
+        return [r.0, r.1, r.2]
+    }
+    return { a in
+        let r = compileState.call([a])
+        return (r[0], r[1], r[2])
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f: @escaping @Sendable (MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray)
+) -> @Sendable (MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray) {
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        let r = f(args[0])
+        return [r.0, r.1, r.2, r.3]
+    }
+    return { a in
+        let r = compileState.call([a])
+        return (r[0], r[1], r[2], r[3])
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f: @escaping @Sendable (MLXArray, MLXArray) -> (MLXArray, MLXArray)
+) -> @Sendable (MLXArray, MLXArray) -> (MLXArray, MLXArray) {
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        let r = f(args[0], args[1])
+        return [r.0, r.1]
+    }
+    return { a, b in
+        let r = compileState.call([a, b])
+        return (r[0], r[1])
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f: @escaping @Sendable (MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray)
+) -> @Sendable (MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray) {
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        let r = f(args[0], args[1])
+        return [r.0, r.1, r.2]
+    }
+    return { a, b in
+        let r = compileState.call([a, b])
+        return (r[0], r[1], r[2])
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f: @escaping @Sendable (MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray)
+) -> @Sendable (MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray) {
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        let r = f(args[0], args[1])
+        return [r.0, r.1, r.2, r.3]
+    }
+    return { a, b in
+        let r = compileState.call([a, b])
+        return (r[0], r[1], r[2], r[3])
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f: @escaping @Sendable (MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray)
+) -> @Sendable (MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray) {
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        let r = f(args[0], args[1], args[2])
+        return [r.0, r.1]
+    }
+    return { a, b, c in
+        let r = compileState.call([a, b, c])
+        return (r[0], r[1])
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f: @escaping @Sendable (MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray)
+) -> @Sendable (MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray) {
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        let r = f(args[0], args[1], args[2])
+        return [r.0, r.1, r.2]
+    }
+    return { a, b, c in
+        let r = compileState.call([a, b, c])
+        return (r[0], r[1], r[2])
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray) -> (
+            MLXArray, MLXArray, MLXArray, MLXArray
+        )
+) -> @Sendable (MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray) {
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        let r = f(args[0], args[1], args[2])
+        return [r.0, r.1, r.2, r.3]
+    }
+    return { a, b, c in
+        let r = compileState.call([a, b, c])
+        return (r[0], r[1], r[2], r[3])
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f: @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray
+) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray {
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        [f(args[0], args[1], args[2], args[3])]
+    }
+    return { a, b, c, d in
+        compileState.call([a, b, c, d])[0]
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f: @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray)
+) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray) {
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        let r = f(args[0], args[1], args[2], args[3])
+        return [r.0, r.1]
+    }
+    return { a, b, c, d in
+        let r = compileState.call([a, b, c, d])
+        return (r[0], r[1])
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray) -> (
+            MLXArray, MLXArray, MLXArray
+        )
+) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray) {
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        let r = f(args[0], args[1], args[2], args[3])
+        return [r.0, r.1, r.2]
+    }
+    return { a, b, c, d in
+        let r = compileState.call([a, b, c, d])
+        return (r[0], r[1], r[2])
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray) -> (
+            MLXArray, MLXArray, MLXArray, MLXArray
+        )
+) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray, MLXArray)
+{
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        let r = f(args[0], args[1], args[2], args[3])
+        return [r.0, r.1, r.2, r.3]
+    }
+    return { a, b, c, d in
+        let r = compileState.call([a, b, c, d])
+        return (r[0], r[1], r[2], r[3])
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f: @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray
+) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray {
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        [f(args[0], args[1], args[2], args[3], args[4])]
+    }
+    return { a, b, c, d, e in
+        compileState.call([a, b, c, d, e])[0]
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+            MLXArray, MLXArray
+        )
+) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray) {
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        let r = f(args[0], args[1], args[2], args[3], args[4])
+        return [r.0, r.1]
+    }
+    return { a, b, c, d, e in
+        let r = compileState.call([a, b, c, d, e])
+        return (r[0], r[1])
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+            MLXArray, MLXArray, MLXArray
+        )
+) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray, MLXArray)
+{
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        let r = f(args[0], args[1], args[2], args[3], args[4])
+        return [r.0, r.1, r.2]
+    }
+    return { a, b, c, d, e in
+        let r = compileState.call([a, b, c, d, e])
+        return (r[0], r[1], r[2])
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+            MLXArray, MLXArray, MLXArray, MLXArray
+        )
+)
+    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+        MLXArray, MLXArray, MLXArray, MLXArray
+    )
+{
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        let r = f(args[0], args[1], args[2], args[3], args[4])
+        return [r.0, r.1, r.2, r.3]
+    }
+    return { a, b, c, d, e in
+        let r = compileState.call([a, b, c, d, e])
+        return (r[0], r[1], r[2], r[3])
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray
+) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray {
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        [f(args[0], args[1], args[2], args[3], args[4], args[5])]
+    }
+    return { a, b, c, d, e, g in
+        compileState.call([a, b, c, d, e, g])[0]
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+            MLXArray, MLXArray
+        )
+) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (MLXArray, MLXArray)
+{
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        let r = f(args[0], args[1], args[2], args[3], args[4], args[5])
+        return [r.0, r.1]
+    }
+    return { a, b, c, d, e, g in
+        let r = compileState.call([a, b, c, d, e, g])
+        return (r[0], r[1])
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+            MLXArray, MLXArray, MLXArray
+        )
+)
+    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+        MLXArray, MLXArray, MLXArray
+    )
+{
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        let r = f(args[0], args[1], args[2], args[3], args[4], args[5])
+        return [r.0, r.1, r.2]
+    }
+    return { a, b, c, d, e, g in
+        let r = compileState.call([a, b, c, d, e, g])
+        return (r[0], r[1], r[2])
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+            MLXArray, MLXArray, MLXArray, MLXArray
+        )
+)
+    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+        MLXArray, MLXArray, MLXArray, MLXArray
+    )
+{
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        let r = f(args[0], args[1], args[2], args[3], args[4], args[5])
+        return [r.0, r.1, r.2, r.3]
+    }
+    return { a, b, c, d, e, g in
+        let r = compileState.call([a, b, c, d, e, g])
+        return (r[0], r[1], r[2], r[3])
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray)
+        -> MLXArray
+) -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> MLXArray {
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        [f(args[0], args[1], args[2], args[3], args[4], args[5], args[6])]
+    }
+    return { a, b, c, d, e, g, h in
+        compileState.call([a, b, c, d, e, g, h])[0]
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray)
+        -> (
+            MLXArray, MLXArray
+        )
+)
+    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+        MLXArray, MLXArray
+    )
+{
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        let r = f(args[0], args[1], args[2], args[3], args[4], args[5], args[6])
+        return [r.0, r.1]
+    }
+    return { a, b, c, d, e, g, h in
+        let r = compileState.call([a, b, c, d, e, g, h])
+        return (r[0], r[1])
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray)
+        -> (
+            MLXArray, MLXArray, MLXArray
+        )
+)
+    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+        MLXArray, MLXArray, MLXArray
+    )
+{
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        let r = f(args[0], args[1], args[2], args[3], args[4], args[5], args[6])
+        return [r.0, r.1, r.2]
+    }
+    return { a, b, c, d, e, g, h in
+        let r = compileState.call([a, b, c, d, e, g, h])
+        return (r[0], r[1], r[2])
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f:
+        @escaping @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray)
+        -> (
+            MLXArray, MLXArray, MLXArray, MLXArray
+        )
+)
+    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) -> (
+        MLXArray, MLXArray, MLXArray, MLXArray
+    )
+{
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        let r = f(args[0], args[1], args[2], args[3], args[4], args[5], args[6])
+        return [r.0, r.1, r.2, r.3]
+    }
+    return { a, b, c, d, e, g, h in
+        let r = compileState.call([a, b, c, d, e, g, h])
+        return (r[0], r[1], r[2], r[3])
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f:
+        @escaping @Sendable (
+            MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray
+        )
+        -> MLXArray
+)
+    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) ->
+    MLXArray
+{
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        [f(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7])]
+    }
+    return { a, b, c, d, e, g, h, i in
+        compileState.call([a, b, c, d, e, g, h, i])[0]
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f:
+        @escaping @Sendable (
+            MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray
+        )
+        -> (MLXArray, MLXArray)
+)
+    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) ->
+    (MLXArray, MLXArray)
+{
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        let r = f(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7])
+        return [r.0, r.1]
+    }
+    return { a, b, c, d, e, g, h, i in
+        let r = compileState.call([a, b, c, d, e, g, h, i])
+        return (r[0], r[1])
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f:
+        @escaping @Sendable (
+            MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray
+        )
+        -> (MLXArray, MLXArray, MLXArray)
+)
+    -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) ->
+    (MLXArray, MLXArray, MLXArray)
+{
+    let compileState = CompiledFunction(shapeless: shapeless) {
+        args in
+        let r = f(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7])
+        return [r.0, r.1, r.2]
+    }
+    return { a, b, c, d, e, g, h, i in
+        let r = compileState.call([a, b, c, d, e, g, h, i])
+        return (r[0], r[1], r[2])
+    }
+}
+
+@_documentation(visibility: internal)
+public func compile(
+    shapeless: Bool = false,
+    _ f:
+        @escaping @Sendable (
+            MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray
+        )
         -> (MLXArray, MLXArray, MLXArray, MLXArray)
 )
     -> @Sendable (MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray, MLXArray) ->
     (MLXArray, MLXArray, MLXArray, MLXArray)
 {
-    let compileState = CompiledFunction(inputs: inputs, outputs: outputs, shapeless: shapeless) {
+    let compileState = CompiledFunction(shapeless: shapeless) {
         args in
         let r = f(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7])
         return [r.0, r.1, r.2, r.3]

--- a/Source/MLX/Transforms+Grad.swift
+++ b/Source/MLX/Transforms+Grad.swift
@@ -30,9 +30,7 @@ public func grad(
 // See ``grad(_:)-r8dv``
 public func grad(
     _ f: @escaping ([MLXArray]) -> MLXArray, argumentNumbers: some Collection<Int> = [0]
-) -> (
-    [MLXArray]
-) -> MLXArray {
+) -> ([MLXArray]) -> MLXArray {
     let wrappedFunction = wrapResult(wrapArguments(f))
     let gradientFunction = buildGradient(wrappedFunction, argumentNumbers: argumentNumbers)
     let uag: ([MLXArray]) -> [MLXArray] = unwrapArguments(gradientFunction)

--- a/Source/MLX/Transforms+Vmap.swift
+++ b/Source/MLX/Transforms+Vmap.swift
@@ -1,25 +1,30 @@
 import Cmlx
 import Foundation
 
-/// Returns a vectorized version of `f()`.
-///
-/// The returned function applies `f()` independently over the axis
-/// specified by `inAxes` and stacks the results along `outAxes`.
-///
-/// - Parameters:
-///   - f: Function to vectorize
-///   - inAxes: Axis of each input to map over. `nil` disables mapping for that input.
-///   - outAxes: Axis of each output to stack the results along
-/// - Returns: A vectorized function
-///
-/// ### See Also
-/// - <doc:vmap>
-public func vmap(
+@usableFromInline
+final internal class UncheckedSendableBox<T>: @unchecked Sendable {
+    @usableFromInline
+    let value: T
+
+    @usableFromInline
+    init(_ value: T) {
+        self.value = value
+    }
+}
+
+/// Internal vmap implementation.  This takes a closure with sendability erased and produces
+/// a (declared) sendable closure.  Callers must declare their return sendability correctly.
+/// For example, ``vmap(_:inAxes:outAxes:)->(MLXArray)->MLXArray`` produces
+/// a non-Sendable closure from a non-Sendable input while
+/// ``vmapPure(_:inAxes:outAxes:)->(MLXArray)->MLXArray`` produces
+/// Sendable from Sendable.
+private func vmapInternal(
     _ f: @escaping ([MLXArray]) -> [MLXArray],
-    inAxes: some Sequence<Int?> = [0],
-    outAxes: some Sequence<Int?> = [0]
-) -> ([MLXArray]) -> [MLXArray] {
-    { arrays in
+    inAxes: some Sequence<Int?> & Sendable = [0],
+    outAxes: some Sequence<Int?> & Sendable = [0]
+) -> @Sendable ([MLXArray]) -> [MLXArray] {
+    let box = UncheckedSendableBox(f)
+    return { arrays in
         let inAxes32 = inAxes.map { Int32($0 ?? -1) }
         let outAxes32 = outAxes.map { Int32($0 ?? -1) }
 
@@ -30,7 +35,7 @@ public func vmap(
         var traceOutputs = mlx_vector_array_new()
 
         withEvalLock {
-            let closure = new_mlx_closure(f)
+            let closure = new_mlx_closure(box.value)
             _ = inAxes32.withUnsafeBufferPointer { inAxesBuf in
                 mlx_detail_vmap_trace(
                     &traceInputs, &traceOutputs, closure, inputs, inAxesBuf.baseAddress,
@@ -66,6 +71,56 @@ public func vmap(
     }
 }
 
+/// Returns a vectorized version of `f()`.
+///
+/// The returned function applies `f()` independently over the axis
+/// specified by `inAxes` and stacks the results along `outAxes`.
+///
+/// - Parameters:
+///   - f: Function to vectorize
+///   - inAxes: Axis of each input to map over. `nil` disables mapping for that input.
+///   - outAxes: Axis of each output to stack the results along
+/// - Returns: A vectorized function
+///
+/// ### See Also
+/// - <doc:vmap>
+/// - ``vmapPure(_:inAxes:outAxes:)->(MLXArray)->MLXArray``
+public func vmap(
+    _ f: @escaping ([MLXArray]) -> [MLXArray],
+    inAxes: some Sequence<Int?> & Sendable = [0],
+    outAxes: some Sequence<Int?> & Sendable = [0]
+) -> ([MLXArray]) -> [MLXArray] {
+    vmapInternal(f, inAxes: inAxes, outAxes: outAxes)
+}
+
+/// Returns a vectorized version of `f()`, a pure function (`Sendable`).
+///
+/// The returned function applies `f()` independently over the axis
+/// specified by `inAxes` and stacks the results along `outAxes`.
+///
+/// ```swift
+/// @Sendable
+/// func add(_ x: MLXArray, _ y: MLXArray) -> MLXArray { x + y }
+/// let vf = vmapPure(add, inAxes: (0, nil))
+/// ```
+///
+/// - Parameters:
+///   - f: Function to vectorize
+///   - inAxes: Axis of each input to map over. `nil` disables mapping for that input.
+///   - outAxes: Axis of each output to stack the results along
+/// - Returns: A vectorized function
+///
+/// ### See Also
+/// - <doc:vmap>
+/// - ``vmap(_:inAxes:outAxes:)->(MLXArray)->MLXArray``
+public func vmapPure(
+    _ f: @escaping @Sendable ([MLXArray]) -> [MLXArray],
+    inAxes: some Sequence<Int?> & Sendable = [0],
+    outAxes: some Sequence<Int?> & Sendable = [0]
+) -> @Sendable ([MLXArray]) -> [MLXArray] {
+    vmapInternal(f, inAxes: inAxes, outAxes: outAxes)
+}
+
 /// Overload of ``vmap(_:inAxes:outAxes:)`` for a single ``MLXArray`` input and
 /// output.
 ///
@@ -81,6 +136,21 @@ public func vmap(
     return { a in inner([a])[0] }
 }
 
+/// Overload of ``vmapPure(_:inAxes:outAxes:)->([MLXArray])->[MLXArray]``
+/// for a single ``MLXArray`` input and output.
+///
+/// ### See Also
+/// - <doc:vmap>
+/// - ``vmapPure(_:inAxes:outAxes:)->([MLXArray])->[MLXArray]``
+public func vmapPure(
+    _ f: @escaping @Sendable (MLXArray) -> MLXArray,
+    inAxes: Int? = 0,
+    outAxes: Int? = 0
+) -> @Sendable (MLXArray) -> MLXArray {
+    let inner = vmapPure({ [f($0[0])] }, inAxes: [inAxes], outAxes: [outAxes])
+    return { a in inner([a])[0] }
+}
+
 /// Overload of ``vmap(_:inAxes:outAxes:)`` for two ``MLXArray`` inputs and a
 /// single ``MLXArray`` output.
 ///
@@ -93,5 +163,20 @@ public func vmap(
     outAxes: Int? = 0
 ) -> (MLXArray, MLXArray) -> MLXArray {
     let inner = vmap({ [f($0[0], $0[1])] }, inAxes: [inAxes.0, inAxes.1], outAxes: [outAxes])
+    return { a, b in inner([a, b])[0] }
+}
+
+/// Overload of ``vmapPure(_:inAxes:outAxes:)->([MLXArray])->[MLXArray]``
+/// for a two ``MLXArray`` inputs and a single output.
+///
+/// ### See Also
+/// - <doc:vmap>
+/// - ``vmapPure(_:inAxes:outAxes:)->([MLXArray])->[MLXArray]``
+public func vmapPure(
+    _ f: @escaping @Sendable (MLXArray, MLXArray) -> MLXArray,
+    inAxes: (Int?, Int?) = (0, 0),
+    outAxes: Int? = 0
+) -> @Sendable (MLXArray, MLXArray) -> MLXArray {
+    let inner = vmapPure({ [f($0[0], $0[1])] }, inAxes: [inAxes.0, inAxes.1], outAxes: [outAxes])
     return { a, b in inner([a, b])[0] }
 }

--- a/Source/MLX/Transforms+Vmap.swift
+++ b/Source/MLX/Transforms+Vmap.swift
@@ -14,9 +14,9 @@ final internal class UncheckedSendableBox<T>: @unchecked Sendable {
 
 /// Internal vmap implementation.  This takes a closure with sendability erased and produces
 /// a (declared) sendable closure.  Callers must declare their return sendability correctly.
-/// For example, ``vmap(_:inAxes:outAxes:)->(MLXArray)->MLXArray`` produces
+/// For example, ``vmap(_:inAxes:outAxes:)`` produces
 /// a non-Sendable closure from a non-Sendable input while
-/// ``vmapPure(_:inAxes:outAxes:)->(MLXArray)->MLXArray`` produces
+/// ``vmapPure(_:inAxes:outAxes:)`` produces
 /// Sendable from Sendable.
 private func vmapInternal(
     _ f: @escaping ([MLXArray]) -> [MLXArray],
@@ -84,7 +84,6 @@ private func vmapInternal(
 ///
 /// ### See Also
 /// - <doc:vmap>
-/// - ``vmapPure(_:inAxes:outAxes:)->(MLXArray)->MLXArray``
 public func vmap(
     _ f: @escaping ([MLXArray]) -> [MLXArray],
     inAxes: some Sequence<Int?> & Sendable = [0],
@@ -112,7 +111,6 @@ public func vmap(
 ///
 /// ### See Also
 /// - <doc:vmap>
-/// - ``vmap(_:inAxes:outAxes:)->(MLXArray)->MLXArray``
 public func vmapPure(
     _ f: @escaping @Sendable ([MLXArray]) -> [MLXArray],
     inAxes: some Sequence<Int?> & Sendable = [0],
@@ -136,12 +134,11 @@ public func vmap(
     return { a in inner([a])[0] }
 }
 
-/// Overload of ``vmapPure(_:inAxes:outAxes:)->([MLXArray])->[MLXArray]``
+/// Overload of ``vmapPure(_:inAxes:outAxes:)``
 /// for a single ``MLXArray`` input and output.
 ///
 /// ### See Also
 /// - <doc:vmap>
-/// - ``vmapPure(_:inAxes:outAxes:)->([MLXArray])->[MLXArray]``
 public func vmapPure(
     _ f: @escaping @Sendable (MLXArray) -> MLXArray,
     inAxes: Int? = 0,
@@ -166,12 +163,11 @@ public func vmap(
     return { a, b in inner([a, b])[0] }
 }
 
-/// Overload of ``vmapPure(_:inAxes:outAxes:)->([MLXArray])->[MLXArray]``
+/// Overload of ``vmapPure(_:inAxes:outAxes:)``
 /// for a two ``MLXArray`` inputs and a single output.
 ///
 /// ### See Also
 /// - <doc:vmap>
-/// - ``vmapPure(_:inAxes:outAxes:)->([MLXArray])->[MLXArray]``
 public func vmapPure(
     _ f: @escaping @Sendable (MLXArray, MLXArray) -> MLXArray,
     inAxes: (Int?, Int?) = (0, 0),

--- a/Tests/MLXTests/CompileLockOrderingTests.swift
+++ b/Tests/MLXTests/CompileLockOrderingTests.swift
@@ -137,14 +137,14 @@ import XCTest
         /// compiler-cache erase -- happen at a chosen instant on a chosen
         /// thread.
         private final class Victim: @unchecked Sendable {
-            private var compiled: (@Sendable (MLXArray) -> MLXArray)?
+            private var compiled: ((MLXArray) -> MLXArray)?
 
             init() {
                 // A fresh compile() per instance, so the erase has a populated
                 // cache entry to remove.  The unique constant keeps this from
                 // sharing an entry with anything else.
                 let bias = MLXArray(Float.random(in: 1 ... 2))
-                compiled = MLX.compile { (x: MLXArray) in x * 3 + bias }
+                compiled = MLX.compile(inputs: [bias]) { (x: MLXArray) in x * 3 + bias }
             }
 
             /// Populate the cache entry that `deinit` will erase.

--- a/Tests/MLXTests/OptimizerTests.swift
+++ b/Tests/MLXTests/OptimizerTests.swift
@@ -61,6 +61,7 @@ class OptimizerTests: XCTestCase {
         // measure the distance from the prediction (model(x)) and the
         // ground truth (y).  this gives feedback on how close the
         // prediction is from matching the truth
+        @Sendable
         func loss(model: LinearFunctionModel, x: MLXArray, y: MLXArray) -> MLXArray {
             mseLoss(predictions: model(x), targets: y, reduction: .mean)
         }

--- a/Tests/MLXTests/TransformTests.swift
+++ b/Tests/MLXTests/TransformTests.swift
@@ -113,6 +113,7 @@ class TransformTests: XCTestCase {
     }
 
     func testCompile() {
+        @Sendable
         func f(inputs: [MLXArray]) -> [MLXArray] {
             [square(inputs[0] * inputs[1])]
         }
@@ -232,11 +233,14 @@ class TransformTests: XCTestCase {
     }
 
     func testCompileCapturesModuleParameterWithoutState() {
-        // verify the capture path happens
+        // verify that compile captures all values used if not
+        // passed as inputs.
 
         let model = ScaleModule(2.0)
 
-        let compiled = compile { (x: MLXArray) -> MLXArray in
+        // lie about the inputs so that we can use a non-Sendable
+        // closure.  this is meant to demonstrate the failure
+        let compiled = compile(inputs: []) { (x: MLXArray) -> MLXArray in
             model(x)
         }
 
@@ -251,7 +255,7 @@ class TransformTests: XCTestCase {
         let r2 = compiled(MLXArray(Float(3)))
         XCTAssertEqual(
             r2.item(Float.self), 6,
-            "compiled function incorrectly ignored the updated module parameter")
+            "compiled function saw the update and it should not")
     }
 
     func testCompileWithStateObservesModuleParameterUpdates() {
@@ -277,6 +281,7 @@ class TransformTests: XCTestCase {
     }
 
     func testCompiledRandom() {
+        @Sendable
         func f(_ bias: MLXArray) -> MLXArray {
             MLXRandom.uniform(0 ..< 1, [4]) + bias
         }
@@ -336,7 +341,26 @@ class TransformTests: XCTestCase {
         assertEqual(vf(x), expected)
     }
 
+    func testVmapPureSimple() async {
+        @Sendable
+        func f(_ x: MLXArray) -> MLXArray { x * 2 }
+
+        let x = MLXArray(0 ..< 6, [3, 2])
+
+        // this result type is Sendable
+        let vf = vmapPure(f)
+
+        let t = Task {
+            let expected = stacked((0 ..< 3).map { f(x[$0]) }, axis: 0)
+
+            assertEqual(vf(x), expected)
+        }
+
+        _ = await t.value
+    }
+
     func testVmapTwoInputs() {
+        @Sendable
         func f(_ x: MLXArray, _ y: MLXArray) -> MLXArray { x + y }
 
         let x = MLXArray(0 ..< 6, [3, 2])
@@ -349,6 +373,7 @@ class TransformTests: XCTestCase {
     }
 
     func testVmapAxisPermutations() {
+        @Sendable
         func f(_ x: MLXArray) -> MLXArray { x * 2 }
 
         let x = MLXArray(0 ..< 6, [2, 3])
@@ -367,6 +392,7 @@ class TransformTests: XCTestCase {
     }
 
     func testVmapTwoInputsAxisPermutations() {
+        @Sendable
         func f(_ x: MLXArray, _ y: MLXArray) -> MLXArray { x + y }
 
         let x = MLXArray(0 ..< 6, [2, 3])
@@ -382,6 +408,7 @@ class TransformTests: XCTestCase {
     }
 
     func testVmapWithCompile() {
+        @Sendable
         func f(_ x: MLXArray) -> MLXArray { x.square() }
 
         let x = MLXRandom.normal([4, 2])
@@ -390,7 +417,9 @@ class TransformTests: XCTestCase {
         let mapCompile = vmap(compiled)
         assertEqual(mapCompile(x), vmap(f)(x))
 
-        let compiledMap = compile(vmap(f))
+        // use a non-Sendable version of compile because vmap doesn't produce
+        // a Sendable function
+        let compiledMap = compile(inputs: [], vmap(f))
         assertEqual(compiledMap(x), vmap(f)(x))
     }
 
@@ -409,6 +438,7 @@ class TransformTests: XCTestCase {
 
     func testCompileThreadSafety() async throws {
 
+        @Sendable
         func swiglu(_ xLinear: MLXArray, _ xGlu: MLXArray, alpha: Float = 1.702, limit: Float = 7.0)
             -> MLXArray
         {


### PR DESCRIPTION
## Proposed changes

- this idea comes from https://github.com/ml-explore/mlx-swift-lm/pull/589 (@aleroot)
- breaking change for compile calls that capture state without using inputs:

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
