### PR TITLE
Fix wired-memory ticket lifecycle during cancellation

### DIFF
--- a/Source/MLX/WiredMemory.swift
+++ b/Source/MLX/WiredMemory.swift
@@ -291,43 +291,23 @@ public struct WiredMemoryTicket: Sendable, Identifiable {
 }
 
 extension WiredMemoryTicket {
-    /// Guards against calling `end()` more than once when task cancellation
-    /// races with normal completion inside `withWiredLimit`.
-    private final class EndOnceGuard: @unchecked Sendable {
-        private var _ended = false
-        private let _lock = NSLock()
-
-        /// Returns `true` exactly once; all subsequent calls return `false`.
-        func tryMark() -> Bool {
-            _lock.lock()
-            defer { _lock.unlock() }
-            if _ended { return false }
-            _ended = true
-            return true
-        }
-    }
-
-    /// Convenience wrapper that guarantees start/end pairing and is safe under
-    /// cancellation. This is the recommended pattern for inference.
+    /// Keeps the ticket active until the body returns or throws, including during cancellation.
+    ///
+    /// If admission is cancelled, the body still runs in the cancelled task so it can
+    /// clean up. Check cancellation before starting work that requires admission.
+    /// Use a distinct ticket for each overlapping scope.
     public static func withWiredLimit<R>(
         _ ticket: WiredMemoryTicket,
         _ body: () async throws -> R
     ) async rethrows -> R {
         _ = await ticket.start()
-        let guard_ = EndOnceGuard()
-        return try await withTaskCancellationHandler {
-            do {
-                let result = try await body()
-                if guard_.tryMark() { _ = await ticket.end() }
-                return result
-            } catch {
-                if guard_.tryMark() { _ = await ticket.end() }
-                throw error
-            }
-        } onCancel: {
-            Task {
-                if guard_.tryMark() { _ = await ticket.end() }
-            }
+        do {
+            let result = try await body()
+            _ = await ticket.end()
+            return result
+        } catch {
+            _ = await ticket.end()
+            throw error
         }
     }
 
@@ -366,6 +346,11 @@ public actor WiredMemoryManager {
         let kind: WiredMemoryTicketKind
     }
 
+    private struct AdmissionWaiter {
+        let ticketID: UUID
+        let continuation: CheckedContinuation<Void, Never>
+    }
+
     /// Stable grouping key for policies.
     private enum PolicyKey: Hashable {
         case identifier(AnyHashable)
@@ -379,8 +364,8 @@ public actor WiredMemoryManager {
     private var policies: [PolicyKey: any WiredMemoryPolicy] = [:]
     /// Last limit applied by the manager.
     private var currentLimit: Int?
-    /// Admission waiters parked while capacity is unavailable.
-    private var waiters: [UUID: CheckedContinuation<Void, Never>] = [:]
+    /// Each wait has its own identity so late cancellation cannot affect a later wait.
+    private var waiters: [UUID: AdmissionWaiter] = [:]
     /// Timestamp used to enforce shrink cooldown.
     private var lastLimitChange: Date?
     /// Hysteresis configuration for shrink behavior.
@@ -458,9 +443,6 @@ public actor WiredMemoryManager {
 
         var baselineValue = resolveBaselineAndEmit(refresh: baseline == nil || !hasActiveWork())
         if tickets[id] != nil {
-            #if DEBUG
-                assertionFailure("Ticket already started: \(id)")
-            #endif
             emit(
                 kind: .ticketStartIgnored,
                 ticketID: id,
@@ -489,16 +471,23 @@ public actor WiredMemoryManager {
                 return currentLimit ?? baselineValue
             }
 
+            let waiterID = UUID()
             await withTaskCancellationHandler {
                 await withCheckedContinuation { continuation in
-                    waiters[id] = continuation
+                    waiters[waiterID] = AdmissionWaiter(ticketID: id, continuation: continuation)
                 }
-            } onCancel: { [id] in
-                Task { await self.cancelWaiter(id: id) }
+            } onCancel: {
+                Task { await self.cancelWaiter(id: waiterID) }
             }
 
             baselineValue = resolveBaselineAndEmit(refresh: baseline == nil || !hasActiveWork())
             if Task.isCancelled {
+                return currentLimit ?? baselineValue
+            }
+            if tickets[id] != nil {
+                emit(
+                    kind: .ticketStartIgnored, ticketID: id, size: normalizedSize,
+                    baseline: baselineValue)
                 return currentLimit ?? baselineValue
             }
         }
@@ -533,8 +522,9 @@ public actor WiredMemoryManager {
     /// If this was the last ticket, the manager restores the baseline and
     /// clears internal state.
     public func end(id: UUID, policy: any WiredMemoryPolicy) -> Int {
-        if let waiter = waiters.removeValue(forKey: id) {
-            waiter.resume()
+        for (waiterID, waiter) in waiters where waiter.ticketID == id {
+            waiters.removeValue(forKey: waiterID)
+            waiter.continuation.resume()
         }
 
         guard WiredMemoryBackend.isSupported || policyOnlyMode else {
@@ -545,9 +535,6 @@ public actor WiredMemoryManager {
         }
 
         guard let state = tickets.removeValue(forKey: id) else {
-            #if DEBUG
-                assertionFailure("Ticket not active: \(id)")
-            #endif
             emit(kind: .ticketEndIgnored, ticketID: id)
             return currentLimit ?? baseline ?? 0
         }
@@ -774,8 +761,8 @@ public actor WiredMemoryManager {
         guard !waiters.isEmpty else { return }
         let pending = waiters
         waiters.removeAll()
-        for (_, continuation) in pending {
-            continuation.resume()
+        for waiter in pending.values {
+            waiter.continuation.resume()
         }
     }
 
@@ -786,10 +773,9 @@ public actor WiredMemoryManager {
 
     /// Cancel an admission waiter and emit a debug event.
     private func cancelWaiter(id: UUID) {
-        if let waiter = waiters.removeValue(forKey: id) {
-            waiter.resume()
-        }
-        emit(kind: .admissionCancelled, ticketID: id)
+        guard let waiter = waiters.removeValue(forKey: id) else { return }
+        waiter.continuation.resume()
+        emit(kind: .admissionCancelled, ticketID: waiter.ticketID)
     }
 
     #if DEBUG

--- a/Tests/MLXTests/WiredMemoryLifecycleTests.swift
+++ b/Tests/MLXTests/WiredMemoryLifecycleTests.swift
@@ -1,0 +1,244 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import XCTest
+
+final class WiredMemoryLifecycleTests: XCTestCase {
+    private enum Failure: Error { case expected }
+    private struct Policy: WiredMemoryPolicy, Hashable {
+        let capacity: Int
+
+        func limit(baseline: Int, activeSizes: [Int]) -> Int {
+            baseline + activeSizes.reduce(0, +)
+        }
+
+        func canAdmit(baseline: Int, activeSizes: [Int], newSize: Int) -> Bool {
+            activeSizes.reduce(0, +) + newSize <= capacity
+        }
+    }
+
+    private actor Gate {
+        private var isOpen = false
+        private var continuation: CheckedContinuation<Void, Never>?
+
+        func wait() async {
+            if isOpen { return }
+            await withCheckedContinuation { continuation = $0 }
+        }
+
+        func open() {
+            isOpen = true
+            continuation?.resume()
+            continuation = nil
+        }
+    }
+
+    private static func manager() -> WiredMemoryManager {
+        .makeForTesting(
+            configuration: .init(
+                policyOnlyWhenUnsupported: true, baselineOverride: 1024,
+                useRecommendedWorkingSetWhenUnsupported: false))
+    }
+
+    func testDuplicateStartAndUnmatchedEndAreIdempotent() async {
+        await Device.withDefaultDevice(.cpu) {
+            let manager = Self.manager()
+            let ticket = WiredMemoryTicket(size: 64, policy: Policy(capacity: 64), manager: manager)
+            let events = await manager.events()
+            _ = await ticket.end()
+            _ = await ticket.start()
+            _ = await ticket.start()
+            _ = await ticket.end()
+            _ = await ticket.end()
+
+            var started = 0
+            var ignoredStarts = 0
+            var ended = 0
+            var ignoredEnds = 0
+            for await event in events {
+                switch event.kind {
+                case .ticketStarted: started += 1
+                case .ticketStartIgnored: ignoredStarts += 1
+                case .ticketEnded: ended += 1
+                case .ticketEndIgnored: ignoredEnds += 1
+                default: break
+                }
+                if ignoredEnds == 2 { break }
+            }
+            XCTAssertEqual(started, 1)
+            XCTAssertEqual(ignoredStarts, 1)
+            XCTAssertEqual(ended, 1)
+        }
+    }
+
+    func testCancellationWhileAdmissionIsDeniedStillRunsCleanup() async {
+        await Device.withDefaultDevice(.cpu) {
+            let manager = Self.manager()
+            let ticket = WiredMemoryTicket(size: 1, policy: Policy(capacity: 0), manager: manager)
+            let events = await manager.events()
+            let task = Task {
+                await ticket.withWiredLimit {
+                    XCTAssertTrue(Task.isCancelled)
+                    return 123
+                }
+            }
+            for await event in events {
+                if event.kind == .admissionWait { break }
+            }
+            task.cancel()
+            let result = await task.value
+            XCTAssertEqual(result, 123)
+            // The cancelled waiter must be removed before the scope returns.
+            await manager.updateConfiguration { $0.baselineOverride = 2048 }
+        }
+    }
+
+    func testCancellationKeepsTicketUntilBodyFinishes() async {
+        await Device.withDefaultDevice(.cpu) {
+            let manager = Self.manager()
+            let ticket = WiredMemoryTicket(size: 64, policy: Policy(capacity: 64), manager: manager)
+            let events = await manager.events()
+            let gate = Gate()
+            let started = expectation(description: "body started")
+            let endedEarly = expectation(description: "ticket ended before body completed")
+            endedEarly.isInverted = true
+            let observer = Task {
+                for await event in events {
+                    if event.kind == .ticketEnded {
+                        endedEarly.fulfill()
+                        break
+                    }
+                }
+            }
+            let task = Task {
+                await ticket.withWiredLimit {
+                    started.fulfill()
+                    await gate.wait()
+                    XCTAssertTrue(Task.isCancelled)
+                }
+            }
+            await fulfillment(of: [started], timeout: 5)
+            task.cancel()
+            await fulfillment(of: [endedEarly], timeout: 0.2)
+            observer.cancel()
+            await observer.value
+            await gate.open()
+            await task.value
+            // End is awaited; no active ticket may remain after task.value.
+            await manager.updateConfiguration { $0.baselineOverride = 2048 }
+        }
+    }
+
+    func testThrowingBodyReleasesTicketBeforeReturning() async {
+        await Device.withDefaultDevice(.cpu) {
+            let manager = Self.manager()
+            let ticket = WiredMemoryTicket(size: 64, policy: Policy(capacity: 64), manager: manager)
+            do {
+                try await ticket.withWiredLimit { throw Failure.expected }
+                XCTFail("Expected the body's error")
+            } catch {
+                XCTAssertTrue(error is Failure)
+            }
+            await manager.updateConfiguration { $0.baselineOverride = 2048 }
+        }
+    }
+
+    func testAlreadyCancelledScopeCanCleanUpWithoutAdmission() async {
+        await Device.withDefaultDevice(.cpu) {
+            let manager = Self.manager()
+            let ticket = WiredMemoryTicket(size: 1, policy: Policy(capacity: 0), manager: manager)
+            let task = Task {
+                withUnsafeCurrentTask { $0?.cancel() }
+                return await ticket.withWiredLimit {
+                    XCTAssertTrue(Task.isCancelled)
+                    return 123
+                }
+            }
+            let result = await task.value
+            XCTAssertEqual(result, 123)
+            await manager.updateConfiguration { $0.baselineOverride = 2048 }
+        }
+    }
+
+    func testCancellationRacingCompletionAlwaysFinishesCleanup() async {
+        await Device.withDefaultDevice(.cpu) {
+            let manager = Self.manager()
+            for index in 0 ..< 100 {
+                let ticket = WiredMemoryTicket(
+                    size: 64, policy: Policy(capacity: 64), manager: manager)
+                let task = Task {
+                    await ticket.withWiredLimit {
+                        await Task.yield()
+                        return index
+                    }
+                }
+                if index.isMultiple(of: 2) { await Task.yield() }
+                task.cancel()
+                let result = await task.value
+                XCTAssertEqual(result, index)
+                await manager.updateConfiguration { $0.baselineOverride = 1024 }
+            }
+        }
+    }
+
+    func testConcurrentStartsOfWaitingTicketDoNotLoseWaiters() async {
+        await checkConcurrentStarts(cancelFirst: false)
+    }
+
+    func testCancellingOneStartDoesNotCancelAnotherWaiterForSameTicket() async {
+        await checkConcurrentStarts(cancelFirst: true)
+    }
+
+    private func checkConcurrentStarts(cancelFirst: Bool) async {
+        await Device.withDefaultDevice(.cpu) {
+            let manager = Self.manager()
+            let policy = Policy(capacity: 64)
+            let blocker = WiredMemoryTicket(size: 64, policy: policy, manager: manager)
+            let ticket = WiredMemoryTicket(size: 32, policy: policy, manager: manager)
+            _ = await blocker.start()
+            let events = await manager.events()
+            let firstFinished = expectation(description: "first start returned")
+            let secondFinished = expectation(description: "second start returned")
+            let first = Task {
+                _ = await ticket.start()
+                firstFinished.fulfill()
+            }
+            // Ensure the first waiter is installed before adding the second.
+            for await event in events {
+                if event.kind == .admissionWait { break }
+            }
+            let secondEvents = await manager.events()
+            let second = Task {
+                _ = await ticket.start()
+                secondFinished.fulfill()
+            }
+            for await event in secondEvents {
+                if event.kind == .admissionWait { break }
+            }
+            if cancelFirst {
+                first.cancel()
+                let result = await XCTWaiter.fulfillment(of: [firstFinished], timeout: 5)
+                guard result == .completed else {
+                    XCTFail("Cancelling the first start did not resume its continuation")
+                    second.cancel()
+                    _ = await blocker.end()
+                    return
+                }
+            }
+            _ = await blocker.end()
+            let expected = cancelFirst ? [secondFinished] : [firstFinished, secondFinished]
+            let result = await XCTWaiter.fulfillment(of: expected, timeout: 5)
+            guard result == .completed else {
+                XCTFail("A duplicate start lost an admission continuation")
+                first.cancel()
+                second.cancel()
+                return
+            }
+            await first.value
+            await second.value
+            _ = await ticket.end()
+            await manager.updateConfiguration { $0.baselineOverride = 2048 }
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

Related issue: [ml-explore/mlx-swift-lm#600](https://github.com/ml-explore/mlx-swift-lm/issues/600).

`withWiredLimit` ends its ticket from a separate task as soon as cancellation arrives. The body can still be running at that point: cancellation is cooperative, and inference may need to finish outstanding work before returning. Releasing the ticket early lets the manager lower the wired-memory limit or admit more work while the cancelled operation still needs its reservation.

There are two other lifecycle problems:

- Cancelling a task while it waits for admission still runs the body's cleanup, but the wrapper then ends a ticket that was never admitted. This triggers a debug assertion, even though unmatched `end()` calls are documented as idempotent.
- Admission continuations are keyed by ticket ID. Two concurrent starts of the same waiting ticket overwrite one another, leaving a task suspended indefinitely. A delayed cancellation handler can also remove a newer wait for that ticket.

### The fix

Keep the ticket active until the body returns or throws, then await `end()` before returning to the caller. This removes the separate cancellation cleanup task and its lock-based guard.

Give each admission wait its own ID, while retaining the ticket ID for wakeups and events. Cancellation removes only its own registration. After waking, check whether another start already admitted the ticket so it is accounted for only once.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
