### PR TITLE
pool Streams, fix Device inheritance

### DIFF
--- a/Source/CompileLockRepro/CompileLockRepro.swift
+++ b/Source/CompileLockRepro/CompileLockRepro.swift
@@ -112,8 +112,6 @@ struct CompileLockRepro {
             default: die(2, "unknown --device \(CommandLine.arguments[index + 1])")
             }
         }
-        Device.setDefault(device: device)
-
         print(
             "compile-lock repro: device=\(device), \(rounds) rounds, \(Int(deadline))s deadline per round"
         )
@@ -125,7 +123,8 @@ struct CompileLockRepro {
         var tracedAtLeastOnce = false
 
         for round in 1 ... rounds {
-            tracedAtLeastOnce = runRound(round, keepAlive: &keepAlive) || tracedAtLeastOnce
+            tracedAtLeastOnce =
+                runRound(round, device: device, keepAlive: &keepAlive) || tracedAtLeastOnce
         }
 
         if !tracedAtLeastOnce {
@@ -141,7 +140,7 @@ struct CompileLockRepro {
     }
 
     /// Runs one round.  Returns whether the traced body actually executed.
-    static func runRound(_ round: Int, keepAlive: inout [Any]) -> Bool {
+    static func runRound(_ round: Int, device: Device, keepAlive: inout [Any]) -> Bool {
         let gate = DispatchSemaphore(value: 0)  // H (inside the trace) -> W
         let hDone = DispatchSemaphore(value: 0)
         let wDone = DispatchSemaphore(value: 0)
@@ -165,23 +164,27 @@ struct CompileLockRepro {
         keepAlive.append(outer)
 
         let h = Thread {
-            let a = MLXArray([1.0, 2.0, 3.0] as [Float])
-            let r = outer(a)
-            eval(r)
-            hDone.signal()
+            Device.withDefaultDevice(device) {
+                let a = MLXArray([1.0, 2.0, 3.0] as [Float])
+                let r = outer(a)
+                eval(r)
+                hDone.signal()
+            }
         }
         h.name = "H-nested-compiled-call"
 
         let w = Thread {
-            gate.wait()
-            let b = MLXArray([4.0, 5.0, 6.0] as [Float])
-            var iterations = 0
-            repeat {
-                let r = shared(b)  // W takes L_cf(shared), then wants evalLock
-                eval(r)
-                iterations += 1
-            } while !stop.isSet && iterations < 1000
-            wDone.signal()
+            Device.withDefaultDevice(device) {
+                gate.wait()
+                let b = MLXArray([4.0, 5.0, 6.0] as [Float])
+                var iterations = 0
+                repeat {
+                    let r = shared(b)  // W takes L_cf(shared), then wants evalLock
+                    eval(r)
+                    iterations += 1
+                } while !stop.isSet && iterations < 1000
+                wDone.signal()
+            }
         }
         w.name = "W-plain-compiled-call"
 

--- a/Source/MLX/Device.swift
+++ b/Source/MLX/Device.swift
@@ -211,7 +211,7 @@ public final class Device: @unchecked Sendable, Hashable {
 
         var type: mlx_device_type = MLX_CPU
         mlx_device_get_type(&type, ctx)
-        hasher.combine(type)
+        hasher.combine(type.rawValue)
     }
 }
 

--- a/Source/MLX/Device.swift
+++ b/Source/MLX/Device.swift
@@ -9,60 +9,77 @@ import Foundation
 public enum DeviceType: String, Hashable, Sendable {
     case cpu
     case gpu
+
+    var cDeviceType: mlx_device_type {
+        switch self {
+        case .cpu: return MLX_CPU
+        case .gpu: return MLX_GPU
+        }
+    }
+
+    init(_ cDeviceType: mlx_device_type) {
+        switch cDeviceType {
+        case MLX_CPU: self = .cpu
+        case MLX_GPU: self = .gpu
+        default: fatalError("Unknown deviceType: \(cDeviceType)")
+        }
+    }
 }
 
 /// Representation of a Device in MLX.
 ///
-/// Typically this is used via the `stream: ` parameter on a method with a ``StreamOrDevice``:
+/// This is typically used with ``withDefaultDevice(_:_:)-17vjl`` or ``Stream/withNewDefaultStream(device:_:)-5bwc3``.
 ///
 /// ```swift
-/// let a: MLXArray ...
-/// let result = sqrt(a, stream: .gpu)
+/// Device.withDefaultDevice(.cpu) {
+///     // default device is cpu inside this scope/task
+/// }
+///
+/// Stream.withNewDefaultStream(device: .cpu) {
+///     // default device is cpu inside this scope/task AND there
+///     // is a new Stream scoped to the work
+/// }
 /// ```
 ///
-/// Read more at <doc:using-streams>.
+/// Implementation: ``Stream`` hold the current device as a Task local variable.
 ///
 /// ### See Also
 /// - <doc:using-streams>
 /// - ``StreamOrDevice``
-public final class Device: @unchecked Sendable, Equatable {
+/// - ``Stream``
+public final class Device: @unchecked Sendable, Hashable {
 
     let ctx: mlx_device
-    let defaultStream: Stream
 
     init(_ ctx: mlx_device) {
         self.ctx = ctx
-
-        var deviceType = MLX_GPU
-        mlx_device_get_type(&deviceType, ctx)
-        self.defaultStream =
-            switch deviceType {
-            case MLX_CPU: .cpu
-            case MLX_GPU: .gpu
-            default: .gpu
-            }
     }
 
+    /// Initialize a new `Device` with a type and optional index.
+    ///
+    /// If `deviceType` is ``DeviceType/cpu`` then index _must_ be 0.
     public init(_ deviceType: DeviceType, index: Int32 = 0) {
-        var cDeviceType: mlx_device_type
-        switch deviceType {
-        case DeviceType.cpu:
-            cDeviceType = MLX_CPU
-        case DeviceType.gpu:
-            cDeviceType = MLX_GPU
+        if deviceType == .cpu {
+            precondition(index == 0)
         }
+        let cDeviceType = deviceType.cDeviceType
         self.ctx = mlx_device_new_type(cDeviceType, index)
-        self.defaultStream =
-            switch deviceType {
-            case .cpu: .cpu
-            case .gpu: .gpu
-            }
     }
 
     @available(*, deprecated, message: "please use defaultDevice()")
     public convenience init() {
+        self.init(copying: Stream.defaultDevice)
+    }
+
+    convenience init(stream: mlx_stream) {
         var ctx = mlx_device_new()
-        mlx_get_default_device(&ctx)
+        mlx_stream_get_device(&ctx, stream)
+        self.init(ctx)
+    }
+
+    convenience init(copying device: Device) {
+        var ctx = mlx_device_new()
+        mlx_device_set(&ctx, device.ctx)
         self.init(ctx)
     }
 
@@ -70,114 +87,131 @@ public final class Device: @unchecked Sendable, Equatable {
         mlx_device_free(ctx)
     }
 
-    /// static CPU device
+    /// Current CPU device.
     ///
-    /// See ``withDefaultDevice(_:_:)-17vjl``
-    static public let cpu: Device = Device(.cpu)
-
-    /// static GPU device
+    /// Note: previously this returned a `static` CPU device.
     ///
-    /// See ``withDefaultDevice(_:_:)-17vjl``
-    static public let gpu: Device = Device(.gpu)
-
-    public var deviceType: DeviceType? {
-        var cDeviceType = MLX_CPU
-        mlx_device_get_type(&cDeviceType, ctx)
-        return switch cDeviceType {
-        case MLX_CPU: DeviceType.cpu
-        case MLX_GPU: DeviceType.gpu
-        default: nil
-        }
+    /// ### See Also
+    /// - ``gpu``
+    /// - ``Stream/cpu``
+    /// - ``withDefaultDevice(_:_:)-17vjl``
+    static public var cpu: Device {
+        Stream.cpu.device
     }
 
-    // support for global default device
-    static let _lock = NSLock()
-    #if swift(>=5.10)
-        nonisolated(unsafe) static var _defaultDevice: Device?
-    #else
-        static var _defaultDevice: Device?
-    #endif
+    /// Current GPU device.
+    ///
+    /// Note: previously this returned a `static` GPU device -- it would
+    /// always be index 0, even if there were multiple GPUs in the system.
+    ///
+    /// ### See Also
+    /// - ``cpu``
+    /// - ``Stream/gpu``
+    /// - ``withDefaultDevice(_:_:)-17vjl``
+    static public var gpu: Device {
+        Stream.gpu.device
+    }
 
-    @TaskLocal static var _tlDefaultDevice = _resolveGlobalDefaultDevice()
-
-    private static func _resolveGlobalDefaultDevice() -> Device {
-        _lock.withLock {
-            if let device = _defaultDevice {
-                return device
-            }
-            // Ask the underlying MLX C++ core for its default device rather
-            // than hard-coding `.gpu`. On Apple platforms with Metal this
-            // still resolves to GPU; on a CPU-only host (Linux without
-            // CUDA / no Metal) it correctly resolves to CPU. Hard-coding GPU
-            // here meant `defaultDevice()` / `StreamOrDevice.default`
-            // returned an unavailable device on those hosts.
-            var ctx = mlx_device_new()
-            mlx_get_default_device(&ctx)
-            return Device(ctx)
-        }
+    /// The ``DeviceType`` for the device.
+    ///
+    /// Note: previously this returned an Optional ``DeviceType``.  Now it is
+    /// not optional and it will be a `fatalError` if the DeviceType is unknown.
+    public var deviceType: DeviceType {
+        var cDeviceType = MLX_CPU
+        mlx_device_get_type(&cDeviceType, ctx)
+        return DeviceType(cDeviceType)
     }
 
     /// Return the current default device.
-    ///
-    /// This is used by ``StreamOrDevice/default`` -- the default stream parameter
-    /// to most functions.
     static public func defaultDevice() -> Device {
-        _tlDefaultDevice
+        Stream.defaultDevice
     }
 
-    /// Use a device scoped to a task.
+    /// Use a device scoped to a Task.
+    ///
+    /// This can be used to set the default device to e.g. the CPU:
+    ///
+    /// ```swift
+    /// Device.withDefaultDevice(.cpu) {
+    ///     // default device is cpu inside this scope/task
+    /// }
+    /// ```
+    ///
+    /// If a GPU device is given and it does not match the current GPU it will
+    /// override the default device and provide a new stream:
+    ///
+    /// ```swift
+    /// Device.withDefaultDevice(.init(.gpu, index: 3)) {
+    ///     // if the enclosing GPU was index 0, this will have
+    ///     // both a new default device and a new stream
+    /// }
+    /// ```
+    ///
+    /// See also ``Stream/withNewDefaultStream(device:_:)-5bwc3``.
     static public func withDefaultDevice<R>(
         _ device: Device, _ body: () throws -> R
     ) rethrows -> R {
-        try $_tlDefaultDevice.withValue(device, operation: body)
+        try Stream.withNewDefaultDevice(device: device, body)
     }
 
-    /// Use a device scoped to a task.
+    /// Use a device scoped to a Task.
+    ///
+    /// This can be used to set the default device to e.g. the CPU:
+    ///
+    /// ```swift
+    /// Device.withDefaultDevice(.cpu) {
+    ///     // default device is cpu inside this scope/task
+    /// }
+    /// ```
+    ///
+    /// If a GPU device is given and it does not match the current GPU it will
+    /// override the default device and provide a new stream:
+    ///
+    /// ```swift
+    /// Device.withDefaultDevice(.init(.gpu, index: 3)) {
+    ///     // if the enclosing GPU was index 0, this will have
+    ///     // both a new default device and a new stream
+    /// }
+    /// ```
+    ///
+    /// See also ``Stream/withNewDefaultStream(device:_:)-5bwc3``.
     static public func withDefaultDevice<R>(
         _ device: Device, _ body: () async throws -> R
     ) async rethrows -> R {
-        try await $_tlDefaultDevice.withValue(device, operation: body)
+        try await Stream.withNewDefaultDevice(device: device, body)
     }
 
-    /// Return the current default stream.
-    static func defaultStream() -> Stream {
-        _tlDefaultDevice.defaultStream
-    }
-
-    /// Set the default device globally.  Prefer the scoped version, ``withDefaultDevice(_:_:)-17vjl``.
+    /// Set the default device globally.  Use the scoped version, ``withDefaultDevice(_:_:)-17vjl``
+    /// -- this is only usable before any mlx resources are created.
     ///
-    /// For example:
+    /// Beware: using the static cpu and gpu values will render this unusable.  If required, call like this:
     ///
     /// ```swift
-    /// Device.setDefault(device: Device(.cpu, index: 1))
+    /// Device.setDefault(device: .init(.cpu))
     /// ```
-    ///
-    /// By default this is ``gpu``.
-    ///
-    /// ### See Also
-    /// - ``withDefaultDevice(_:_:)-17vjl``
-    /// - ``StreamOrDevice/default``
-    @available(*, deprecated, message: "please use withDefaultDevice()")
+    @available(
+        *, deprecated,
+        message: "use withDefaultDevice() -- this only works before any mlx resources are created"
+    )
     static public func setDefault(device: Device?) {
-        _lock.withLock {
-            if let device {
-                // sets the mlx core default device -- only used
-                // by the deprecated init().  this isn't thread
-                // safe or really usable across tasks/threads
-                // but is kept for backward compatibility
-                mlx_set_default_device(device.ctx)
-            }
-            _defaultDevice = device
+        if let ctx = device?.ctx {
+            mlx_set_default_device(ctx)
         }
     }
 
-    /// Compare two ``Device`` for equality -- this does not compare the index, just the device type.
+    /// Compare two ``Device`` for equality
     public static func == (lhs: Device, rhs: Device) -> Bool {
-        var lhs_type = MLX_CPU
-        var rhs_type = MLX_CPU
-        mlx_device_get_type(&lhs_type, lhs.ctx)
-        mlx_device_get_type(&rhs_type, rhs.ctx)
-        return lhs_type == rhs_type
+        mlx_device_equal(lhs.ctx, rhs.ctx)
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        var index: Int32 = 0
+        mlx_device_get_index(&index, ctx)
+        hasher.combine(index)
+
+        var type: mlx_device_type = MLX_CPU
+        mlx_device_get_type(&type, ctx)
+        hasher.combine(type)
     }
 }
 

--- a/Source/MLX/Documentation.docc/Articles/using-streams.md
+++ b/Source/MLX/Documentation.docc/Articles/using-streams.md
@@ -8,7 +8,7 @@ All operations (including random number generation) take an optional
 argument `stream`. The `stream` specifies which
 `Stream` the operation should run on. If the stream is unspecified then
 the operation is run on the default stream of the default device:
-``Stream/defaultStream(_:)``.  The `stream` can also
+``Stream/defaultStream(_:)-(DeviceType)``.  The `stream` can also
 be a ``Device`` (e.g. `stream: .cpu`) in which case the operation is
 run on the default stream of the provided device.
 

--- a/Source/MLX/Stream.swift
+++ b/Source/MLX/Stream.swift
@@ -32,25 +32,27 @@ public struct StreamOrDevice: Sendable, CustomStringConvertible, Equatable {
 
     /// The default stream on the default device.
     ///
-    /// This will be ``Device/gpu`` unless ``Device/setDefault(device:)``
-    /// sets it otherwise.
+    /// See ``Stream/defaultStream``.
     public static var `default`: StreamOrDevice {
-        StreamOrDevice(Stream.defaultStream ?? Device.defaultStream())
+        StreamOrDevice(Stream.defaultStream)
     }
 
+    /// Evaluate on the given ``Device``.
+    ///
+    /// Prefer ``cpu`` and ``gpu`` instead as they will use the current Device for the
+    /// Task.
+    @available(*, deprecated, message: "prefer stream(Stream)")
     public static func device(_ device: Device) -> StreamOrDevice {
         StreamOrDevice(Stream.defaultStream(device))
     }
 
-    /// The ``Stream/defaultStream(_:)`` on the ``Device/cpu``
-    public static let cpu = device(.cpu)
+    /// Evaluate on the current CPU stream, ``Stream/cpu``.
+    public static var cpu: StreamOrDevice { .stream(.cpu) }
 
-    /// The ``Stream/defaultStream(_:)`` on the ``Device/gpu``
-    ///
-    /// ### See Also
-    /// - ``GPU``
-    public static let gpu = device(.gpu)
+    /// Evaluate on the current GPU stream, ``Stream/gpu``.
+    public static var gpu: StreamOrDevice { .stream(.gpu) }
 
+    /// Evaluate on the given stream.
     public static func stream(_ stream: Stream) -> StreamOrDevice {
         StreamOrDevice(stream)
     }
@@ -65,9 +67,174 @@ public struct StreamOrDevice: Sendable, CustomStringConvertible, Equatable {
     }
 }
 
+/// Pool for recycling ``Stream`` (`mlx_stream`).
+///
+/// See also https://github.com/ml-explore/mlx/issues/2118 -- there are
+/// metal/OS resources associated with a GPU stream that may never be collected.
+/// Reuse the streams.
+///
+/// `Stream.deinit` will return the underlying `mlx_stream` to the pool.
+private final class StreamPool: @unchecked Sendable {
+    private var idle: [Device: [mlx_stream]] = [:]
+    private let lock = NSLock()
+
+    init() {
+    }
+
+    func newStream(_ device: Device) -> mlx_stream {
+        // do not hold the evalLock at the same time as the pool lock
+        let (valid, stream) = lock.withLock {
+            if let value = idle[device, default: []].popLast() {
+                return (true, value)
+            }
+            return (false, mlx_stream())
+        }
+        if valid {
+            return stream
+        }
+
+        return withEvalLock {
+            let result = mlx_stream_new_thread_unsafe(device.ctx)
+            if result.ctx == nil {
+                fatalError("Unable to create stream: \(device)")
+            }
+            return result
+        }
+    }
+
+    func releaseStream(_ stream: mlx_stream) {
+        let device = Device(stream: stream)
+
+        lock.withLock {
+            idle[device, default: []].append(stream)
+        }
+    }
+}
+
+/// global stream pool
+private let streamPool = StreamPool()
+
+private protocol StreamPromise: Sendable {
+    var current: Stream { get }
+    var device: Device { get }
+}
+
+private final class LazyStreamPromise: StreamPromise, @unchecked Sendable {
+    private var stream: Stream?
+    private let lock = NSLock()
+
+    let device: Device
+
+    init(_ device: Device) {
+        self.stream = nil
+        self.device = device
+    }
+
+    var current: Stream {
+        if let stream = lock.withLock({ self.stream }) {
+            return stream
+        }
+
+        // double checked lock to avoid holding a lock outside evalLock
+        let stream = Stream(streamPool.newStream(device))
+
+        return lock.withLock {
+            if let current = self.stream {
+                return current
+            } else {
+                self.stream = stream
+                return stream
+            }
+        }
+    }
+}
+
+private final class RealizedStreamPromise: StreamPromise, Sendable {
+    let current: Stream
+    let device: Device
+
+    init(_ device: Device) {
+        self.device = device
+        self.current = Stream(streamPool.newStream(device))
+    }
+
+    init(_ promise: StreamPromise) {
+        self.device = promise.device
+        self.current = promise.current
+    }
+}
+
+/// TaskLocal promise for a pair of Streams -- one for CPU and one for GPU.
+///
+/// Implementation note: the default device will be a realized Stream and the
+/// none default device will be a lazy promise.
+private final class StreamPairPromise: Sendable {
+    let cpu: StreamPromise
+    let gpu: StreamPromise
+    let defaultDeviceType: DeviceType
+
+    var defaultStream: StreamPromise {
+        switch defaultDeviceType {
+        case .cpu: cpu
+        case .gpu: gpu
+        }
+    }
+
+    /// Initialize the global promise.
+    init() {
+        var default_ctx = mlx_device_new()
+        mlx_get_default_device(&default_ctx)
+
+        let defaultDevice = Device(default_ctx)
+        self.defaultDeviceType = defaultDevice.deviceType
+        if defaultDevice.deviceType == .cpu {
+            self.cpu = RealizedStreamPromise(defaultDevice)
+            self.gpu = LazyStreamPromise(Device(.gpu))
+        } else {
+            self.cpu = LazyStreamPromise(Device(.cpu))
+            self.gpu = RealizedStreamPromise(defaultDevice)
+        }
+    }
+
+    /// Initialize with new streams.
+    ///
+    /// See ``Stream/withNewDefaultStream(device:_:)``.
+    init(cpu: Device, gpu: Device, defaultDeviceType: DeviceType) {
+        self.defaultDeviceType = defaultDeviceType
+        if defaultDeviceType == .cpu {
+            self.cpu = RealizedStreamPromise(cpu)
+            self.gpu = LazyStreamPromise(gpu)
+        } else {
+            self.cpu = LazyStreamPromise(cpu)
+            self.gpu = RealizedStreamPromise(gpu)
+        }
+    }
+
+    /// Initialize with a new default device and a parent.
+    ///
+    /// See ``Device/withDefaultDevice(_:_:)``.
+    init(parent: StreamPairPromise, device: Device) {
+        self.defaultDeviceType = device.deviceType
+
+        switch self.defaultDeviceType {
+        case .cpu:
+            self.cpu = RealizedStreamPromise(parent.cpu)
+            self.gpu = parent.gpu
+
+        case .gpu:
+            self.cpu = parent.cpu
+            if parent.gpu.device == device {
+                self.gpu = RealizedStreamPromise(parent.gpu)
+            } else {
+                self.gpu = RealizedStreamPromise(device)
+            }
+        }
+    }
+}
+
 /// A stream of evaluation attached to a particular device.
 ///
-/// Typically this is used via the `stream: ` parameter on a method with a ``StreamOrDevice``:
+/// Typically this is used via the `stream:` parameter on a method with a ``StreamOrDevice``:
 ///
 /// ```swift
 /// let a: MLXArray ...
@@ -76,81 +243,185 @@ public struct StreamOrDevice: Sendable, CustomStringConvertible, Equatable {
 ///
 /// Read more at <doc:using-streams>.
 ///
+/// ## Implementation Notes
+///
+/// There is a global pair of CPU/GPU streams.  On devices with a GPU (and associated GPU software)
+/// the default stream will be a GPU stream.
+///
+/// The default streams can be overridden and scoped to a `Task` using:
+///
+/// ```swift
+/// Stream.withNewDefaultStream {
+///     // the default stream is private to this Task
+/// }
+/// ```
+///
+/// Callers can override the default device by passing a device to that method or using
+/// ``Device/withDefaultDevice(_:_:)-17vjl`` to override the default device without
+/// getting a new (private) default stream.
+///
+/// Also note that the current ``Device/defaultDevice()`` is owned by ``Stream/defaultStream``.
+///
 /// ### See Also
 /// - <doc:using-streams>
 /// - ``StreamOrDevice``
+/// - ``Device``
 public final class Stream: @unchecked Sendable, Equatable {
 
+    /// reference to the backing C++ stream object
     let ctx: mlx_stream
 
-    private static func newStreamThreadUnsafe(_ deviceType: DeviceType) -> mlx_stream {
-        var cDeviceType: mlx_device_type
-        switch deviceType {
-        case DeviceType.cpu:
-            cDeviceType = MLX_CPU
-        case DeviceType.gpu:
-            cDeviceType = MLX_GPU
-        }
-        return evalLock.withLock {
-            let ctx = mlx_device_new_type(cDeviceType, 0)
-            defer { mlx_device_free(ctx) }
-            return mlx_stream_new_thread_unsafe(ctx)
-        }
+    /// the global cpu and gpu streams
+    private static let globalStreams = StreamPairPromise()
+
+    /// the task local override streams, see ``withNewDefaultStream(device:_:)``
+    @TaskLocal private static var localStreams: StreamPairPromise?
+
+    /// the current GPU stream
+    public static var gpu: Stream {
+        localStreams?.gpu.current ?? globalStreams.gpu.current
     }
 
-    public static let gpu = Stream(newStreamThreadUnsafe(.gpu))
-    public static let cpu = Stream(newStreamThreadUnsafe(.cpu))
-
-    @TaskLocal static var defaultStream: Stream?
-
-    /// Set the ``StreamOrDevice/default`` scoped to a Task.
-    public static func withNewDefaultStream<R>(device: Device? = nil, _ body: () throws -> R)
-        rethrows -> R
-    {
-        let device = device ?? Device.defaultDevice()
-        return try $defaultStream.withValue(Stream(device), operation: body)
+    /// the current CPU stream
+    public static var cpu: Stream {
+        localStreams?.cpu.current ?? globalStreams.cpu.current
     }
 
-    /// Set the ``StreamOrDevice/default`` scoped to a Task.
+    /// the current default stream, see ``StreamOrDevice`` -- if no stream is
+    /// specified, this will be the stream that all operations run on.
+    public static var defaultStream: Stream {
+        localStreams?.defaultStream.current ?? globalStreams.defaultStream.current
+    }
+
+    static var defaultDevice: Device {
+        let streams = localStreams ?? globalStreams
+        return streams.defaultStream.device
+    }
+
+    var device: Device { Device(stream: ctx) }
+    var index: Int {
+        var index: Int32 = 0
+        mlx_stream_get_index(&index, ctx)
+        return Int(index)
+    }
+
+    /// Obtain a new CPU and GPU stream scoped to the block and inherited through `Tasks`.
+    ///
+    /// For example you can get a new stream on the current device:
+    ///
+    /// ```swift
+    /// Stream.withNewDefaultStream {
+    ///     // A new Stream on the default Device scoped to the block and Task
+    /// }
+    /// ```
+    ///
+    /// Or a new stream on a different device (it will become the default device, scoped to the block
+    /// and Task):
+    ///
+    /// ```swift
+    /// Stream.withNewDefaultStream(device: .cpu) {
+    ///     // A new Stream on the cpu Device scoped to the block and Task.
+    ///     // The cpu is now the default device.
+    /// }
+    /// ```
+    ///
+    /// These calls can be nested arbitrarily.
+    ///
+    /// See also ``Device/withDefaultDevice(_:_:)-17vjl`` which can change the default device
+    /// without creating new scoped Streams.
+    public static func withNewDefaultStream<R>(
+        device: Device? = nil, _ body: () throws -> R
+    ) rethrows -> R {
+        let streams = localStreams ?? globalStreams
+        let device = device ?? streams.defaultStream.device
+        let cpu = device.deviceType == .cpu ? device : streams.cpu.device
+        let gpu = device.deviceType == .gpu ? device : streams.gpu.device
+        return try $localStreams.withValue(
+            StreamPairPromise(cpu: cpu, gpu: gpu, defaultDeviceType: device.deviceType),
+            operation: body)
+    }
+
+    /// Obtain a new CPU and GPU stream scoped to the block and inherited through `Tasks`.
+    ///
+    /// For example you can get a new stream on the current device:
+    ///
+    /// ```swift
+    /// Stream.withNewDefaultStream {
+    ///     // A new Stream on the default Device scoped to the block and Task
+    /// }
+    /// ```
+    ///
+    /// Or a new stream on a different device (it will become the default device, scoped to the block
+    /// and Task):
+    ///
+    /// ```swift
+    /// Stream.withNewDefaultStream(device: .cpu) {
+    ///     // A new Stream on the cpu Device scoped to the block and Task.
+    ///     // The cpu is now the default device.
+    /// }
+    /// ```
+    ///
+    /// These calls can be nested arbitrarily.
+    ///
+    /// See also ``Device/withDefaultDevice(_:_:)-17vjl`` which can change the default device
+    /// without creating new scoped Streams.
     public static func withNewDefaultStream<R>(
         device: Device? = nil, _ body: () async throws -> R
     ) async rethrows -> R {
-        let device = device ?? Device.defaultDevice()
-        return try await $defaultStream.withValue(Stream(device), operation: body)
+        let streams = localStreams ?? globalStreams
+        let device = device ?? streams.defaultStream.device
+        let cpu = device.deviceType == .cpu ? device : streams.cpu.device
+        let gpu = device.deviceType == .gpu ? device : streams.gpu.device
+        return try await $localStreams.withValue(
+            StreamPairPromise(cpu: cpu, gpu: gpu, defaultDeviceType: device.deviceType),
+            operation: body)
+    }
+
+    /// Implementation for ``Device/withDefaultDevice(_:_:)``
+    static func withNewDefaultDevice<R>(
+        device: Device, _ body: () throws -> R
+    ) rethrows -> R {
+        let pair = StreamPairPromise(
+            parent: localStreams ?? globalStreams, device: device)
+        return try $localStreams.withValue(pair, operation: body)
+    }
+
+    /// Implementation for ``Device/withDefaultDevice(_:_:)``
+    static func withNewDefaultDevice<R>(
+        device: Device, _ body: () async throws -> R
+    ) async rethrows -> R {
+        let pair = StreamPairPromise(
+            parent: localStreams ?? globalStreams, device: device)
+        return try await $localStreams.withValue(pair, operation: body)
     }
 
     init(_ ctx: mlx_stream) {
         self.ctx = ctx
     }
 
-    /// Default stream on the default device.
+    /// New stream on the default device.
+    @available(*, deprecated, message: "use withNewDefaultStream instead")
     public init() {
-        let device = Device.defaultDevice()
-        self.ctx = evalLock.withLock {
-            mlx_stream_new_thread_unsafe(device.ctx)
-        }
-    }
-
-    @available(*, deprecated, message: "use init(Device) -- index not supported")
-    public init(index: Int32, _ device: Device) {
-        self.ctx = evalLock.withLock {
-            mlx_stream_new_thread_unsafe(device.ctx)
-        }
+        self.ctx = streamPool.newStream(Device.defaultDevice())
     }
 
     /// New stream on the given device.
     ///
-    /// See also ``withNewDefaultStream(device:_:)-5bwc3``
+    /// Note: `index` is unused.
+    @available(*, deprecated, message: "use withNewDefaultStream instead")
+    public init(index: Int32, _ device: Device) {
+        self.ctx = streamPool.newStream(device)
+    }
+
+    /// New stream on the given device.
+    ///
+    /// Prefer ``withNewDefaultStream(device:_:)-5bwc3``
     public init(_ device: Device) {
-        self.ctx = evalLock.withLock {
-            mlx_stream_new_thread_unsafe(device.ctx)
-        }
+        self.ctx = streamPool.newStream(device)
     }
 
     deinit {
-        _ = withEvalLock {
-            mlx_stream_free(ctx)
-        }
+        streamPool.releaseStream(ctx)
     }
 
     /// Synchronize with the given stream
@@ -160,11 +431,27 @@ public final class Stream: @unchecked Sendable, Equatable {
         }
     }
 
+    @_disfavoredOverload
+    @available(
+        *, deprecated, message: "use defaultStream(DeviceType) or withNewDefaultStream(Device)"
+    )
     static public func defaultStream(_ device: Device) -> Stream {
         switch device.deviceType {
+        case .cpu: return .cpu
+        case .gpu:
+            let streams = localStreams ?? globalStreams
+            if streams.gpu.device == device {
+                return streams.gpu.current
+            } else {
+                return Stream(device)
+            }
+        }
+    }
+
+    static public func defaultStream(_ deviceType: DeviceType) -> Stream {
+        switch deviceType {
         case .cpu: .cpu
         case .gpu: .gpu
-        default: fatalError("Unexpected device type: \(device)")
         }
     }
 

--- a/Tests/MLXTests/CompileLockOrderingTests.swift
+++ b/Tests/MLXTests/CompileLockOrderingTests.swift
@@ -23,7 +23,6 @@ import XCTest
     class CompileLockOrderingTests: XCTestCase {
 
         override class func setUp() {
-            setDefaultDevice()
         }
 
         /// The instrumentation must be able to report "not held", otherwise a

--- a/Tests/MLXTests/FFTTests.swift
+++ b/Tests/MLXTests/FFTTests.swift
@@ -7,7 +7,6 @@ import XCTest
 class FFTTests: XCTestCase {
 
     override class func setUp() {
-        setDefaultDevice()
     }
 
     func testFFTRoundTrip() {

--- a/Tests/MLXTests/FP8Tests.swift
+++ b/Tests/MLXTests/FP8Tests.swift
@@ -7,7 +7,6 @@ import XCTest
 class FP8Tests: XCTestCase {
 
     override class func setUp() {
-        setDefaultDevice()
     }
 
     func testFromFP8DecodesE4M3Bytes() {

--- a/Tests/MLXTests/GraphUtilsTests.swift
+++ b/Tests/MLXTests/GraphUtilsTests.swift
@@ -7,7 +7,6 @@ import XCTest
 class GraphUtilsTests: XCTestCase {
 
     override class func setUp() {
-        setDefaultDevice()
     }
 
     func testExportToDot() {

--- a/Tests/MLXTests/IntegrationTests.swift
+++ b/Tests/MLXTests/IntegrationTests.swift
@@ -16,7 +16,6 @@ import XCTest
 class MLXIntegrationTests: XCTestCase {
 
     override class func setUp() {
-        setDefaultDevice()
     }
 
     func testRandomSeed() {

--- a/Tests/MLXTests/LinalgTests.swift
+++ b/Tests/MLXTests/LinalgTests.swift
@@ -7,7 +7,6 @@ import XCTest
 class LinalgTests: XCTestCase {
 
     override class func setUp() {
-        setDefaultDevice()
     }
 
     func testNormNoAxes() {

--- a/Tests/MLXTests/LossTests.swift
+++ b/Tests/MLXTests/LossTests.swift
@@ -7,7 +7,6 @@ import XCTest
 
 class LossTests: XCTestCase {
     override class func setUp() {
-        setDefaultDevice()
     }
 
     func testCrossEntropy() {

--- a/Tests/MLXTests/MLXArray+IndexingTests.swift
+++ b/Tests/MLXTests/MLXArray+IndexingTests.swift
@@ -23,7 +23,6 @@ extension MLXArrayIndexOperation: Equatable {
 class MLXArrayIndexingTests: XCTestCase {
 
     override class func setUp() {
-        setDefaultDevice()
     }
 
     // MARK: - Subscript (get)

--- a/Tests/MLXTests/MLXArray+InitTests.swift
+++ b/Tests/MLXTests/MLXArray+InitTests.swift
@@ -13,7 +13,6 @@ import XCTest
 class MLXArrayInitTests: XCTestCase {
 
     override class func setUp() {
-        setDefaultDevice()
     }
 
     // MARK: - Dtype

--- a/Tests/MLXTests/MLXArray+OpsTests.swift
+++ b/Tests/MLXTests/MLXArray+OpsTests.swift
@@ -9,7 +9,6 @@ import XCTest
 class MLXArrayOpsTests: XCTestCase {
 
     override class func setUp() {
-        setDefaultDevice()
     }
 
     // MARK: - Operators

--- a/Tests/MLXTests/MLXArrayTests.swift
+++ b/Tests/MLXTests/MLXArrayTests.swift
@@ -8,7 +8,6 @@ import XCTest
 class MLXArrayTests: XCTestCase {
 
     override class func setUp() {
-        setDefaultDevice()
     }
 
     func testArrayProperties() {

--- a/Tests/MLXTests/MLXRandomTests.swift
+++ b/Tests/MLXTests/MLXRandomTests.swift
@@ -7,7 +7,6 @@ import XCTest
 class MLXRandomTests: XCTestCase {
 
     override class func setUp() {
-        setDefaultDevice()
     }
 
     func testSplit() {

--- a/Tests/MLXTests/ModuleTests.swift
+++ b/Tests/MLXTests/ModuleTests.swift
@@ -9,7 +9,6 @@ import XCTest
 class ModuleTests: XCTestCase {
 
     override class func setUp() {
-        setDefaultDevice()
     }
 
     func newTestModule() -> Module {

--- a/Tests/MLXTests/NestedTests.swift
+++ b/Tests/MLXTests/NestedTests.swift
@@ -7,7 +7,6 @@ import XCTest
 class NestedTests: XCTestCase {
 
     override class func setUp() {
-        setDefaultDevice()
     }
 
     static let defaultValues = [10, 1, 2, 1, 2, 3, 10, 20, 30]

--- a/Tests/MLXTests/OpsTests.swift
+++ b/Tests/MLXTests/OpsTests.swift
@@ -8,7 +8,6 @@ import XCTest
 class OpsTests: XCTestCase {
 
     override class func setUp() {
-        setDefaultDevice()
     }
 
     func testAsStridedReshape() {

--- a/Tests/MLXTests/OptimizerTests.swift
+++ b/Tests/MLXTests/OptimizerTests.swift
@@ -10,7 +10,6 @@ import XCTest
 class OptimizerTests: XCTestCase {
 
     override class func setUp() {
-        setDefaultDevice()
     }
 
     class ShapeModule: Module {

--- a/Tests/MLXTests/SaveTests.swift
+++ b/Tests/MLXTests/SaveTests.swift
@@ -16,7 +16,6 @@ final class SaveTests: XCTestCase {
     )
 
     override func setUpWithError() throws {
-        setDefaultDevice()
         try FileManager.default.createDirectory(
             at: temporaryPath,
             withIntermediateDirectories: false

--- a/Tests/MLXTests/StreamTests.swift
+++ b/Tests/MLXTests/StreamTests.swift
@@ -1,21 +1,60 @@
 // Copyright © 2024 Apple Inc.
 
 import Foundation
-import MLX
 import XCTest
 
+@testable import MLX
+
 class StreamTests: XCTestCase {
+
+    // MARK: - Device: Equatable / Hashable
 
     func testEquatableDevice() {
         let s1 = Device.gpu
         let s2 = Device(.gpu, index: 3)
         let s3 = Device.cpu
+        let s4 = Device(.gpu)
 
-        // equality ignores index
-        XCTAssertEqual(s1, s2)
+        // equality does not ignore the index -- this changed: it used to
+        // compare the device type only
+        XCTAssertNotEqual(s1, s2)
+
+        XCTAssertEqual(s1, s4)
 
         XCTAssertNotEqual(s1, s3)
         XCTAssertNotEqual(s2, s3)
+    }
+
+    func testHashableDevice() {
+        XCTAssertEqual(Device.gpu.hashValue, Device(.gpu).hashValue)
+        XCTAssertEqual(Device.cpu.hashValue, Device(.cpu).hashValue)
+
+        // usable as a dictionary key
+        var counts: [Device: Int] = [:]
+        counts[Device.gpu, default: 0] += 1
+        counts[Device(.gpu), default: 0] += 1
+        counts[Device(.gpu, index: 3), default: 0] += 1
+        counts[Device.cpu, default: 0] += 1
+
+        XCTAssertEqual(counts.count, 3)
+        XCTAssertEqual(counts[Device.gpu], 2)
+        XCTAssertEqual(counts[Device(.gpu, index: 3)], 1)
+        XCTAssertEqual(counts[Device.cpu], 1)
+    }
+
+    @available(*, deprecated)
+    func testDeprecatedDeviceInitCopiesDefault() {
+        // Device() produces the same value as defaultDevice
+        XCTAssertEqual(Device(), Device.defaultDevice())
+
+        Device.withDefaultDevice(.cpu) {
+            XCTAssertEqual(Device(), Device.cpu)
+        }
+
+        let gpu = Device(.gpu, index: 7)
+        Device.withDefaultDevice(gpu) {
+            XCTAssertEqual(Device(), gpu)
+        }
     }
 
     func testDeviceType() {
@@ -28,37 +67,112 @@ class StreamTests: XCTestCase {
         XCTAssertEqual(s3.deviceType, .cpu)
     }
 
+    // MARK: - withDefaultDevice
+
     func testUsingDevice() {
         let defaultDevice = Device.defaultDevice()
 
         Device.withDefaultDevice(.cpu) {
-            // these _should_ be the same
-            XCTAssertTrue(Device.defaultDevice().description.contains("cpu"))
-            XCTAssertTrue(StreamOrDevice.default.description.contains("cpu"))
+            // the default device and the default stream must agree
+            XCTAssertEqual(Device.defaultDevice(), Device.cpu)
+            XCTAssertEqual(StreamOrDevice.default.stream, MLX.Stream.cpu)
         }
         XCTAssertEqual(defaultDevice, Device.defaultDevice())
 
         Device.withDefaultDevice(.gpu) {
-            XCTAssertTrue(Device.defaultDevice().description.contains("gpu"))
-            XCTAssertTrue(StreamOrDevice.default.description.contains("gpu"))
+            XCTAssertEqual(Device.defaultDevice(), Device.gpu)
+            XCTAssertEqual(StreamOrDevice.default.stream, MLX.Stream.gpu)
         }
-        XCTAssertTrue(StreamOrDevice.default.description.contains("gpu"))
+
+        let gpu = Device(.gpu, index: 7)
+        Device.withDefaultDevice(gpu) {
+            XCTAssertEqual(Device.defaultDevice(), gpu)
+            XCTAssertEqual(StreamOrDevice.default.stream, MLX.Stream.gpu)
+        }
+
+        // restored on scope exit
+        XCTAssertEqual(defaultDevice, Device.defaultDevice())
     }
 
-    func testSetUnsetDefaultDevice() {
-        // Issue #237 -- setting an unsetting the default device in a loop
-        // exhausts many resources
-        for _ in 1 ..< 10000 {
-            let defaultDevice = MLX.Device.defaultDevice()
-            MLX.Device.setDefault(device: .cpu)
-            defer {
-                MLX.Device.setDefault(device: defaultDevice)
+    func testWithDefaultDeviceNests() {
+        Device.withDefaultDevice(.cpu) {
+            XCTAssertEqual(Device.defaultDevice(), Device.cpu)
+
+            Device.withDefaultDevice(.gpu) {
+                XCTAssertEqual(Device.defaultDevice(), Device.gpu)
+
+                Device.withDefaultDevice(.cpu) {
+                    XCTAssertEqual(Device.defaultDevice(), Device.cpu)
+                }
+
+                XCTAssertEqual(Device.defaultDevice(), Device.gpu)
             }
 
-            let x = MLXArray(1)
-            let _ = x * x
+            XCTAssertEqual(Device.defaultDevice(), Device.cpu)
         }
-        print("here")
+    }
+
+    func testNestedStreamsAndDevices() {
+        let outerCpu = MLX.Stream.cpu
+        let outerGpu = MLX.Stream.gpu
+
+        Device.withDefaultDevice(.cpu) {
+            XCTAssertEqual(MLX.Stream.defaultStream, outerCpu)
+            XCTAssertEqual(MLX.Stream.cpu, outerCpu)
+            XCTAssertEqual(MLX.Stream.gpu, outerGpu)
+        }
+
+        let gpu7 = Device(.gpu, index: 7)
+        Stream.withNewDefaultStream(device: gpu7) {
+            // default is now gpu/7
+            XCTAssertNotEqual(MLX.Stream.defaultStream, outerGpu)
+            XCTAssertEqual(MLX.Stream.defaultStream, MLX.Stream.gpu)
+            XCTAssertEqual(MLX.Stream.defaultStream.device, gpu7)
+
+            // not the same stream
+            XCTAssertNotEqual(MLX.Stream.cpu, outerCpu)
+
+            let gpu7Stream = MLX.Stream.defaultStream
+
+            // this will override the cpu stream but not the gpu stream
+            Device.withDefaultDevice(.cpu) {
+                XCTAssertEqual(MLX.Stream.defaultStream.device, outerCpu.device)
+
+                // this is the same stream, we are just changing the default device
+                XCTAssertEqual(MLX.Stream.gpu, gpu7Stream)
+            }
+
+            // new scoped stream on GPU index 0
+            Stream.withNewDefaultStream(device: .init(.gpu, index: 0)) {
+                XCTAssertEqual(MLX.Stream.defaultStream.device, outerGpu.device)
+                XCTAssertNotEqual(MLX.Stream.gpu, gpu7Stream)
+                XCTAssertNotEqual(MLX.Stream.gpu, outerGpu)
+                XCTAssertEqual(MLX.Stream.gpu.device, outerGpu.device)
+                XCTAssertNotEqual(MLX.Stream.gpu.device, gpu7)
+            }
+
+            // new scoped stream with default cpu but gpu inheriting from parent (gpu7)
+            Stream.withNewDefaultStream(device: .cpu) {
+                XCTAssertEqual(MLX.Stream.defaultStream.device, outerCpu.device)
+
+                // not the same stream
+                XCTAssertNotEqual(MLX.Stream.gpu, gpu7Stream)
+
+                // but the same device
+                XCTAssertEqual(MLX.Stream.gpu.device, gpu7)
+            }
+
+        }
+    }
+
+    func testWithNewDefaultStreamDefaultsToCurrentDevice() {
+        // `device:` omitted means "a new stream on the current default device".
+        Device.withDefaultDevice(.cpu) {
+            MLX.Stream.withNewDefaultStream {
+                XCTAssertEqual(Device.defaultDevice(), Device.cpu)
+                XCTAssertEqual(MLX.Stream.defaultStream, MLX.Stream.cpu)
+            }
+        }
     }
 
     func testWithDefaultDevice() {
@@ -71,7 +185,179 @@ class StreamTests: XCTestCase {
                 }
             }
         }
-        print("here")
+    }
+
+    // MARK: - Task-local scoping (async + propagation boundaries)
+
+    func testScopeIsInheritedByChildTasks() async {
+        // The scope is task-local, so structured child tasks inherit it.
+        await Device.withDefaultDevice(.cpu) {
+            async let child = Device.defaultDevice()
+            let value = await child
+            XCTAssertEqual(value, Device.cpu)
+
+            await withTaskGroup(of: Device.self) { group in
+                for _ in 0 ..< 4 {
+                    group.addTask { Device.defaultDevice() }
+                }
+                for await device in group {
+                    XCTAssertEqual(device, Device.cpu)
+                }
+            }
+        }
+    }
+
+    func testScopeIsNotInheritedByDetachedWork() async {
+        // detached Tasks and Threads do not inherit
+        let global = Device.defaultDevice()
+
+        // pick a scope device that differs from the process default so the
+        // assertion below can actually distinguish them
+        let scoped = Device(.gpu, index: 3)
+        XCTAssertNotEqual(scoped, global)
+
+        await Device.withDefaultDevice(scoped) {
+            XCTAssertEqual(Device.defaultDevice(), scoped)
+
+            let detached = await Task.detached { Device.defaultDevice() }.value
+            XCTAssertEqual(detached, global, "a detached task must see the global default")
+
+            let fromThread = await withCheckedContinuation { continuation in
+                let thread = Thread { continuation.resume(returning: Device.defaultDevice()) }
+                thread.start()
+            }
+            XCTAssertEqual(fromThread, global, "a raw Thread must see the global default")
+        }
+    }
+
+    func testConcurrentFirstTouchYieldsOneStream() async {
+        // test of the double checked lock in StreamPromise
+        await MLX.Stream.withNewDefaultStream(device: .cpu) {
+            let streams = await withTaskGroup(of: ObjectIdentifier.self) { group in
+                for _ in 0 ..< 16 {
+                    group.addTask { ObjectIdentifier(MLX.Stream.defaultStream) }
+                }
+                var seen = Set<ObjectIdentifier>()
+                for await id in group { seen.insert(id) }
+                return seen
+            }
+
+            XCTAssertEqual(
+                streams.count, 1,
+                "a cold promise handed out \(streams.count) distinct streams under contention")
+        }
+    }
+
+    // MARK: - Stream / StreamOrDevice resolution
+
+    func testDeviceTypeOverloads() {
+        XCTAssertEqual(MLX.Stream.defaultStream(.cpu), MLX.Stream.cpu)
+        XCTAssertEqual(MLX.Stream.defaultStream(.gpu), MLX.Stream.gpu)
+
+        XCTAssertEqual(StreamOrDevice.device(.cpu).stream, MLX.Stream.cpu)
+        XCTAssertEqual(StreamOrDevice.device(.gpu).stream, MLX.Stream.gpu)
+
+        XCTAssertEqual(StreamOrDevice.cpu.stream, MLX.Stream.cpu)
+        XCTAssertEqual(StreamOrDevice.gpu.stream, MLX.Stream.gpu)
+    }
+
+    func testStreamOrDeviceStaticsTrackTheCurrentScope() {
+        // `StreamOrDevice.cpu`/`.gpu` became computed, so they must track the
+        // current scope rather than caching whatever was current at first access.
+        MLX.Stream.withNewDefaultStream(device: .cpu) {
+            XCTAssertEqual(StreamOrDevice.cpu.stream, MLX.Stream.cpu)
+            XCTAssertEqual(StreamOrDevice.default.stream, MLX.Stream.defaultStream)
+        }
+    }
+
+    @available(*, deprecated)
+    func testDeprecatedDeviceOverloadHonorsTheDevice() {
+        XCTAssertEqual(MLX.Stream.defaultStream(Device.cpu), MLX.Stream.cpu)
+        XCTAssertEqual(MLX.Stream.defaultStream(Device.gpu), MLX.Stream.gpu)
+        XCTAssertEqual(StreamOrDevice.device(Device.cpu).stream, MLX.Stream.cpu)
+    }
+
+    // MARK: - Stream pool
+
+    func testConcurrentStreamsAreDistinct() {
+        // Streams handed out at the same time must never alias -- a double-release
+        // into the pool would let two owners share one `mlx_stream`.
+        final class Box: @unchecked Sendable {
+            private let lock = NSLock()
+            private var streams: [MLX.Stream] = []
+            func append(_ stream: MLX.Stream) { lock.withLock { streams.append(stream) } }
+            var all: [MLX.Stream] { lock.withLock { streams } }
+        }
+
+        let n = 32
+        let box = Box()
+
+        DispatchQueue.concurrentPerform(iterations: n) { _ in
+            box.append(MLX.Stream(.cpu))
+        }
+
+        let live = box.all
+        XCTAssertEqual(live.count, n)
+        for i in 0 ..< live.count {
+            for j in (i + 1) ..< live.count {
+                XCTAssertNotEqual(
+                    live[i], live[j], "the pool handed the same stream to two owners")
+            }
+        }
+    }
+
+    func testPoolDoesNotCrossDevices() throws {
+        // recycling stream innards should never mix types
+        for _ in 0 ..< 100 {
+            autoreleasepool {
+                let device = Device(.gpu, index: Int32.random(in: 0 ..< 10))
+                let stream = MLX.Stream(device)
+                XCTAssertEqual(stream.device, device)
+            }
+        }
+    }
+
+    func testScopeExitRecyclesTheStream() {
+        // see https://github.com/ml-explore/mlx/issues/2118 -- this used to
+        // exhaust metal/OS resources; the pool makes it bounded
+
+        // stream pooling should reuse the same stream over and over
+        var indices = Set<Int>()
+
+        for _ in 0 ..< 100 {
+            MLX.Stream.withNewDefaultStream(device: .gpu) {
+                indices.insert(MLX.Stream.defaultStream.index)
+
+                let x = MLXArray(1)
+                let _ = x * x
+            }
+        }
+
+        XCTAssertEqual(
+            indices.count, 1,
+            "100 sequential scopes used \(indices.count) distinct streams, expected 1")
+    }
+
+    func testPoolingConcurrent() {
+        // but if we have two live streams they cannot be the same
+        let s1 = Stream(.cpu)
+        let s2 = Stream(.cpu)
+
+        XCTAssertNotEqual(s1.index, s2.index)
+    }
+
+    // MARK: - Misc
+
+    func testStreamSynchronize() {
+        let stream = MLX.Stream(.cpu)
+        stream.synchronize()
+        MLX.Stream.defaultStream.synchronize()
+    }
+
+    func testStreamOrDeviceDescriptionMatchesItsStream() {
+        let stream = MLX.Stream(.cpu)
+        XCTAssertEqual(StreamOrDevice.stream(stream).description, stream.description)
+        XCTAssertEqual(StreamOrDevice.default.description, MLX.Stream.defaultStream.description)
     }
 
     func testStreamOrDeviceStreamUsesGivenStream() {
@@ -84,22 +370,50 @@ class StreamTests: XCTestCase {
         XCTAssertEqual(StreamOrDevice.stream(.gpu).stream, Stream.gpu)
     }
 
-    func disabledTestCreateStream() {
+    func testStreamPoolRecyclesStreams() {
+        // Streams must be recycled through the pool rather than allocated without
+        // bound -- see https://github.com/ml-explore/mlx/issues/2118 and #237.
+
+        let n = 5
+
+        // hold n at once, drop them, then take n again -- the second batch must
+        // be the same underlying streams
+        var first = Set<Int>()
+        var live: [MLX.Stream] = []
+        for _ in 0 ..< n {
+            let stream = Stream(.cpu)
+            first.insert(stream.index)
+            live.append(stream)
+        }
+        XCTAssertEqual(first.count, n, "streams held at the same time must be distinct")
+        live.removeAll()
+
+        var second = Set<Int>()
+        for _ in 0 ..< n {
+            let stream = Stream(.cpu)
+            second.insert(stream.index)
+            live.append(stream)
+        }
+        XCTAssertEqual(second, first, "the pool did not recycle the released streams")
+        live.removeAll()
+
+        // and the set of distinct streams stays bounded over many rounds
+        var observed = first
+        for _ in 0 ..< 10000 {
+            let stream = Stream(.cpu)
+            observed.insert(stream.index)
+        }
+        XCTAssertEqual(
+            observed, first,
+            "10k sequential streams allocated \(observed.count) distinct streams, expected \(n)")
+    }
+
+    func testCreateStream() {
         // see https://github.com/ml-explore/mlx/issues/2118
         for _ in 1 ..< 10000 {
             let _ = Stream(.cpu)
         }
         print("here")
-    }
-
-    func disabledTestCreateStreamScoped() {
-        // see https://github.com/ml-explore/mlx/issues/2118
-        for _ in 1 ..< 10000 {
-            Stream.withNewDefaultStream(device: .cpu) {
-                let x = MLXArray(1)
-                let _ = x * x
-            }
-        }
     }
 
 }

--- a/Tests/MLXTests/TransformTests.swift
+++ b/Tests/MLXTests/TransformTests.swift
@@ -10,7 +10,6 @@ import XCTest
 class TransformTests: XCTestCase {
 
     override class func setUp() {
-        setDefaultDevice()
     }
 
     func testEval() {

--- a/Tests/MLXTests/Utils.swift
+++ b/Tests/MLXTests/Utils.swift
@@ -33,7 +33,3 @@ func assertNotEqual(
         array1.allClose(array2, rtol: rtol, atol: atol).item(Bool.self),
         "contents same:\n\(array1)\n\(array2)")
 }
-
-func setDefaultDevice() {
-    MLX.Device.setDefault(device: .gpu)
-}


### PR DESCRIPTION
## Proposed changes

- see https://github.com/ml-explore/mlx/issues/2118
- Streams are finite and seem to leak OS/Metal resources
- implements a pool to reuse Streams -- withNewDefaultStream is fully usable

- much more care is taken with GPU devices
- using index != 0 now works in all cases
- and inherits properly when creating new streams

- Device.setDefaultDevice is documented as to how it works and fails -- use the task scoped calls instead

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [x] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)
